### PR TITLE
Add headers to CSV files

### DIFF
--- a/elixir.csv
+++ b/elixir.csv
@@ -1,1 +1,2 @@
+version,url_precompiled,release_type,windows_installer_compat
 0.14.3,https://github.com/elixir-lang/elixir/releases/download/v0.14.3/Precompiled.zip,release,1

--- a/erlang.csv
+++ b/erlang.csv
@@ -1,2 +1,3 @@
+version_otp,version_erts,url_win32,url_win64
 17.1,6.1,http://www.erlang.org/download/otp_win32_17.1.exe,http://www.erlang.org/download/otp_win64_17.1.exe
 17,6.0,http://www.erlang.org/download/otp_win32_17.0.exe,http://www.erlang.org/download/otp_win64_17.0.exe


### PR DESCRIPTION
This is just so we can document the meaning of each column.  It's pretty easy to make my installer ignore the header, and it might be useful in the future.  We can also use more friendly-looking names if we want ("version" -> "Version", "url_precompiled" -> "URL (Precompiled.zip)", etc.).
