### PR TITLE
Fix issues in Chapter 3 of the guide

### DIFF
--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -7,7 +7,7 @@ guide: 3
 
 # 3 Modules
 
-In Elixir, you can group several functions into a module. In the previous chapter, we have invoked for example functions from the module List:
+In Elixir, you can group several functions into a module. In the previous chapter, for example, we have invoked functions from the module List:
 
     iex> List.flatten [1,[2],3]
     [1, 2, 3]
@@ -91,7 +91,7 @@ Inside a module, we can define functions with `def` and private functions with `
     Math.sum(1, 2)    #=> 3
     Math.do_sum(1, 2) #=> ** (UndefinedFunctionError)
 
-Function declarations also supports guards and multiple clauses. If a function has several clauses, Elixir will try each clause until find one that matches. For example, here is the implementation for a function that checks if the given number is zero or not:
+Function declarations also supports guards and multiple clauses. If a function has several clauses, Elixir will try each clause until it finds one that matches. For example, here is the implementation for a function that checks if the given number is zero or not:
 
     defmodule Math do
       def zero?(0) do
@@ -142,11 +142,11 @@ And then we can use `only` or `except` to filter the macros being included. Fina
       end
     end
 
-In the example above, we imported `Orddict.values` only for during that specific function. `values` won't be available in any other functions in that module.
+In the example above, the imported `Orddict.values` is only visible within that specific function. `values` won't be available in any other function in that module (or any other module for that matter).
 
 ### 3.4.2 require
 
-`require` is responsible to enforce that a module is loaded and to setup references aliases for a given module. For instance, one can do:
+`require` ensures that a module is loaded and provides a means to setup reference aliases for a given module. For instance, one can do:
 
     defmodule Math do
       require MyOrddict, as: Orddict
@@ -164,11 +164,11 @@ In general, a module does not need to be required before usage, except if we wan
       MyMacros.my_if do_something, it_works
     end
 
-An attempt to call a macro that was not loaded will raise an error. Note that, as the import directive, `require` is lexical.
+An attempt to call a macro that was not loaded will raise an error. Note that, as the `import` directive, `require` is lexical.
 
 ## 3.5 Module data
 
-Elixir also allows module to store their own data. The canonical example for such data is annotating that a module implements the OTP behavior called `gen_server`:
+Elixir also allows modules to store their own data. The canonical example for such data is annotating that a module implements the OTP behavior called `gen_server`:
 
     defmodule MyServer do
       @behavior :gen_server
@@ -181,26 +181,26 @@ Now if the module above does not implement any of the callbacks required by `gen
       @vsn 2
     end
 
-`@vsn` refers to version and is used by the code reloading mechanism to check if a module is updated or not. If no version is specified, the version is set to the MD5 of the module functions.
+`@vsn` refers to the version and is used by the code reloading mechanism to check if a module has been updated or not. If no version is specified, the version is set to the MD5 checksum of the module functions.
 
 Elixir has a handful of reserved data attributes. The following are currently functional in Elixir:
 
 * `@behaviour` and `@behavior` - used for specifying an OTP or user-defined behavior;
 * `@vsn` - used for specifying the module version;
 * `@compile` - provides options for the module compilation;
-* `@moduledoc` - provides documentation to the current module;
-* `@doc` - provides documentation to the next function;
-* `@on_load` - provides a function, with arity 0, that will be invoked whenever the module is loaded. The function needs to return `:ok`, otherwise the loading of the function is aborted;
-* `@overridable` - when true, the function can be overridden and referenced later using the special form `super`;
+* `@moduledoc` - provides documentation for the current module;
+* `@doc` - provides documentation for the function that follows it;
+* `@on_load` - provides a function, with arity 0, that will be invoked whenever the module is loaded. The function has to return `:ok`, otherwise the loading of the module is aborted;
+* `@overridable` - when true, the function following it can be overridden and referenced later using the special form `super`;
 
-The following are also reserved by Elixir (as they have special semantics to the Erlang VM) but not currently supported (if you need support to any of these in your current projects, please make yourself heard in the issues tracker):
+The following ones are also reserved by Elixir (as they have special semantics to the Erlang VM) but not currently supported (if you need support for any of these in your current projects, please open a ticket on the issue tracker):
 
-* `@spec` - provides an specification for the next function to be defined;
-* `@callback` - provides an specification for the behavior callback;
+* `@spec` - provides a specification for the function following it;
+* `@callback` - provides a specification for the behavior callback;
 * `@type` - provides a type to be used in @spec;
 * `@export_type` - provides a type to be used in @spec that can be accessed from external specs;
 
-Besides the built-in data above, any developer can also add custom data:
+Besides the built-in data attributes outlined above, any developer can also add custom data:
 
     defmodule MyServer do
       @my_data 13
@@ -211,7 +211,7 @@ After the module is compiled, the stored custom data can be accessed via `__info
 
     MyServer.__info__(:data) #=> [my_data: 13]
 
-> Note: Erlang developers may be wondering why Elixir provides its own data abstraction instead of using Erlang attributes. Erlang attributes are basically a list which also allow duplicated entries. For Elixir, since the same data may be read and updated several times during compilation, it makes more sense to have a dictionary structure instead of a list. Erlang developers wishing to have the attributes functionality have two options:
+> Note: Erlang developers may be wondering why Elixir provides its own data abstraction instead of using Erlang attributes. Erlang attributes are basically lists which also allow duplicated entries. For Elixir, since the same data may be read and updated several times during compilation, it makes more sense to have a dictionary structure instead of a list. Erlang developers wishing to have the attributes functionality have two options:
 >
 > 1) Manually add Erlang attributes via the `Module.add_attribute(module, attribute, value)` API;
 >
@@ -226,7 +226,7 @@ In Elixir, nesting a module inside the other does not affect its name:
       end
     end
 
-The example above will define two modules `Foo` and `Bar`. Notice that the second module is **not** called `Foo::Bar`. In general, nesting modules is discouraged in Elixir.
+The example above will define two modules `Foo` and `Bar`. Notice that the second module is **not** called `Foo::Bar`. In general, nesting of modules is discouraged in Elixir.
 
 ## 3.7 References
 
@@ -235,19 +235,19 @@ In Erlang (and consequently in the Erlang VM), modules and functions are represe
     Mod = lists,
     Mod:flatten([1,[2],3]).
 
-In the example above, we store the atom `lists` in the variable `Mod` and then invoked the function flatten in it. In Elixir, exactly the same idiom is allowed. In fact, we could call the same function `flatten` in `lists` as:
+In the example above, we store the atom `lists` in the variable `Mod` and then invoke the function `flatten` in it. In Elixir, exactly the same idiom is allowed. In fact, we could call the same function `flatten` in `lists` as:
 
     iex> :lists.flatten([1,[2],3])
     [1,2,3]
 
-This mechanism is exactly what empowers Elixir references. Elixir references are uppercase identifiers (like `List`, `Orddict`, etc) that are converted to an atom representing a module at compilation time. For instance, by default `List` translates to the atom `::List`:
+This mechanism is exactly what empowers Elixir references. A reference in Elixir is a capitalized identifier (like `List`, `Orddict`, etc) which is converted to an atom representing a module during compilation. For instance, by default `List` translates to the atom `::List`:
 
     iex> List
     ::List
     iex> is_atom(List)
     true
 
-References are powerful when used with the `require` directive discussed above. For instance, let's imagine our Math module relies heavily on the `Orddict` module. If, at some point, we find out most algorithms in `Orddict` could be implemented in a much faster way, we could implement `FastOrddict` and use it as a drop-in replacement:
+References are powerful when used with the `require` directive discussed above. For instance, let's imagine that our Math module relies heavily on the `Orddict` module. If, at some point, we find out most algorithms in `Orddict` could be implemented in a much faster way, we could implement `FastOrddict` and use it as a drop-in replacement:
 
     defmodule Math do
       require FastOrddict, as: Orddict
@@ -266,4 +266,4 @@ Finally, in Elixir `::` is simply an operator (like `+`). It is used to concaten
     iex> Foo :: Bar
     ::Foo::Bar
 
-> Note: a reference does not actually ensure the reference really exists. For instance, `::FooBarBaz` will return an atom regardless if a `::FooBarBaz` module is defined or not.
+> Note: a reference does not actually ensure the referenced module really exists. For instance, `::FooBarBaz` will return an atom regardless if a `::FooBarBaz` module is defined or not.


### PR DESCRIPTION
These are mostly grammar issues. I'm not a native speaker myself, but I'm very cautiously checking with google if my corrections actually make sense.

---

I'm not sure if the term `lexical` is common in the Erlang community, but it just doesn't feel right to me. By itself, it has a very general meaning. Since you mean lexical scoping, it may be more appropriate to use `scoped` or `lexically scoped` instead, as in:

> As we are going to see below, they are called directives because they are the only functions in Elixir that **have lexical scope**.

as opposed to the current

> As we are going to see below, they are called directives because they are the only functions in Elixir that are lexical.
