### PR TITLE
Fix a typo/syntax error in OTP chapter 5.

### DIFF
--- a/getting_started/mix_otp/5.markdown
+++ b/getting_started/mix_otp/5.markdown
@@ -195,7 +195,7 @@ test "removes bucket on crash", %{registry: registry} do
   # Kill the bucket and wait for the notification
   Process.exit(bucket, :shutdown)
   assert_receive {:exit, "shopping", ^bucket}
-  assert KV.Registry.lookup(manager, "shopping") == :error
+  assert KV.Registry.lookup(registry, "shopping") == :error
 end
 ```
 


### PR DESCRIPTION
Looks like we inadvertently have "manager" instead of "registry" in the
code for the "removes bucket on crash" test.
