### PR TITLE
Modify the filename of a compiled bytecode

### DIFF
--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -38,7 +38,7 @@ This file can be compiled using `elixirc` (remember, if you installed Elixir fro
 
     elixirc math.ex
 
-Which will then generate a file named `Math.beam` containing the bytecode for the defined module. Now, if we start `iex` again, our module definition will be available (considering `iex` is being started in the same directory the bytecode file is):
+Which will then generate a file named `Elixir-Math.beam` containing the bytecode for the defined module. Now, if we start `iex` again, our module definition will be available (considering `iex` is being started in the same directory the bytecode file is):
 
     iex> Math.sum(1, 2)
     3


### PR DESCRIPTION
This pull request modifies the filename of the compiled bytecode for `math.ex` in Getting Started guide to fit recent elixirc.
