### PR TITLE
add Gentoo to "getting started" section

### DIFF
--- a/getting_started/1.markdown
+++ b/getting_started/1.markdown
@@ -43,6 +43,7 @@ This tutorial requires Elixir v0.9.0 or later and it may be available in some di
 * openSUSE : Elixir is available at devel:languages:erlang project
   * Add repo: `zypper ar -f obs://devel:languages:erlang/ erlang`
   * Install elixir: `zypper in elixir`
+* Gentoo : available in main portage tree: `emerge --ask dev-lang/elixir`
 
 If you don't use any of the distributions above, don't worry, we also provide a precompiled package!
 


### PR DESCRIPTION
available in gentoo: http://packages.gentoo.org/package/dev-lang/elixir
(might take some time until it shows up)
