### PR TITLE
Add ElixirSips to Learning Resources

### DIFF
--- a/_includes/learning-resources.html
+++ b/_includes/learning-resources.html
@@ -3,6 +3,6 @@
   <ul>
     <li class="image"><a href="http://pragprog.com/titles/elixir" target="_blank" title="Programming Elixir cover"><img src="http://imagery.pragprog.com/products/361/elixir_xlargebeta.jpg?1368724397" /></a></li>
     <li class="image"><a href="https://peepcode.com/products/elixir" target="_blank" title="PeepCode Meet Elixir cover"><img src="https://peepcode.com/system/uploads/2013/peepcode-elixir-lang-cover.jpg" width="190" height="228" /></a></li>
-    <li class="image"><a href="http://elixirsips.com" target="_blank" title="ElixirSips cover"><img src="http://elixirsips.com/images/ElixirLangAd_194x232.png" width="190" height="232" /></a></li>
+    <li class="image"><a href="http://elixirsips.com" target="_blank" title="ElixirSips cover"><img src="http://elixirsips.com/images/ElixirLangAd2_190x160.png" width="190" height="160" /></a></li>
   </ul>
 </div>


### PR DESCRIPTION
@josevalim suggested I could send in a PR adding ElixirSips to the Learning Resources in the sidebar.  For the record, this is the cover image I used:

![ElixirSips Cover](http://elixirsips.com/images/ElixirLangAd_194x232.png)

It's a modification of the image I've got on the RubyRogues site.  If it doesn't look good enough, let me know :)
