### PR TITLE
Fix typo in section 2.8

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -310,7 +310,7 @@ iex> list = [1|[2|[3|[]]]]
 [1, 2, 3]
 ```
 
-This means accessing the length of a list is a linear operation: we need to traverse the whole list in order to figure out its size. Updating a list as fast as long as we are prepending elements:
+This means accessing the length of a list is a linear operation: we need to traverse the whole list in order to figure out its size. Updating a list is fast as long as we are prepending elements:
 
 ```iex
 iex> [0] ++ list


### PR DESCRIPTION
s/as/is
