### PR TITLE
Link mix otp page to recieve

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -508,7 +508,7 @@ x = 1
 x #=> 1
 ```
 
-### 2.6.4 Receive
+### <a name="receive"></a>2.6.4 Receive
 
 This next control-flow mechanism is essential to Elixir's actors. In Elixir, the code is run in separate processes that exchange messages between them. Those processes are not Operating System processes (they are actually quite light-weight) but are called so since they do not share state with each other.
 

--- a/getting_started/mix/2.markdown
+++ b/getting_started/mix/2.markdown
@@ -9,7 +9,7 @@ total_guides: 3
 
 Where do we keep state in Elixir?
 
-Our software needs to keep state, configuration values, data about the running system, etc. We have learned in previous sections how we can use processes/actors to keep state, receiving and responding to messages in a loop but this approach seems to be brittle. What happens if there is an error in our actor and it crashes? Even more, is it really required to create a new process when all we want to do is to keep simple configuration values?
+Our software needs to keep state, configuration values, data about the running system, etc. We have learned in [previous sections](../2.html#receive) how we can use processes/actors to keep state, receiving and responding to messages in a loop but this approach seems to be brittle. What happens if there is an error in our actor and it crashes? Even more, is it really required to create a new process when all we want to do is to keep simple configuration values?
 
 In this chapter, we will answer those questions by building an OTP application. In practice, we don't need Mix in order to build such applications, however Mix provides some conveniences that we are going to explore throughout this chapter.
 


### PR DESCRIPTION
The mix otp docs had this line:

> We have learned in previous sections how we can use processes/actors to keep state, receiving and responding to messages in a loop but this approach seems to be brittle. 

I didn't know when it had been mentioned before.  Asked on IRC.  Found it, made a link there.
