### PR TITLE
teardown must return :ok or {:ok, keywords}

### DIFF
--- a/getting_started/ex_unit/1.markdown
+++ b/getting_started/ex_unit/1.markdown
@@ -136,6 +136,7 @@ defmodule CallbacksTest do
 
   teardown meta do
     assert meta[:from_setup] == :hello
+    :ok
   end
 end
 ```


### PR DESCRIPTION
Otherwise, the test will fail with a runtime error:

```
  1) test the truth (CallbacksTest)
     ** (RuntimeError) expected ExUnit callback in CallbacksTest to
return :ok  or { :ok, keywords }, got true instead
```
