### PR TITLE
Support installing master branch from S3

### DIFF
--- a/releases.csv
+++ b/releases.csv
@@ -1,3 +1,4 @@
+0.14.3-dev,http://s3.hex.pm/builds/elixir/master.zip,prerelease,1
 0.14.2,https://github.com/elixir-lang/elixir/releases/download/v0.14.2/Precompiled.zip,release,1
 0.14.1,https://github.com/elixir-lang/elixir/releases/download/v0.14.1/Precompiled.zip,release,1
 0.14.0,https://github.com/elixir-lang/elixir/releases/download/v0.14.0/Precompiled.zip,release,1


### PR DESCRIPTION
This is so that people can install the latest development prerelease.
