### PR TITLE
Minor grammatical fixes

### DIFF
--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -65,7 +65,7 @@ defmodule KV.BucketTest do
 end
 ```
 
-Our first test is quite straight-forward. We start a new `KV.Bucket` and perform some `get/2` and `put/3` operations on it, asserting the result. We don't need to explicitly stop the agent because it is linked to the test process and the agents is shutdown automatically once the test finishes.
+Our first test is quite straight-forward. We start a new `KV.Bucket` and perform some `get/2` and `put/3` operations on it, asserting the result. We don't need to explicitly stop the agent because it is linked to the test process and the agent is shut down automatically once the test finishes.
 
 Also note that we passed the `async: true` option to `ExUnit.Case`. This option makes this test case run in parallel with other test cases that set up the `:async` option. This is extremely useful to speed up our test suite by using our cores in our machine. Note though the `:async option must only be set if the test case does not rely or change any global value. For example, if the test requires writing to the filesystem, registering processes, accessing a database, you must not make it async to avoid race conditions in between tests.
 


### PR DESCRIPTION
Subject/verb agreement fix.  Also, "shut down" is two words as a verb, but one word as a noun. ( See http://workinginwords.blogspot.com/2013/10/shutdown-vs-shut-down-which-is-proper.html )
