### PR TITLE
Fix typo in Chapter 6

### DIFF
--- a/getting_started/6.markdown
+++ b/getting_started/6.markdown
@@ -70,7 +70,7 @@ iex> byte_size <<0, 1, 2, 3>>
 A binary is just a sequence of bytes. Of course, those bytes can be organized in any way, even in a sequence that does not make them a valid string:
 
 ```iex
-iex> String.valid?(<239, 191, 191>>)
+iex> String.valid?(<<239, 191, 191>>)
 false
 ```
 


### PR DESCRIPTION
The code sample of `String.valid?/1` lacks a `<`.
