### PR TITLE
Fix output for single/double quoted string comparison example

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -179,7 +179,7 @@ Keep in mind `single-quoted` and `double-quoted` strings are not equivalent in E
 
 ```iex
 iex> 'hellö' == "hellö"
-true
+false
 ```
 
 We will talk more about Unicode support and the difference in between single and double-quoted strings in the "Binaries, strings and char lists" chapter.


### PR DESCRIPTION
Was true, should be false.
