### PR TITLE
Added install instructions for OS X via Macports.

### DIFF
--- a/getting_started/1.markdown
+++ b/getting_started/1.markdown
@@ -36,6 +36,8 @@ Elixir is available on the following distributions:
   * Homebrew for Mac OS X
     * Update your homebrew to latest with `brew update`
     * Install Elixir: `brew install elixir`
+  * Macports for Mac OS X
+    * `sudo port install elixir`
   * Fedora 17+ and Fedora Rawhide
     * `sudo yum -y install elixir`
   * Arch Linux (on AUR)


### PR DESCRIPTION
Added install instructions for OS X via [Macports](https://www.macports.org/). The Portfile is available [here](https://svn.macports.org/repository/macports/trunk/dports/lang/elixir/Portfile).
