### PR TITLE
Fix deprecated octal syntax

### DIFF
--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -51,7 +51,7 @@ Elixir also supports shortcut notations for entering binary, octal and hexadecim
 ```iex
 iex> 0b1010
 10
-iex> 0777
+iex> 0o777
 511
 iex> 0x1F
 31


### PR DESCRIPTION
refs
elixir-lang/elixir#2598
elixir-lang/elixir@6874eb7ce8bb89c74abe6819bed994cb776bf397
