### PR TITLE
Correct initial test assertion

### DIFF
--- a/getting_started/mix_otp/1.markdown
+++ b/getting_started/mix_otp/1.markdown
@@ -132,7 +132,7 @@ defmodule KVTest do
   use ExUnit.Case
 
   test "the truth" do
-    assert true
+    assert 1 + 1 == 2
   end
 end
 ```


### PR DESCRIPTION
The initial test is "assert 1 + 1 == 2", not "assert true".  I think the math example works better since line 170 refers to it, as well.
