### PR TITLE
Function clause without body => function head

### DIFF
--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -190,7 +190,7 @@ hello
 :ok
 ```
 
-If a function with default values has multiple clauses, it is recommended to create a separate clause without an actual body, just for declaring defaults:
+If a function with default values has multiple clauses, it is recommended to create a function head (without an actual body), just for declaring defaults:
 
 ```elixir
 defmodule Concat do


### PR DESCRIPTION
Calling it a function clause implies that a single function head `def foo(arg)` or `def foo(arg \\ default)` will be matched with the other clauses of the same arity when in fact it won't. That it creates a function clause with lesser arity when declaring defaults is an implementation detail.

If you agree with this I will also update the error message " ...has default values and multiple clauses, use a separate clause for declaring defaults". The suggested solution is very confusing.
