### PR TITLE
Fix typos and remove repetition

### DIFF
--- a/getting_started/meta/3.markdown
+++ b/getting_started/meta/3.markdown
@@ -9,9 +9,7 @@ last: true
 
   <div class="toc"></div>
 
-[Domain Specific Languages](https://en.wikipedia.org/wiki/Domain-specific_language) allows developers to specialize their application to a particular domain. There are many language features that come together to aid developers to write Domain Specific Languages and in this chapter we will focus on just one of them.
-
-In particular, we will focus on how macros and module attributes can be used together to create domain specific modules, that are focused on solving one particular example. To showcase our implementation, we will write a very simple test case implementation.
+[Domain Specific Languages](https://en.wikipedia.org/wiki/Domain-specific_language) allow developers to tailor their application to a particular domain. There are many language features that, when used in combination, can aid developers to write Domain Specific Languages. In this chapter we will focus on how macros and module attributes can be used together to create domain specific modules that are focused on solving one particular problem. As an example, we will write a very simple module to define and run tests.
 
 The goal is to build a module named `TestCase` that allows us to write the following:
 
@@ -31,15 +29,15 @@ end
 MyTest.run
 ```
 
-In the example above, by using `TestCase`, we can define tests using the `test` macro and it automatically defines a function named `run` that will automatically run all tests for us. Our prototype will also simply rely on the match operator (`=`) as a mechanism to do assertions.
+In the example above, by using `TestCase`, we can write tests using the `test` macro, which defines a function named `run` to automatically run all tests for us. Our prototype will simply rely on the match operator (`=`) as a mechanism to do assertions.
 
 ## 3.1 The `test` macro
 
-Let's start by defining a module that simply defines and imports the `test` macro when used:
+Let's start by creating a module that simply defines and imports the `test` macro when used:
 
 ```elixir
 defmodule TestCase do
-  # Callback invoked when by `use`.
+  # Callback invoked by `use`.
   #
   # For now it simply returns a quoted expression that
   # imports the module itself into the user code.
@@ -69,7 +67,7 @@ defmodule TestCase do
 end
 ```
 
-Assuming we defined `TestCase` in a file named `tests.exs`, we can open it up `iex tests.exs` and define our first tests:
+Assuming we defined `TestCase` in a file named `tests.exs`, we can open it up by running `iex tests.exs` and define our first tests:
 
 ```iex
 iex> defmodule MyTest do
@@ -81,7 +79,7 @@ iex> defmodule MyTest do
 ...> end
 ```
 
-For now we don't have a mechanism to run tests, but we know that a function named "test hello" was defined behind the scenes, so we can invoke it and it should fail:
+For now we don't have a mechanism to run tests, but we know that a function named "test hello" was defined behind the scenes. When we invoke it, it should fail:
 
 ```iex
 iex> MyTest."test hello"()
@@ -90,11 +88,11 @@ iex> MyTest."test hello"()
 
 ## 3.2 Storing information with attributes
 
-In order to finish our `TestCase` implementation, we need to be able to retrieve all defined test cases. One way of doing such is by retrieving the tests at runtime via `__MODULE__.__info__(:functions)` which returns a list of all functions in a given module. However, considering that we may want to store more information with each tests beyond the test name, are more flexible approach is required.
+In order to finish our `TestCase` implementation, we need to be able to access all defined test cases. One way of doing this is by retrieving the tests at runtime via `__MODULE__.__info__(:functions)`, which returns a list of all functions in a given module. However, considering that we may want to store more information about each test besides the test name, a more flexible approach is required.
 
-When discussing module attributes in early chapters, we have discussed how they can be used as temporary storage and that's exactly what we will do in this section.
+When discussing module attributes in earlier chapters, we mentioned how they can be used as temporary storage. That's exactly the property we will apply in this section.
 
-In the `__using__/1` implementation, we will initialize a module attribute named `@tests` to an empty list, then store each defined test in this attribute until we compile into into a `run` function.
+In the `__using__/1` implementation, we will initialize a module attribute named `@tests` to an empty list, then store each defined test in this attribute until we compile all tests in the list inside the `run` function.
 
 Here is the updated code for the `TestCase` module:
 
@@ -163,6 +161,6 @@ Running test hello
 ** (MatchError) no match of right hand side value: "world"
 ```
 
-Although we have glanced over some details, the bulk of how we can create domain specific modules in Elixir is here. Macros allows us to return quoted expressions that are executed in the caller, which in turn we use to transform code and to store relevant information in the target module via module attributes. Finally, with callbacks such as `@before_compile`, we have the perfect opportunity to inject code into the module when its definition is complete.
+Although we have overlooked some details, this is the main idea behind creating domain specific modules in Elixir. Macros enable us to return quoted expressions that are executed in the caller, which we can then use to transform code and store relevant information in the target module via module attributes. Finally, callbacks such as `@before_compile` allow us to inject code into the module when its definition is complete.
 
-Besides `@before_compile`, there are other useful module attributes, like `@on_definition` and `@after_compile` and you can more about read them in [the docs for the `Module` module](/docs/stable/elixir/Module.html). You can also find useful documentation about macros in the [`Macro` module](/docs/stable/elixir/Macro.html) and about the compilation environment in [`Macro.Env`](/docs/stable/elixir/Macro.Env.html).
+Besides `@before_compile`, there are other useful module attributes like `@on_definition` and `@after_compile`, which you can read more about in [the docs for the `Module` module](/docs/stable/elixir/Module.html). You can also find useful information about macros and the compilation environment in the documentation for the [`Macro` module](/docs/stable/elixir/Macro.html) and [`Macro.Env`](/docs/stable/elixir/Macro.Env.html).


### PR DESCRIPTION
I just tried to make some of the paragraphs smoother and more idiomatic.

I'm not totally sure I understood line 97 (In the `__using__/1` implementation...), so if someone could check that more carefully, that'd probably be good.

Thanks!
