### PR TITLE
Remove references to homoiconicity

### DIFF
--- a/docs/master/Kernel.SpecialForms.html
+++ b/docs/master/Kernel.SpecialForms.html
@@ -432,11 +432,10 @@ iex&gt; lc &lt;&lt;r:8,g:8,b:8&gt;&gt; inbits pixels, do: {r,g,b}
 #=&gt; { :sum, 0, [1, 2, 3] }
 </code></pre>
 
-<h2>Homoiconicity</h2>
+<h2>Program representation</h2>
 
-<p>Elixir is an homoiconic language. Any Elixir program can be
-represented using its own data structures. The building block
-of Elixir homoiconicity is a tuple with three elements, for example:</p>
+<p>The building block of an Elixir program is a tuple with three elements,
+for example:</p>
 
 <pre><code>{ :sum, 1, [1, 2, 3] }
 </code></pre>

--- a/docs/stable/Kernel.SpecialForms.html
+++ b/docs/stable/Kernel.SpecialForms.html
@@ -428,11 +428,10 @@ iex&gt; lc &lt;&lt;r:8,g:8,b:8&gt;&gt; inbits pixels, do: {r,g,b}
 #=&gt; { :sum, 0, [1, 2, 3] }
 </code></pre>
 
-<h2>Homoiconicity</h2>
+<h2>Program representation</h2>
 
-<p>Elixir is an homoiconic language. Any Elixir program can be
-represented using its own data structures. The building block
-of Elixir homoiconicity is a tuple with three elements, for example:</p>
+<p>The building block of an Elixir program is a tuple with three elements,
+for example:</p>
 
 <pre><code>{ :sum, 1, [1, 2, 3] }
 </code></pre>

--- a/getting_started/5.markdown
+++ b/getting_started/5.markdown
@@ -6,11 +6,9 @@ guide: 5
 
 # 5 Macros
 
-Elixir is a homoiconic language. Any Elixir program can be represented using its own data structures. This chapter will describe what those structures look like and how to manipulate them to create your own macros.
+## 5.1 Building blocks of an Elixir program
 
-## 5.1 Building blocks of homoiconicity
-
-The building block of Elixir homoiconicity is a tuple with three elements, for example:
+The building block of an Elixir program is a tuple with three elements, for example:
 
     { :sum, 1, [1, 2, 3] }
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <img src="/images/contents/home-code.png" alt="Elixir Sample" class="archive-thumbnail" />
 
     <div class="entry-summary">
-      <p>Elixir is a functional meta-programming aware language built on top of the Erlang VM. It is a dynamic language with flexible and homoiconic syntax that leverages Erlang's abilities to build concurrent, distributed, fault-tolerant applications with hot code upgrades.</p>
+      <p>Elixir is a functional meta-programming aware language built on top of the Erlang VM. It is a dynamic language with support for macros that leverages Erlang's abilities to build concurrent, distributed, fault-tolerant applications with hot code upgrades.</p>
       <p>Elixir also supports polymorphism via protocols (similar to Clojure's), dynamic records, aliases and first-class support to associative data structures (usually known as dicts or hashes in other programming languages).</p>
       <p>Finally, Elixir and Erlang share the same bytecode and data types. This means you can invoke Erlang code from Elixir (and vice-versa) without any conversion or performance hit. This allows a developer to mix the expressiveness of Elixir with the robustness and performance of Erlang.</p>
       <p>To install Elixir or learn more about it, check our <a href="/getting_started/1.html">getting started guide</a>. We also have <a href="/docs">online documentation available</a> and a <a href="/crash-course.html">Crash Course for Erlang developers</a>.</p>


### PR DESCRIPTION
Elixir is not an homoiconic language: if you pretty print the result of a quote expression as data; you don't read the same thing as the textual representation of the quote argument, this means code and data don't have the same primary representation.
