### PR TITLE
Changed "last call optimiation" to "tail call optimization" in Getting Started chapter 3

### DIFF
--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -249,9 +249,9 @@ sum_list [3], 3
 sum_list [], 6
 ```
 
-When the list is empty, it will match the final clause which returns the final result of `6`. In imperative languages, such implementation would usually fail for large lists because the stack (in which our execution path is kept) would grow until it reaches a limit. Elixir, however, does last call optimization in which the stack does not grow when a function exits by calling another function.
+When the list is empty, it will match the final clause which returns the final result of `6`. In imperative languages, such implementation would usually fail for large lists because the stack (in which our execution path is kept) would grow until it reaches a limit. Elixir, however, does tail call optimization in which the stack does not grow when a function exits by calling another function.
 
-Recursion and last call optimization are an important part of Elixir and are commonly used to create loops, especially in cases where a process needs to wait and respond to messages (using the `receive` macro we saw in the previous chapter). However, recursion as above is rarely used to manipulate lists, since [the `Enum` module](/docs/stable/Enum.html) already abstracts such use cases. For instance, the example above could be simply written as:
+Recursion and tail call optimization are an important part of Elixir and are commonly used to create loops, especially in cases where a process needs to wait and respond to messages (using the `receive` macro we saw in the previous chapter). However, recursion as above is rarely used to manipulate lists, since [the `Enum` module](/docs/stable/Enum.html) already abstracts such use cases. For instance, the example above could be simply written as:
 
 ```elixir
 Enum.reduce([1,2,3], 0, fn(x, acc) -> x + acc end)


### PR DESCRIPTION
I believe this is the more common name. Google concurs with 2x more results.
