### PR TITLE
Fix erlang code example 'fun'

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -376,14 +376,14 @@ Each Erlang module lives in its own file which has the following structure:
 
 ```erlang
 -module(hello_module).
--export([some_fun/0, fun/1]).
+-export([some_fun/0, some_fun/1]).
 
 % A "Hello world" function
 some_fun() ->
   io:format('~s~n', ['Hello world!']).
 
 % This one works only with lists
-fun(List) when is_list(List) ->
+some_fun(List) when is_list(List) ->
   io:format('~s~n', List).
 
 % Non-exported functions are private


### PR DESCRIPTION
Shouldn't call a function "fun" in erlang code.
Update the erlang function naming to match the Elixir code.
