### PR TITLE
Changed from Integer.odd? to Integer.is_odd in "Generators and filters" ...

### DIFF
--- a/getting_started/18.markdown
+++ b/getting_started/18.markdown
@@ -40,7 +40,7 @@ Alternatively, filters can be used to filter some particular elements out. For e
 
 ```iex
 iex> require Integer
-iex> for n <- 1..4, Integer.odd?(n), do: n * n
+iex> for n <- 1..4, Integer.is_odd(n), do: n * n
 [1, 9]
 ```
 


### PR DESCRIPTION
Hi again 
Corrected another usage of odd?/1 macro in the getting started guide.
