### PR TITLE
Removed ExUnit.start default option, because it is assumed.

### DIFF
--- a/getting_started/mix/1.markdown
+++ b/getting_started/mix/1.markdown
@@ -107,7 +107,7 @@ It is important to note a couple things:
 The last file we are going to check is the `test_helper.exs`, which simply sets up the test framework:
 
 {% highlight elixir %}
-ExUnit.start []
+ExUnit.start
 {% endhighlight %}
 
 And that is it, our project is created. We are ready to move on!


### PR DESCRIPTION
http://elixir-lang.org/getting_started/mix/1.html

**1.1.4 test/test_helper.exs**

The empty array `[]` is assumed when no option is passed (`def start(options // []) do...`) so I removed it from section 1.1.4 in the "Introduction to Mix" which is also on a par with how mix (0.9.1-dev) works.
