### PR TITLE
Fix "behavior" instead of "behaviour"

### DIFF
--- a/getting_started/14.markdown
+++ b/getting_started/14.markdown
@@ -81,7 +81,7 @@ We also provide a tool called [ExDoc](https://github.com/elixir-lang/ex_doc) whi
 You can take a look at the docs for [Module](/docs/stable/elixir/Module.html) for a complete list of supported attributes. Elixir also uses attributes to define [typespecs](/docs/stable/elixir/Kernel.Typespec.html), via:
 
 * `@spec` - provides a specification for a function.
-* `@callback` - provides a specification for the behavior callback.
+* `@callback` - provides a specification for the behaviour callback.
 * `@type` - defines a type to be used in `@spec`.
 * `@typep` - defines a private type to be used in `@spec`.
 * `@opaque` - defines an opaque type to be used in `@spec`.


### PR DESCRIPTION
It was specified that the spelling was british, and since it was referring to the same thing I felt like it should have been corrected.
