### PR TITLE
Add example of Macro.var/2 to Meta guide

### DIFF
--- a/getting_started/meta/2.markdown
+++ b/getting_started/meta/2.markdown
@@ -163,6 +163,31 @@ Notice that the third element in the quoted variable is the atom `Sample`, inste
 
 Elixir provides similar mechanisms for imports and aliases too. This guarantees macros will behave as specified by its source module rather than conflicting with the target module where the macro is expanded. Hygiene can be bypassed under specific situations by using macros like `var!/2` and `alias!/2`, although one must be careful when using those as they directly change the user environment.
 
+Sometimes variable names might be dynamically created. In these cases, `Macro.var/2` can be used to define new variables:
+
+```elixir
+defmodule Sample do
+  defmacro initialize_to_char_count(variables) do
+    Enum.map variables, fn(name) ->
+      var = Macro.var(name, nil)
+      value = Atom.to_string(name)|> String.length
+      quote do
+        unquote(var) = unquote(length)
+      end
+    end
+  end
+  
+  def run do
+    initialize_to_char_count [:red, :green, :yellow]
+    [red, green, yellow]
+  end
+end
+
+> Sample.run #=> [3, 5, 6]
+```
+
+Take note of the second argument to `Macro.var/2`. This is the context used and will determine hygiene as described in this section.
+
 ## 2.3 The environment
 
 When using `Macro.expand_once/2` earlier in this chapter, we have used the special form `__ENV__`.


### PR DESCRIPTION
Since var!/2 no longer accepts atoms directly, Macro.var/2 is recommended. As a user upgrading to the latest Elixir, this was fairly confusing and I think it's a worthy addition to the hygiene section.
