### PR TITLE
Touchups to chapter 9

### DIFF
--- a/getting_started/mix_otp/9.markdown
+++ b/getting_started/mix_otp/9.markdown
@@ -8,7 +8,7 @@ guide: 9
 
   <div class="toc"></div>
 
-In this chapter, we will implement the code that parses the commands we have first described in the first chapter:
+In this chapter, we will implement the code that parses the commands we described in the first chapter:
 
 ```
 CREATE shopping
@@ -28,13 +28,13 @@ DELETE shopping eggs
 OK
 ```
 
-After the parsing is done, we will update our server to dispatch the parsed commands to the `:kv` application we have built in previous chapters.
+After the parsing is done, we will update our server to dispatch the parsed commands to the `:kv` application we built previously.
 
 ## 9.1 Doctests
 
-On the language homepage, we mention how Elixir makes documentation a first-class citizen in the language. We have explored this chapter many times throughout this guide, be it via `mix help` or by typing `h Enum` or another module in the terminal.
+On the language homepage, we mention that Elixir makes documentation a first-class citizen in the language. We have explored this concept many times throughout this guide, be it via `mix help` or by typing `h Enum` or another module in an IEx console.
 
-In this section, we will implement the parse functionality using doctests, which allows us to write tests directly from our documentation, which helps provide documentation with accurate code samples.
+In this section, we will implement the parse functionality using doctests, which allows us to write tests directly from our documentation. This helps us provide documentation with accurate code samples.
 
 Let's create our command parser at `lib/kv_server/command.ex` and start with the doctest:
 
@@ -55,11 +55,11 @@ defmodule KVServer.Command do
 end
 ```
 
-Doctests are specified by four spaces in the documentation followed by the `iex>` prompt. If a command spawns multiple lines, you can use `...>`, as in IEx. The expected result should start at the next line after `iex>` or `...>` line(s) and is terminated either by a newline or a new `iex>` prefix.
+Doctests are specified in by an indentation of four spaces followed by the `iex>` prompt in a documentation string. If a command spans multiple lines, you can use `...>`, as in IEx. The expected result should start at the next line after `iex>` or `...>` line(s) and is terminated either by a newline or a new `iex>` prefix.
 
-Also note that we started the documentation string using `@doc ~S"""`. We have used `~S` so the `\r\n` characters inside the doctest are preserved as is.
+Also note that we started the documentation string using `@doc ~S"""`. The `~S` prevents the `\r\n` characters from being converted to a carriage return and line feed until they are evaluated in the test.
 
-In order to run our doctests, create a file at `test/kv_server/command_test.exs` and simply call `doctest KVServer.Command` in the test case:
+To run our doctests, we'll create a file at `test/kv_server/command_test.exs` and call `doctest KVServer.Command` in the test case:
 
 ```elixir
 defmodule KVServer.CommandTest do
@@ -90,7 +90,7 @@ def parse(line) do
 end
 ```
 
-Our implementation simply splits the line on every whitespace and then matches the command against a list. Using `String.split/2` means our commands are actually white-space insensitive. Let's add some new doctests to test this behaviour and the other commands:
+Our implementation simply splits the line on whitespace and then matches the command against a list. Using `String.split/1` means our commands will be whitespace-insensitive. Leading and trailing whitespace won't matter, nor will consecutive spaces between words. Let's add some new doctests to test this behaviour along with the other commands:
 
 ```elixir
 @doc ~S"""
@@ -125,7 +125,7 @@ arguments return an error:
 """
 ```
 
-With doctests is hand, it is your turn to make tests pass! Once you ready, you can compare with our solution below:
+With doctests at hand, it is your turn to make tests pass! Once you're ready, you can compare your work with our solution below:
 
 ```elixir
 def parse(line) do
@@ -139,9 +139,9 @@ def parse(line) do
 end
 ```
 
-Notice how we were able to elegantly parse the commands without adding a bunch of `if/else` clauses that checks the command name and length!
+Notice how we were able to elegantly parse the commands without adding a bunch of `if/else` clauses that check the command name and number of arguments!
 
-Finally, you may have observed that each doctest was considered to be a different test in our test case, as our test suite now reports a total of 7 tests. That is because ExUnit considers this two different tests:
+Finally, you may have observed that each doctest was considered to be a different test in our test case, as our test suite now reports a total of 7 tests. That is because ExUnit considers the following to define two different tests:
 
 ```iex
 iex> KVServer.Command.parse "UNKNOWN shopping eggs\r\n"
@@ -151,7 +151,7 @@ iex> KVServer.Command.parse "GET shopping\r\n"
 {:error, :unknown_command}
 ```
 
-But without new lines, like the one below, ExUnit compiles it into a single test:
+Without new lines, as seen below, ExUnit compiles it into a single test:
 
 ```iex
 iex> KVServer.Command.parse "UNKNOWN shopping eggs\r\n"
@@ -177,7 +177,7 @@ defmodule KVServer.Command do
 end
 ```
 
-Before we implement this function, let's change our server to start using both `parse/1` and `run/1` functions. Remember our `read_line/1` function was also crashing when the client closed the socket, so let's take the opportunity to fix it too. Open up `lib/kv_server.ex` and replace the existing server definition:
+Before we implement this function, let's change our server to start using our new `parse/1` and `run/1` functions. Remember, our `read_line/1` function was also crashing when the client closed the socket, so let's take the opportunity to fix it, too. Open up `lib/kv_server.ex` and replace the existing server definition:
 
 ```elixir
 defp serve(socket) do
@@ -198,7 +198,7 @@ defp write_line(line, socket) do
 end
 ```
 
-by the following:
+with the following:
 
 ```elixir
 defp serve(socket) do
@@ -232,7 +232,7 @@ defp format_msg({:error, :unknown_command}), do: "UNKNOWN COMMAND\r\n"
 defp format_msg({:error, _}), do: "ERROR\r\n"
 ```
 
-If we start our server, we can now send commands to it. For now we can get two different responses, "OK" when the command is known and "UNKNOWN COMMAND" otherwise:
+If we start our server, we can now send commands to it. For now we will get two different responses: "OK" when the command is known and "UNKNOWN COMMAND" otherwise:
 
     $ telnet 127.0.0.1 4040
     Trying 127.0.0.1...
@@ -251,9 +251,11 @@ The previous implementation used pipes which made the logic straight-forward to 
 read_line(socket) |> KVServer.Command.parse |> KVServer.Command.run()
 ```
 
-Since we may have failures along the way, we need our pipeline logic to match error outputs and abort if they occur. Wouldn't it be great if instead we could say: "pipe those functions while the response is ok" or "pipe those functions while the response matches the `{:ok, _}` tuple"?
+Since we may have failures along the way, we need our pipeline logic to match error outputs and abort if they occur. Wouldn't it be great if instead we could say: "pipe these functions while the response is `:ok`" or "pipe these functions while the response matches the `{:ok, _}` tuple"?
 
-Actually there is a project called [elixir-pipes](https://github.com/batate/elixir-pipes) that provides exactly this functionality! Let's give it a try. Open up your `apps/kv_server/mix.exs` file and change both `application/0` and `deps/0` functions to the following:
+Thankfully, there is a project called [elixir-pipes](https://github.com/batate/elixir-pipes) that provides exactly this functionality! Let's give it a try.
+
+Open up your `apps/kv_server/mix.exs` file and change both `application/0` and `deps/0` functions to the following:
 
 ```elixir
 def application do
@@ -267,7 +269,7 @@ defp deps do
 end
 ```
 
-Run `mix deps.get` to get the dependency and rewrite `serve/1` function to use the `pipe_matching/3` functionality from the [elixir-pipes](https://github.com/batate/elixir-pipes) project:
+Run `mix deps.get` to get the dependency, and rewrite the `serve/1` function to use the `pipe_matching/3` functionality now avalable to us:
 
 ```elixir
 defp serve(socket) do
@@ -290,7 +292,7 @@ Excellent! Feel free to read the [elixir-pipes](https://github.com/batate/elixir
 
 ## 9.3 Running commands
 
-The last step is to implement `KVServer.Command.run/1` to run the parsed commands against the `:kv` application. Its implementation is shown below:
+The last step is to implement `KVServer.Command.run/1`, to run the parsed commands against the `:kv` application. Its implementation is shown below:
 
 ```elixir
 @doc """
@@ -332,9 +334,9 @@ defp lookup(bucket, callback) do
 end
 ```
 
-The implementation is quite-straight forward: we just dispatch to the `KV.Registry` server registered during the `:kv` application startup.
+The implementation is straightforward: we just dispatch to the `KV.Registry` server that we registered during the `:kv` application startup.
 
-Note we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
+Note that we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
 
 By the way, since we are now returning `{:error, :not_found}`, we should amend the `format_msg/1` function in `KV.Server` to nicely show not found messages too:
 
@@ -345,9 +347,9 @@ defp format_msg({:error, :not_found}), do: "NOT FOUND\r\n"
 defp format_msg({:error, _}), do: "ERROR\r\n"
 ```
 
-And our server functionality is almost complete, we just need to add tests. This time we have left tests for last because there are some important considerations to be done.
+And our server functionality is almost complete! We just need to add tests. This time, we have left tests for last because there are some important considerations to be made.
 
-`KVServer.Command.run/1`'s implementation is sending commands directly to the server named `KV.Registry`, which is registered by the `:kv` application. This means this server is global and if we have two tests sending messages to it at the same time, our tests will conflict with each other (and likely fail). We need to decide in between having unit tests, that are isolated and can run asynchronously, or write integration tests, that work on top of the global state, but exercises our application full stack as it is meant to be exercised in production.
+`KVServer.Command.run/1`'s implementation is sending commands directly to the server named `KV.Registry`, which is registered by the `:kv` application. This means this server is global and if we have two tests sending messages to it at the same time, our tests will conflict with each other (and likely fail). We need to decide between having unit tests that are isolated and can run asynchronously, or writing integration tests that work on top of the global state, but exercise our application's full stack as it is meant to be exercised in production.
 
 So far we have been chosing the unit test approach. For example, in order to make `KVServer.Command.run/1` testable as a unit we would need to change its implementation to not send commands directly to the `KV.Registry` process but instead pass a server as argument. This means we would need to change `run`'s signature to `def run(command, pid)` and the implementation for the `:create` command would look like:
 
@@ -358,20 +360,20 @@ def run({:create, bucket}, pid) do
 end
 ```
 
-Then in `KVServer.Command`'s test case, we need to start an instance of the `KV.Registry`, similar to how we have done in `apps/kv/test/kv/registry_test.exs` and pass it as argument to `run/2`.
+Then in `KVServer.Command`'s test case, we would need to start an instance of the `KV.Registry`, similar to what we've done in `apps/kv/test/kv/registry_test.exs`, and pass it as an argument to `run/2`.
 
-This has been the approach we have done so far in our tests and it brings some benefits:
+This has been the approach we have taken so far in our tests, and it has some benefits:
 
 1. Our implementation is not coupled to any particular server name
-2. We can keep our tests running asynchronously as there is no shared state
+2. We can keep our tests running asynchronously, because there is no shared state
 
-However it comes with the downside that our APIs become increasingly larger in order to receive all external parameters.
+However, it comes with the downside that our APIs become increasingly large in order to accommodate all external parameters.
 
-The alternative is to continue relying on the global server names and run tests against the global data, ensuring we clean up the data in between the tests. In this case, since the test would exercise the whole stack, from the TCP server, to the command parser and running, to the registry and finally reaching the bucket, it becomes an integration test.
+The alternative is to continue relying on the global server names and run tests against the global data, ensuring we clean up the data in between the tests. In this case, since the test would exercise the whole stack, from the TCP server, to the command parsing and running, to the registry and finally reaching the bucket, it becomes an integration test.
 
-The downside of integration tests though is that they can be much slower than unit tests and as such they must be used more sparingly. For example, we should not use integration tests to test an edge case in our command parsing implementation.
+The downside of integration tests is that they can be much slower than unit tests, and as such they must be used more sparingly. For example, we should not use integration tests to test an edge case in our command parsing implementation.
 
-Since we have used unit tests so far, this time we will take the other road and write an integration test. The integration test will have a TCP client that sends commands to our server and we will assert we are getting the desired responses.
+Since we have used unit tests so far, this time we will take the other road and write an integration test. The integration test will have a TCP client that sends commands to our server and we will assert that we are getting the desired responses.
 
 Let's implement our integration test in `test/kv_server_test.exs` as shown below:
 
@@ -423,7 +425,7 @@ defmodule KVServerTest do
 end
 ```
 
-Our integration test checks the whole server interaction, including unknown commands and not found errors. It is worthy reminding that, as in ETS tables and linked processes, there is no need to close the socket because once the test process exits, the socket is automatically closed.
+Our integration test checks all server interaction, including unknown commands and not found errors. It is worth noting that, as with ETS tables and linked processes, there is no need to close the socket. Once the test process exits, the socket is automatically closed.
 
 This time, since our test relies on global data, we have not given `async: true` to `use ExUnit.Case`. Furthermore, in order to guarantee our test is always in a clean slate, we stop and start the `:kv` application before each test. In fact, stopping the `:kv` application even prints a warning on the terminal:
 
@@ -434,7 +436,7 @@ This time, since our test relies on global data, we have not given `async: true`
     type: temporary
 ```
 
-If desired, we can avoid such data being printed by turning the error_logger off and on in the test setup:
+If desired, we can avoid printing this warning by turning the error_logger off and on in the test setup:
 
 ```elixir
 setup do
@@ -446,10 +448,10 @@ setup do
 end
 ```
 
-With this simple integration test, we start to see why integration tests may be slow. Not only this particular test cannot run asynchronously, it also requires the expensive setup of stopping and starting the `:kv` application.
+With this simple integration test, we start to see why integration tests may be slow. Not only can this particular test not be run asynchronously, it also requires the expensive setup of stopping and starting the `:kv` application.
 
-At the end of the day, it is up to you and your team to figure the best testing strategy for your applications. You need to balance the code quality, confidence and time of your test suite. For example, we may start with testing the server only with integration tests, but if the server continuously grows on upcoming releases, or it becomes a part of the application with frequent bugs, it is important to consider breaking it apart and writing more intensive unit tests that don't have the weight of an integration test.
+At the end of the day, it is up to you and your team to figure out the best testing strategy for your applications. You need to balance code quality, confidence, and test suite runtime. For example, we may start with testing the server only with integration tests, but if the server continues to grow in future releases, or it becomes a part of the application with frequent bugs, it is important to consider breaking it apart and writing more intensive unit tests that don't have the weight of an integration test.
 
-I personally err on the side of unit tests and have integration tests only as smoke tests to guarantee the basic skeleton of the system works.
+I personally err on the side of unit tests, and have integration tests only as smoke tests to guarantee the basic skeleton of the system works.
 
-In the next chapter we will finally make our system distributed by adding a bucket routing mechanism and learn about application configurations.
+In the next chapter we will finally make our system distributed by adding a bucket routing mechanism. We'll also learn about application configuration.


### PR DESCRIPTION
The only non-typo/grammar change to note is that we were referring to
String.split/2 but using String.split/1.
