### PR TITLE
Add code editor support link for Atom

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -26,6 +26,7 @@
     <li><a class="spec" href="https://github.com/elixir-lang/elixir-tmbundle" target="_blank">Textmate Bundle</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir" target="_blank">Vim Elixir</a></li>
     <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview" target="_blank">GtkSourceView (gedit)</a></li>
+    <li><a class="spec" href="https://github.com/lucasmazza/language-elixir" target="_blank">Atom Package</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
I added a link for a package for the new IDE Atom. I use it and it works well.
