### PR TITLE
generate linkable id attribtues for <hN> tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 markdown: redcarpet
 pygments: true
 permalink: /blog/:year/:month/:day/:title
+redcarpet:
+  extensions: ['with_toc_data']


### PR DESCRIPTION
So that they can be linked to for easier sharing (as described in by @ericmj https://github.com/elixir-lang/elixir-lang.github.com/pull/157#issuecomment-24446351)

This change only ensures that text-independent id attributes are generated in the HTML, the usability aspects (like the on-hover copyable link that github repo pages have) are not included.

Tested on Xubuntu 13.04 with

```
$ sudo apt-get install ruby1.9.3
$ sudo gem1.9.3 install github-pages
$ cd ~/3rdparty/elixir-lang.github.com/
$ vim _config.yml
$ git diff
diff --git a/_config.yml b/_config.yml
index 18d7dd5..78201b0 100644
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 markdown: redcarpet
 pygments: true
 permalink: /blog/:year/:month/:day/:title
+redcarpet:
+  extensions: ['with_toc_data']
$ jekyll serve --safe
```

It does effect all pages - I checked the tutorial as well as a sample blog post

I submit it as a separate PR from #157, since that is a huge change and somewhat old
