### PR TITLE
call #inspect so you don't get protocol error

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -562,7 +562,7 @@ In order to exchange messages, each process has a mailbox where the received mes
     # Collect the message
     iex> receive do
     ...> match: { :hello, pid }
-    ...>   IO.puts "Hello from #{pid}"
+    ...>   IO.puts "Hello from #{inspect(pid)}"
     ...> end
     Hello from <0.36.0>
 


### PR DESCRIPTION
```
(::Protocol::UndefinedError) protocol ::String::Chars not implemented for <0.36.0>
```
