### PR TITLE
remove `.git` suffix

### DIFF
--- a/getting_started/mix/1.markdown
+++ b/getting_started/mix/1.markdown
@@ -63,7 +63,7 @@ defmodule MyProject.Mixfile do
   # { :foobar, git: "https://github.com/elixir-lang/foobar.git", tag: "0.1" }
   #
   # To specify particular versions, regardless of the tag, do:
-  # { :barbat, "~> 0.1", github: "elixir-lang/barbat.git" }
+  # { :barbat, "~> 0.1", github: "elixir-lang/barbat" }
   defp deps do
     []
   end


### PR DESCRIPTION
No need `.git` suffix.
