### PR TITLE
Fixed issue #331

### DIFF
--- a/getting_started/meta/3.markdown
+++ b/getting_started/meta/3.markdown
@@ -61,7 +61,7 @@ defmodule TestCase do
 
   """
   defmacro test(description, do: block) do
-    function_name = binary_to_atom("test " <> description)
+    function_name = String.to_atom("test " <> description)
     quote do
       def unquote(function_name)(), do: unquote(block)
     end
@@ -124,7 +124,7 @@ defmodule TestCase do
 
   """
   defmacro test(description, do: block) do
-    function_name = binary_to_atom("test " <> description)
+    function_name = String.to_atom("test " <> description)
     quote do
       # Prepend the newly defined test to the list of tests
       @tests [unquote(function_name)|@tests]


### PR DESCRIPTION
Now uses String.to_atom instead of binary_to_atom in examples.
