### PR TITLE
should be get_env/set_env instead of get_key/set_key

### DIFF
--- a/getting_started/mix/2.markdown
+++ b/getting_started/mix/2.markdown
@@ -296,11 +296,11 @@ Besides the `:registered`, `:applications` and `:mod` keys we have seen above, a
 Still in the command line, try:
 
 ```iex
-iex> :application.get_key(:stacker, :foo)
+iex> :application.get_env(:stacker, :foo)
 :undefined
-iex> :application.set_key(:stacker, :foo, :bar)
+iex> :application.set_env(:stacker, :foo, :bar)
 :ok
-iex> :application.get_key(:stacker, :foo)
+iex> :application.get_env(:stacker, :foo)
 { :ok, :bar }
 ```
 


### PR DESCRIPTION
This section incorrectly uses get_key/set_key when it should be get_env/set_env.
