### PR TITLE
Fix intro to records, protocols, and exceptions

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -7,7 +7,7 @@ total_guides: 7
 
 # {{ page.title }}
 
-Elixir provides both records and protocols. This chapter will outline the main features of both and provide some examples. More specifically, we will learn how to use `defprotocol`, `defprotocol` and `defimpl`. At the end, we will briefly talk about exceptions in Elixir.
+Elixir provides both records and protocols. This chapter will outline the main features of both and provide some examples. More specifically, we will learn how to use `defrecord`, `defprotocol` and `defimpl`. At the end, we will briefly talk about exceptions in Elixir.
 
 ## 4.1 Records
 


### PR DESCRIPTION
Intro sentence lists `defprotocol` twice and leaves out `defrecord`
