### PR TITLE
Key-value pair stores in a list, not in a tuple

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -188,7 +188,7 @@ If we inspect our `HashDict`, we can see it is a simple tuple:
 
 ```elixir
 inspect(dict, raw: true)
-#=> { HashDict, 1, [{:hello,"world"}] }
+#=> "{HashDict, 1, [[:hello | \"world\"]]}"
 ```
 
 Since `HashDict` is a data structure that contains values, it would be convenient to implement the `Blank` protocol for it too:


### PR DESCRIPTION
Tested on Interactive Elixir (0.11.2-dev)
