### PR TITLE
Update crash course w/ send for messages instead of deprecated <-

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -101,7 +101,6 @@ Some operators are spelled differently.
     | =/=            | !==            | A negative match                        |
     | /=             | !=             | Not equals                              |
     | =<             | <=             | Less than or equals                     |
-    | !              | <-             | Send messages                           |
 
 
 ### Delimiters
@@ -815,7 +814,7 @@ end.
 ```elixir
 pid = Kernel.self
 
-pid <- { :hello }
+send pid, { :hello }
 
 receive do
   { :hello } -> :ok


### PR DESCRIPTION
I'm just removing the ! vs <- in the operator table, but let me know if we should add a note about send there.
