### PR TITLE
Various phrasing changes for grammatical or redundancy reasons.

### DIFF
--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -78,7 +78,7 @@ iex> {:ok, result} = {:error, :oops}
 ** (MatchError) no match of right hand side value: {:error, :oops}
 ```
 
-We can also pattern match on lists:
+We can pattern match on lists:
 
 ```iex
 iex> [a, b, c] = [1, 2, 3]
@@ -87,7 +87,7 @@ iex> a
 1
 ```
 
-Lists also support matching on its head and tail:
+A list also supports matching on its own head and tail:
 
 ```iex
 iex> [head | tail] = [1, 2, 3]
@@ -105,7 +105,7 @@ iex> [h|t] = []
 ** (MatchError) no match of right hand side value: []
 ```
 
-The `[head | tail]` format is not only used on pattern matching but also for prepending items to a list:
+The `[head | tail]` format is not only used on pattern matching, but also for prepending items to a list:
 
 ```iex
 iex> list = [1, 2, 3]
@@ -149,7 +149,7 @@ iex> {x, x} = {1, 2}
 ** (MatchError) no match of right hand side value: {1, 2}
 ```
 
-In some cases, you don't care about a particular value in a pattern. In those cases, it is a common practice to bind the value to underscore `_`. For example, if only the head of the list matters to us, we can assign the tail to underscore:
+In some cases, you don't care about a particular value in a pattern. It is a common practice to bind those values to the underscore, `_`. For example, if only the head of the list matters to us, we can assign the tail to underscore:
 
 ```iex
 iex> [h | _] = [1, 2, 3]
@@ -158,7 +158,7 @@ iex> h
 1
 ```
 
-The variable `_` in Elixir is special in that it can never be read from. Trying to read from it gives an unbound variable error:
+The variable `_` is special in that it can never be read from. Trying to read from it gives an unbound variable error:
 
 ```iex
 iex> _


### PR DESCRIPTION
Removed a couple of clauses that felt redundant, fixed on noun/verb disagreement.
