### PR TITLE
Fix a wrong section number

### DIFF
--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -341,7 +341,7 @@ Modules in Elixir can be nested too:
 
 The example above will define two modules `Foo` and `Foo.Bar`. The second can be accessed as `Bar` inside `Foo` as long as they are in the same scope. If later the developer decides to move `Bar` to another file, it needs to be referenced by its full name (`Foo.Bar`) or an alias needs to be set using the `alias` directive discussed above.
 
-## 3.7 Aliases
+## 3.8 Aliases
 
 In Erlang (and consequently in the Erlang VM), modules and functions are represented by atoms. For instance, this is valid Erlang code:
 


### PR DESCRIPTION
This pull request fixes a wrong section number in Getting Started guide.
