### PR TITLE
Fix "supervisors" typo in Mix Getting Started guide

### DIFF
--- a/getting_started/mix/2.markdown
+++ b/getting_started/mix/2.markdown
@@ -222,7 +222,7 @@ The sixth message no longer generates an error report, since our server was no l
 
 ## 2.3 Who supervises the supervisor?
 
-We have built our supervisor but a pertinent question is: who supervisors the supervisor? To answer this question, OTP contains the concept of applications. Applications can be started and stopped as an unit and, when doing so, they are often linked to a supervisor.
+We have built our supervisor but a pertinent question is: who supervises the supervisor? To answer this question, OTP contains the concept of applications. Applications can be started and stopped as an unit and, when doing so, they are often linked to a supervisor.
 
 In the previous chapter, we have learned how Mix automatically generates an `.app` file every time we compile our project based on the information contained on the `application` function in our `mix.exs` file.
 


### PR DESCRIPTION
It's a _tiny_ thing: 

`who supervisors the supervisor` => `who supervises the supervisor`
