### PR TITLE
Fix indication to inexistant `is_record` macro

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -425,7 +425,7 @@ In the example above, the second clause will only match when x is positive. The 
 * arithmetic operators (`+`, `-`, `*`, `/`);
 * `<>` and `++` as long as the left side is a literal;
 * the `in` operator;
-* all the following type check functions:
+* all the following type check functions (the number preceded by slash represents number of arguments):
 
     * is_atom/1
     * is_binary/1
@@ -439,8 +439,8 @@ In the example above, the second clause will only match when x is positive. The 
     * is_number/1
     * is_pid/1
     * is_port/1
+    * is_record/1
     * is_record/2
-    * is_record/3
     * is_reference/1
     * is_tuple/1
     * is_exception/1


### PR DESCRIPTION
The macro `is_record/3` doesn't exist.

``` iex
iex(1)> is_record 1
false
iex(2)> is_record 1, 1
false
iex(3)> is_record 1, 1, 1
** (UndefinedFunctionError) undefined function: IEx.Helpers.is_record/3
    IEx.Helpers.is_record(1, 1, 1)
    erl_eval.erl:569: :erl_eval.do_apply/6
    src/elixir.erl:138: :elixir.eval_forms/3
```
