### PR TITLE
Initial releases.csv for web installations

### DIFF
--- a/releases.csv
+++ b/releases.csv
@@ -1,0 +1,12 @@
+0.14.1,https://github.com/elixir-lang/elixir/releases/download/v0.14.1/Precompiled.zip,false,1
+0.14.0,https://github.com/elixir-lang/elixir/releases/download/v0.14.0/Precompiled.zip,false,1
+0.13.3,https://github.com/elixir-lang/elixir/releases/download/v0.13.3/Precompiled.zip,false,1
+0.13.2,https://github.com/elixir-lang/elixir/releases/download/v0.13.2/Precompiled.zip,false,1
+0.13.1,https://github.com/elixir-lang/elixir/releases/download/v0.13.1/Precompiled.zip,false,1
+0.13.0,https://github.com/elixir-lang/elixir/releases/download/v0.13.0/Precompiled.zip,false,1
+0.12.5,https://github.com/elixir-lang/elixir/releases/download/v0.12.5/Precompiled.zip,false,1
+0.12.4,https://github.com/elixir-lang/elixir/releases/download/v0.12.4/Precompiled.zip,false,1
+0.12.3,https://github.com/elixir-lang/elixir/releases/download/v0.12.3/Precompiled.zip,false,1
+0.12.2,https://github.com/elixir-lang/elixir/releases/download/v0.12.2/Precompiled.zip,false,1
+0.12.1,https://github.com/elixir-lang/elixir/releases/download/v0.12.1/Precompiled.zip,false,1
+0.12.0,https://github.com/elixir-lang/elixir/releases/download/v0.12.0/Precompiled.zip,false,1


### PR DESCRIPTION
This is a file for tracking information about Elixir releases, which encodes as `Version,URL,Prerelease,WindowsInstallType`
- `Version` is the Elixir version
- `URL` is the Precompiled.zip corresponding with that version
- `Prerelease` is true or false
- `WindowsInstallType` indexes the type of [Windows installer](https://github.com/chyndman/elixir-windows-setup) that can install this version.

(I elected to put the `WindowsInstallType` last rather than first since any other consumer of this data probably won't care for it.)
