### PR TITLE
Fix link to www.erlang.org in the Maps section

### DIFF
--- a/getting_started/7.markdown
+++ b/getting_started/7.markdown
@@ -156,7 +156,7 @@ In future chapters, we will also learn about structs, which provide compile-time
 
 Manipulating maps is done via [the `Map` module](/docs/stable/Map.html), it provides a very similar API to the `Keyword` module. This is because both modules implement the `Dict` behaviour.
 
-> Note: Maps were recently introduced into the Erlang VM with [EEP 43](www.erlang.org/eeps/eep-0043.html). Erlang 17 provides a partial implementation of the EEP, where only "small maps" are supported. This means maps have good performance characteristics only when storing at maximum a couple of dozens keys. To fill in this gap, Elixir also provides [the `HashDict` module](/docs/stable/HashDict.html) which uses a hashing algorithm to provide a dictionary that supports hundreds of thousands keys with good performance.
+> Note: Maps were recently introduced into the Erlang VM with [EEP 43](http://www.erlang.org/eeps/eep-0043.html). Erlang 17 provides a partial implementation of the EEP, where only "small maps" are supported. This means maps have good performance characteristics only when storing at maximum a couple of dozens keys. To fill in this gap, Elixir also provides [the `HashDict` module](/docs/stable/HashDict.html) which uses a hashing algorithm to provide a dictionary that supports hundreds of thousands keys with good performance.
 
 ## 7.3 Dicts
 


### PR DESCRIPTION
Currently, it's navigated to http://elixir-lang.org/getting_started/www.erlang.org/eeps/eep-0043.html, which results in 404 error.
