### PR TITLE
@hidden affects `mix help` not `mix help TASK`

### DIFF
--- a/getting_started/mix/3.markdown
+++ b/getting_started/mix/3.markdown
@@ -38,7 +38,7 @@ When you invoke `mix hello`, this task will run and print `Hello, World!`. Mix u
 
 You're probably wondering why we have a `@moduledoc` and `@shortdoc`. Both are used by the `help` task for listing tasks and providing documentation. The former is used when `mix help TASK` is invoked, the latter in the general listing with `mix help`.
 
-Besides those two, there is also `@hidden` attribute that, when set to true, marks the task as hidden so it does not show up on `mix help Task`. Any task without `@shortdoc` also won't show up.
+Besides those two, there is also `@hidden` attribute that, when set to true, marks the task as hidden so it does not show up on `mix help`. Any task without `@shortdoc` also won't show up.
 
 ### 3.1 Common API
 


### PR DESCRIPTION
Using `@hidden true` hides the task `TASK` from the output of `mix help`. At the same time `mix help TASK` keeps displaying the value of `@moduledoc`.
