### PR TITLE
StringIO.start -> StringIO.open

### DIFF
--- a/getting_started/12.markdown
+++ b/getting_started/12.markdown
@@ -130,7 +130,7 @@ After `IO.write/2`, we can see the request sent by the IO module printed, which 
 The [`StringIO`](/docs/stable/StringIO.html) module provides an implementation of the IO device messages on top of a string:
 
 ```iex
-iex> {:ok, pid} = StringIO.start("hello")
+iex> {:ok, pid} = StringIO.open("hello")
 {:ok, #PID<0.43.0>}
 iex> IO.read(pid, 2)
 "he"


### PR DESCRIPTION
The function to create a StringIO is `open/1`, not `start/1` in the current versions of Elixir as confirmed by the [docs](http://elixir-lang.org/docs/stable/StringIO.html) and me just running through the Getting Started guide in iex.

``` iex
iex(15)> {:ok, pid} = StringIO.start("hello")
** (UndefinedFunctionError) undefined function: StringIO.start/1
    (elixir) StringIO.start("hello")
iex(15)> l StringIO
{:module, StringIO}
iex(16)> {:ok, pid} = StringIO.start("hello")
** (UndefinedFunctionError) undefined function: StringIO.start/1
    (elixir) StringIO.start("hello")
iex(16)> StringIO.
close/1       contents/1    open/2
iex(16)> {:ok, pid} = StringIO.open("hello")
{:ok, #PID<0.68.0>}
```
