### PR TITLE
Minor touchups to wording in OTP chapter 2

### DIFF
--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -8,7 +8,7 @@ guide: 2
 
   <div class="toc"></div>
 
-In this chapter, we will create a module named `KV.Bucket`. This module will be responsible to store our key-value entries in a way they can be read and modified by different processes.
+In this chapter, we will create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way that allows reading and modification by different processes.
 
 If you have skipped the Getting Started guide or if you have read it long ago, be sure to re-read the chapter about [Processes](/getting_started/11.html). We will use it as starting point.
 
@@ -21,12 +21,12 @@ Elixir is an immutable language where nothing is shared by default. If we want t
 
 We have talked about processes, while ETS is something new that we will explore later in this guide. When it comes to processes though, we rarely hand-roll our own process, instead we use the abstractions available in Elixir and OTP:
 
-* [Agent](/docs/stable/elixir/Agent.html) - agents are simple wrappers around state;
-* [GenServer](/docs/stable/elixir/GenServer.html) - generic servers (processes) that encapsulate state, provide sync and async calls, support for code reloading and more;
-* [GenEvent](/docs/stable/elixir/GenEvent.html) - generic event managers and event handlers. If you need to publish events that are consumed by many handlers, you want a GenEvent;
-* [Task](/docs/stable/elixir/Task.html) - tasks are abstractions around computation. If you want to spawn a computation to happen asynchronously and read its value later, tasks are a great fit;
+* [Agent](/docs/stable/elixir/Agent.html) - Simple wrappers around state
+* [GenServer](/docs/stable/elixir/GenServer.html) - "Generic servers" (processes) that encapsulate state, provide sync and async calls, support code reloading, and more
+* [GenEvent](/docs/stable/elixir/GenEvent.html) - "Generic event" managers that allow publishing events to multiple handlers
+* [Task](/docs/stable/elixir/Task.html) - Asynchronous units of computation that allow spawning a process and easily retrieving its result at a later time
 
-We will explore all of those in this guide. Keep in mind that all of those abstractions are implemented on top of processes using the basic features provided by the VM, like `send`, `receive`, `spawn` and `link`.
+We will explore all of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the VM, like `send`, `receive`, `spawn` and `link`.
 
 ## 2.2 Agents
 
@@ -47,7 +47,7 @@ iex> Agent.stop(agent)
 :ok
 ```
 
-We have started an agent with an initial state of an empty list. Then we issue commands to add a new item to the list and finally retrieved the whole list. Once we are done with the agent, we can call `Agent.stop/1` to terminate the agent process.
+We started an agent with an initial state of an empty list. Next, we issue a command to update the state, adding our new item to the head of the list. Finally, we retrieved the whole list. Once we are done with the agent, we can call `Agent.stop/1` to terminate the agent process.
 
 Let's implement our `KV.Bucket` using agents. But before starting the implementation, let's first write some tests. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
 
@@ -65,9 +65,9 @@ defmodule KV.BucketTest do
 end
 ```
 
-Our first test is quite straight-forward. We start a new `KV.Bucket` and perform some `get/2` and `put/3` operations on it, asserting the result. We don't need to explicitly stop the agent because it is linked to the test process and the agent is shut down automatically once the test finishes.
+Our first test is straightforward. We start a new `KV.Bucket` and perform some `get/2` and `put/3` operations on it, asserting the result. We don't need to explicitly stop the agent because it is linked to the test process and the agent is shut down automatically once the test finishes.
 
-Also note that we passed the `async: true` option to `ExUnit.Case`. This option makes this test case run in parallel with other test cases that set up the `:async` option. This is extremely useful to speed up our test suite by using our cores in our machine. Note though the `:async option must only be set if the test case does not rely or change any global value. For example, if the test requires writing to the filesystem, registering processes, accessing a database, you must not make it async to avoid race conditions in between tests.
+Also note that we passed the `async: true` option to `ExUnit.Case`. This option makes this test case run in parallel with other test cases that set up the `:async` option. This is extremely useful to speed up our test suite by using multiple cores in our machine. Note though the `:async` option must only be set if the test case does not rely or change any global value. For example, if the test requires writing to the filesystem, registering processes, accessing a database, you must not make it async to avoid race conditions in between tests.
 
 Regardless of being async or not, our new test should obviously fail, as none of the functionality is implemented.
 
@@ -98,11 +98,11 @@ defmodule KV.Bucket do
 end
 ```
 
-With the `KV.Bucket` module defined, our test should pass! Note we are using a HashDict as state instead of a `Map` because in the current Elixir version maps are only efficient when holding a small amount of keys.
+With the `KV.Bucket` module defined, our test should pass! Note that we are using a HashDict to store our state instead of a `Map`, because in the current version of Elixir maps are less efficient when holding a large number of keys.
 
 ## 2.3 ExUnit callbacks
 
-Before moving on and adding more features to `KV.Bucket`, let's talk about ExUnit callbacks. As you may expect, all `KV.Bucket` tests will require a bucket to be started during setup and stopped after the test. Luckily, ExUnit supports callbacks that allows us to skip such repetitive tasks.
+Before moving on and adding more features to `KV.Bucket`, let's talk about ExUnit callbacks. As you may expect, all `KV.Bucket` tests will require a bucket to be started during setup and stopped after the test. Luckily, ExUnit supports callbacks that allow us to skip such repetitive tasks.
 
 Let's rewrite the test case to use callbacks:
 
@@ -126,23 +126,25 @@ end
 
 We have first defined a setup callback with the help of the `setup/1` macro. The `setup/1` callback runs before every test, in the same process as the test itself.
 
-Note that we need a mechanism to pass the `bucket` pid from the callback to the test. We do so by using the *test context*. When we return `{:ok, bucket: bucket}` from the callback, ExUnit will merge the second element of the tuple (a dictionary) into the test context. The test context is a map which we can then match during the test definition:
+Note that we need a mechanism to pass the `bucket` pid from the callback to the test. We do so by using the *test context*. When we return `{:ok, bucket: bucket}` from the callback, ExUnit will merge the second element of the tuple (a dictionary) into the test context. The test context is a map which we can then match in the test definition, providing access to these values inside the block:
 
 ```elixir
 test "stores values by key", %{bucket: bucket} do
+  # `bucket` is now the bucket from the setup block
+end
 ```
 
 You can read more about ExUnit cases in the [`ExUnit.Case` module documentation](/docs/stable/ex_unit/ExUnit.Case.html) and more about callbacks in [`ExUnit.Callbacks` docs](/docs/stable/ex_unit/ExUnit.Callbacks.html).
 
 ## 2.4 Other Agent actions
 
-Besides getting a value and updating the agent state, agents allow us to get a value and update the agent state in one tackle via `Agent.get_and_update/2`. Let's implement a `KV.Bucket.delete/2` function that deletes a key from the bucket, returning its current value:
+Besides getting a value and updating the agent state, agents allow us to get a value and update the agent state in one function call via `Agent.get_and_update/2`. Let's implement a `KV.Bucket.delete/2` function that deletes a key from the bucket, returning its current value:
 
 ```elixir
 @doc """
 Deletes `key` from `bucket`.
 
-Returns its current value if such `key` exists.
+Returns the current value of `key`, if `key` exists.
 """
 def delete(bucket, key) do
   Agent.get_and_update(bucket, &HashDict.pop(&1, key))
@@ -163,9 +165,9 @@ def delete(bucket, key) do
 end
 ```
 
-Everything that is inside the function passed to the agent happens in the agent process. In this case, since the agent process is the one receiving and responding to our messages, we say the agent process is the server. Everything outside the function is happening in the client.
+Everything that is inside the function we passed to the agent happens in the agent process. In this case, since the agent process is the one receiving and responding to our messages, we say the agent process is the server. Everything outside the function is happening in the client.
 
-This distinction is important in case there are expensive actions to be done and you must consider if it will be better to perform such actions on the client or on the server. For example:
+This distinction is important. If there are expensive actions to be done, you must consider if it will be better to perform these actions on the client or on the server. For example:
 
 ```elixir
 def delete(bucket, key) do
@@ -179,4 +181,4 @@ end
 
 When a long action is performed on the server, all other requests to that particular server will wait until the action is done, which may cause some clients to timeout.
 
-In the next chapter we will explore GenServers, where the segregation in between clients and servers is made even more apparent.
+In the next chapter we will explore GenServers, where the segregation between clients and servers is made even more apparent.


### PR DESCRIPTION
Nothing too much here -- a few grammatical and typo cleanups, and made the test context example a bit more explicit.
