### PR TITLE
Fix minor syntax error introduced on #132

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -116,6 +116,7 @@ X + Y.
 ```
 
 **Elixir**
+
 ```elixir
 x = 2; y = 3
 x + y


### PR DESCRIPTION
Yeah, this missing `\n` made the elixir code ugly.

http://elixir-lang.org/crash-course.html#notable_differences on Delimiters subsection
