### PR TITLE
emphasize that Inspect.inspect return values starting with '#' are not enforced

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -242,7 +242,7 @@ iex> HashDict.new
 #HashDict<[]>
 ```
 
-  Keep in mind that whenever the inspected value starts with `#`, it is representing a data structure in non-valid Elixir syntax. For those, the true representation can be retrieved by calling `inspect` directly and passing `raw` as an option:
+  Keep in mind that, by convention, whenever the inspected value starts with `#`, it is representing a data structure in non-valid Elixir syntax. For those, the true representation can be retrieved by calling `inspect` directly and passing `raw` as an option:
 
 ```iex
 iex> inspect HashDict.new, raw: true


### PR DESCRIPTION
and that it's the responsibility of the data structure author to follow this convention
