### PR TITLE
clarify the difference between throw and raise

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -283,7 +283,7 @@ Elixir defines other protocols which can be verified in Elixir's documentation. 
 
 ## 4.3 Exceptions
 
-Exception handling would have its own chapter in many languages, but here they play a much lesser role.
+Exception handling would have its own chapter in many languages, but here they play a much lesser role (since for control flow, `throw` is used - see [2.6.5 Try](2.html)).
 
 An exception can be rescued inside a `try` block with the `rescue` keyword:
 


### PR DESCRIPTION
https://github.com/elixir-lang/elixir-lang.github.com/blob/master/getting_started/4.markdown#43-exceptions

Given how in other languages use the same keywords `throw` (in C# and Java) and `raise` (in Python), yet don't make the same semantic distinction (and only use one of keyword per language), pointing this out explicitly would have helped me (I learned of it only via IRC from @ericmj).

The fact that an exception object is created to wrap the message versus just throwing the value might be too much detail to add - interested people can try it out in `iex` to see for themselves, it's just a tutorial :smiley:
