### PR TITLE
Assigning number in Blank.Number.blank? to _ as it's not used

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -82,7 +82,7 @@ The protocol expects a function called `blank?` that receives one argument to be
 
     # Numbers are never blank
     defimpl Blank, for: Number do
-      def blank?(number), do: false
+      def blank?(_), do: false
     end
 
     # Just empty list is blank


### PR DESCRIPTION
In the protocols section, Blank.Number.blank? takes a named value of 'number'.  This isn't used and results in a warning.  Changing it to _.
