### PR TITLE
MyModule needs to be capitalized.

### DIFF
--- a/getting_started/6.markdown
+++ b/getting_started/6.markdown
@@ -68,7 +68,7 @@ A heredoc without escaping or interpolation
 Elixir uses module attributes described in chapter 3 to drive its documentation system. For instance, consider the following example:
 
 ```elixir
-defmodule mymodule do
+defmodule MyModule do
   @moduledoc "it does x"
 
   @doc "returns the version"


### PR DESCRIPTION
Otherwise elixir thinks it is a function name and throws the following
error: "*\* (UndefinedFunctionError) undefined function:
IEx.Helpers.mymodule/0"
