### PR TITLE
Use defined variable

### DIFF
--- a/getting_started/15.markdown
+++ b/getting_started/15.markdown
@@ -58,7 +58,7 @@ iex> jose.name
 "jose"
 iex> eric = %{jose | name: "eric"}
 %User{name: "eric", age: 27}
-iex> %{user | oops: :field}
+iex> %{eric | oops: :field}
 ** (ArgumentError) argument error
 ```
 


### PR DESCRIPTION
The last example showing that `:oops` is not a valid key uses the undefined variable `user` instead of the defined `User`s, either `jose` or `eric`, so instead of `ArgumentError` being raised, a `RuntimeError` is raised:

``` iex
iex(26)> %{user | oops: :field}
** (RuntimeError) undefined function: user/0
iex(26)> %{eric | oops: :field}
** (ArgumentError) argument error
    (stdlib) :maps.update(:oops, :field, %User{age: 27, name: "eric"})
```
