### PR TITLE
Various touchups to Mix and OTP Chapter 3.

### DIFF
--- a/getting_started/mix_otp/3.markdown
+++ b/getting_started/mix_otp/3.markdown
@@ -146,7 +146,7 @@ end
 
 Our test should pass right out of the box!
 
-To shutdown the registry, we are simply sending a `:shutdown` signal to its process when our test finishes While this solution is ok for tests, if there is a need to stop a `GenServer` as part of the application logic, it is best to define a `stop/1` function that sends a `call` message causing the server to stop:
+To shutdown the registry, we are simply sending a `:shutdown` signal to its process when our test finishes. While this solution is ok for tests, if there is a need to stop a `GenServer` as part of the application logic, it is best to define a `stop/1` function that sends a `call` message causing the server to stop:
 
 ```elixir
 ## Client API


### PR DESCRIPTION
As before, minor tweaks to chapter 3. I expanded a bit on why tuples are used in `handle_call/3` and `handle_cast/2`. It might be too obvious/elementary for some, but hopefully helpful to others. :)
