### PR TITLE
Expressions in guard clauses should have their own section.

### DIFF
--- a/getting_started/5.markdown
+++ b/getting_started/5.markdown
@@ -47,7 +47,11 @@ iex> case {1, 2, 3} do
 ...> end
 ```
 
-The first clause above will only match when `x` is positive. The Erlang VM only allows a limited set of expressions in guards:
+The first clause above will only match when `x` is positive.
+
+## 5.2 Expressions in guard clauses.
+
+The Erlang VM only allows a limited set of expressions in guards:
 
 * comparison operators (`==`, `!=`, `===`, `!==`, `>`, `<`, `<=`, `>=`)
 * boolean operators (`and`, `or`) and negation operators (`not`, `!`)
@@ -130,7 +134,7 @@ iex> f.(-1, 3)
 
 The number of arguments in each anonymous function clause needs to be the same, otherwise an error is raised.
 
-## 5.2 cond
+## 5.3 cond
 
 `case` is useful when you need to match against different values. However, in many circumstances, we want to check different conditions and find the first one that evaluates to true. In such cases, one may use `cond`:
 
@@ -171,7 +175,7 @@ iex> cond do
 "1 is considered as true"
 ```
 
-## 5.3 if and unless
+## 5.4 if and unless
 
 Besides `case` and `cond`, Elixir also provides the macros `if/2` and `unless/2` which are useful when you need to check for just one condition:
 
@@ -201,7 +205,7 @@ iex> if nil do
 
 > Note: An interesting note regarding `if/2` and `unless/2` is that they are implemented as macros in the language; they are special language constructs as they would be in many languages. You can check the documentation and the source of `if/2` in [the `Kernel` module docs](/docs/stable/elixir/Kernel.html). The `Kernel` module is also where operators like `+/2` and functions like `is_function/2` are defined, all automatically imported and available in your code by default.
 
-## 5.4 `do` blocks
+## 5.5 `do` blocks
 
 At this point, we have learned four control structures: `case`, `cond`, `if` and `unless`, and they were all wrapped in `do`/`end` blocks. It happens we could also write `if` as follows:
 


### PR DESCRIPTION
IMHO, it seems that expressions in guard clauses, due to their limitations, should have their own section.  This would make this information easier to access and reference.
