### PR TITLE
Update 2.markdown

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -275,7 +275,7 @@ Elixir uses curly brackets to define tuples. As lists, tuples can hold any value
 ```iex
 iex> {:ok, "hello"}
 {:ok, "hello"}
-iex> size {:ok, "hello"}
+iex> tuple_size {:ok, "hello"}
 2
 ```
 


### PR DESCRIPTION
Change `size` to `tuple_size`. Doesn't work with Elixir master(0.14.3-dev).
