### PR TITLE
Fix mix.exs deps definition in Mix/OTP Ch. 9

### DIFF
--- a/getting_started/mix_otp/9.markdown
+++ b/getting_started/mix_otp/9.markdown
@@ -263,7 +263,7 @@ end
 
 defp deps do
   [{:kv, in_umbrella: true},
-   {:pipes, github: "batate/elixir-pipes"}]
+   {:pipe, github: "batate/elixir-pipes"}]
 end
 ```
 


### PR DESCRIPTION
We were referencing the :pipe application as :pipes in the deps
function.
