### PR TITLE
Table of contents for the guide

### DIFF
--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -20,5 +20,17 @@
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
   </script>
+
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <script src="/js/toc/toc.js" type="text/javascript" charset="utf-8"></script>
+  <script type="text/javascript">
+    $(document).ready(function() {
+        $('.toc').toc({
+          title: '',
+          listType: 'ul',
+          showSpeed: 0,
+        });
+    });
+  </script>
 </body>
 </html>

--- a/getting_started/1.markdown
+++ b/getting_started/1.markdown
@@ -6,6 +6,8 @@ guide: 1
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Welcome!
 
 In this tutorial we are going to show you how to get started with Elixir. This chapter will cover installation and how to get started with the Interactive Elixir shell called IEx.

--- a/getting_started/10.markdown
+++ b/getting_started/10.markdown
@@ -6,6 +6,9 @@ guide: 10
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+  <p></p>
+
 ## 10.1 Enumerables
 
 Elixir provides the concept of enumerables and [the `Enum` module](/docs/stable/Enum.html) to work with them. We have already learned two enumerables: lists and maps.

--- a/getting_started/11.markdown
+++ b/getting_started/11.markdown
@@ -6,6 +6,8 @@ guide: 11
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In Elixir, all code runs inside processes. Processes are isolated from each other, run concurrent to one another and communicate via message passing. Processes are not only the basis for concurrency in Elixir, but they also provide the means for building distributed and fault-tolerant programs.
 
 Elixir's processes should not be confused with operating system processes. Processes in Elixir are extremely lightweight in terms of memory and CPU (unlike threads in many other programming languages). Because of this, it is not uncommon to have dozens of thousands of processes running simultaneously.

--- a/getting_started/12.markdown
+++ b/getting_started/12.markdown
@@ -6,6 +6,8 @@ guide: 12
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 This chapter is a quick introduction to input/output mechanisms in Elixir and related modules, like [`IO`](/docs/stable/IO.html), [`File`](/docs/stable/File.html) and [`Path`](/docs/stable/Path.html).
 
 We had originally sketched this chapter to come much earlier in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the VM.

--- a/getting_started/13.markdown
+++ b/getting_started/13.markdown
@@ -6,6 +6,8 @@ guide: 13
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In order to facilitate software reuse, Elixir provides three directives. As we are going to see below, they are called directives because they have **lexical scope**.
 
 ## 13.1 alias

--- a/getting_started/14.markdown
+++ b/getting_started/14.markdown
@@ -6,6 +6,8 @@ guide: 14
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Module attributes in Elixir serve three purposes:
 
 1. They serve to annotate the module, often with information to be used by the user or the VM.

--- a/getting_started/15.markdown
+++ b/getting_started/15.markdown
@@ -6,6 +6,8 @@ guide: 15
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In early chapters, we have learned about maps:
 
 ```iex

--- a/getting_started/16.markdown
+++ b/getting_started/16.markdown
@@ -6,6 +6,8 @@ guide: 16
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Protocols are a mechanism to achieve polymorphism in Elixir. Dispatching on a protocol is available to any data type as long as it implements the protocol. Let's see an example.
 
 In Elixir, only `false` and `nil` are treated as false. Everything else evaluates to true. Depending on the application, it may be important to specify a `blank?` protocol that returns a boolean for other data types that should be considered blank. For instance, an empty list or an empty binary could be considered blanks.

--- a/getting_started/17.markdown
+++ b/getting_started/17.markdown
@@ -6,6 +6,8 @@ guide: 17
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Elixir has three error mechanisms: errors, throws and exits. In this chapter we will explore each of them and include remarks about when each should be used.
 
 ## 17.1 Errors

--- a/getting_started/18.markdown
+++ b/getting_started/18.markdown
@@ -6,6 +6,8 @@ guide: 18
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In Elixir, it is common to loop over Enumerables, often filtering some results, and mapping to another list of values. Comprehensions are syntax sugar for such constructs, grouping those common tasks into the `for` special form.
 
 For example, we can get all the square values of elements in a list as follows:

--- a/getting_started/19.markdown
+++ b/getting_started/19.markdown
@@ -6,6 +6,8 @@ guide: 19
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 We have already learned Elixir provides double-quoted strings and single-quoted char lists. However, this only covers the surface of structures that have textual representation in the language. Atoms are, for example, another structure which are mostly created via the `:atom` representation.
 
 One of Elixir's goals is extensibility: developers should be able to extend the language to particular domains. Computer science has become such a wide field that it is impossible for a language to tackle many fields as part of its core. Our best bet is to rather make the language extensible, so developers, companies and communities can extend the language to their relevant domains.

--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -6,6 +6,8 @@ guide: 2
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In this chapter we will learn more about Elixir basic types: integers, floats, atoms, lists and strings. Some basic types are:
 
 ```iex

--- a/getting_started/20.markdown
+++ b/getting_started/20.markdown
@@ -7,6 +7,8 @@ last: true
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Eager to learn more? Keep on reading!
 
 ## 20.1 Build your first Elixir project

--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -6,6 +6,8 @@ guide: 3
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In the previous chapter, we saw Elixir provides `+`, `-`, `*`, `/` as arithmetic operators, plus the functions `div/2` and `rem/2` for integer division and remainder.
 
 Elixir also provides `++` and `--` to manipulate lists:

--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -6,6 +6,8 @@ guide: 4
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In this chapter, we will show how the `=` operator in Elixir is actually a match operator and how to use it to pattern match inside data structures. Finally, we will learn about the pin operator `^` used to access previously bound values.
 
 ## 4.1 The match operator

--- a/getting_started/5.markdown
+++ b/getting_started/5.markdown
@@ -6,6 +6,8 @@ guide: 5
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In this chapter, we will learn about the `case`, `cond` and `if` control-flow structures.
 
 ## 5.1 case

--- a/getting_started/6.markdown
+++ b/getting_started/6.markdown
@@ -6,6 +6,8 @@ guide: 6
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In "Basic Types", we learned about strings and used the `is_binary/1` function for checks:
 
 ```iex

--- a/getting_started/7.markdown
+++ b/getting_started/7.markdown
@@ -6,6 +6,8 @@ guide: 7
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 So far we haven't discussed any associative data structures, i.e. data structures that are able to associate a certain value (or multiple values) to a key. Different languages call these different names like dictionaries, hashes, associative arrays, maps, etc.
 
 In Elixir, we have two main associative data structures: keyword lists and maps. It's time to learn more about them!

--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -6,6 +6,8 @@ guide: 8
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 In Elixir we group several functions into modules. We've already used many different modules in the previous chapters like [the `String` module](/docs/stable/String.html):
 
 ```iex

--- a/getting_started/9.markdown
+++ b/getting_started/9.markdown
@@ -6,6 +6,8 @@ guide: 9
 
 # {{ page.title }}
 
+  <div class="toc"></div>
+
 Due to immutability, loops in Elixir (and in functional programming languages) are written differently from conventional imperative languages. For example, in an imperative language, one would write:
 
 ```c

--- a/js/toc/LICENSE.txt
+++ b/js/toc/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Alex Ghiculescu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/js/toc/toc.js
+++ b/js/toc/toc.js
@@ -1,0 +1,61 @@
+// https://github.com/ghiculescu/jekyll-table-of-contents
+(function($){
+  $.fn.toc = function(options) {
+    var defaults = {
+      noBackToTopLinks: false,
+      title: '<i>Jump to...</i>',
+      listType: 'ol', // values: [ol|ul]
+      showSpeed: 'slow'
+    },
+    settings = $.extend(defaults, options);
+
+    // I modified the single line below to exlude h1 header
+    // --alco
+    var headers = $('h2, h3, h4, h5, h6').filter(function() {
+      // get all headers with an ID
+      return this.id;
+    }), output = $(this);
+    if (!headers.length || headers.length < 3 || !output.length) {
+      return;
+    }
+
+    var get_level = function(ele) { return parseInt(ele.nodeName.replace("H", ""), 10); }
+    var highest_level = headers.map(function(_, ele) { return get_level(ele); }).get().sort()[0];
+    var return_to_top = '<i class="icon-arrow-up back-to-top"> </i>';
+
+    var level = get_level(headers[0]),
+      this_level,
+      html = settings.title + " <"+settings.listType+">";
+    headers.on('click', function() {
+      if (!settings.noBackToTopLinks) {
+        window.location.hash = this.id;
+      }
+    })
+    .addClass('clickable-header')
+    .each(function(_, header) {
+      this_level = get_level(header);
+      if (!settings.noBackToTopLinks && this_level === highest_level) {
+        $(header).addClass('top-level-header').after(return_to_top);
+      }
+      if (this_level === level) // same level as before; same indenting
+        html += "<li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      else if (this_level < level) // higher level than before; end parent ol
+        html += "</li></"+settings.listType+"></li><li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      else if (this_level > level) // lower level than before; expand the previous to contain a ol
+        html += "<"+settings.listType+"><li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      level = this_level; // update for the next one
+    });
+    html += "</"+settings.listType+">";
+    if (!settings.noBackToTopLinks) {
+      $(document).on('click', '.back-to-top', function() {
+        $(window).scrollTop(0);
+        window.location.hash = '';
+      });
+    }
+    if (0 !== settings.showSpeed) {
+      output.hide().html(html).show(settings.showSpeed);
+    } else {
+      output.html(html);
+    }
+  };
+})(jQuery);


### PR DESCRIPTION
This adds a JS TOC using this library https://github.com/ghiculescu/jekyll-table-of-contents

More precisely, it generates the table of contents for the current chapter just below the chapter title.

Preview:
![screen shot 2014-05-15 at 03 34 51](https://cloud.githubusercontent.com/assets/207748/2979215/f8bdb80c-dbc8-11e3-8826-f793a24ec220.png)
