### PR TITLE
Added link to Elixir-GtkSourceView

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -25,6 +25,7 @@
     <li><a class="spec" href="https://github.com/elixir-lang/emacs-elixir" target="_blank">Emacs Mode</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir-tmbundle" target="_blank">Textmate Bundle</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir" target="_blank">Vim Elixir</a></li>
+    <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview" target="_blank">GtkSourceView (gedit)</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
I wrote a language definition file to provide syntax highlighting for GtkSourceView. It would be a nice addition to the list "Code editor support" on the Elixir webpage.
