### PR TITLE
Fix code highlighting in page 10 of getting started docs

### DIFF
--- a/getting_started/10.markdown
+++ b/getting_started/10.markdown
@@ -81,21 +81,21 @@ iex> 1..100_000 |> Stream.map(&(&1 * 3)) |> Stream.filter(odd?)
 
 Many functions in the `Stream` module accept any enumerable as argument and return a stream as result. It also provides functions for creating streams, possibly infinite. For example, `Stream.cycle/1` can be used to create a stream that cycles a given enumerable infinitely. Be careful to not call a function like `Enum.map/2` on such streams, as they would cycle forever:
 
-    ```iex
-    iex> stream = Stream.cycle([1, 2, 3])
-    #Function<15.16982430/2 in Stream.cycle/1>
-    iex> Enum.take(stream, 10)
-    [1, 2, 3, 1, 2, 3, 1, 2, 3, 1]
-    ```
+```iex
+iex> stream = Stream.cycle([1, 2, 3])
+#Function<15.16982430/2 in Stream.cycle/1>
+iex> Enum.take(stream, 10)
+[1, 2, 3, 1, 2, 3, 1, 2, 3, 1]
+```
 
 On the other hand, `Stream.unfold/2` can be used to generate values from a given initial value:
 
-    ```iex
-    iex> stream = Stream.unfold("hełło", &String.next_codepoint/1)
-    #Function<15.16982430/2 in Stream.cycle/1>
-    iex> Enum.take(stream, 3)
-    ["h", "e", "ł"]
-    ```
+```iex
+iex> stream = Stream.unfold("hełło", &String.next_codepoint/1)
+#Function<15.16982430/2 in Stream.cycle/1>
+iex> Enum.take(stream, 3)
+["h", "e", "ł"]
+```
 
 Another interesting function is `Stream.resource/3` which can be used to wrap around resources, guaranteeing they are opened right before enumeration and closed afterwards, even in case of failures. For example, we can use it to stream a file:
 


### PR DESCRIPTION
Shows up without code coloring:
![10_enumerables_and_streams_-_elixir](https://cloud.githubusercontent.com/assets/635121/2806865/94684252-ccd5-11e3-85f0-272d491512c0.png)
