### PR TITLE
Remove `:crypto` application start from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,6 @@ iex> h IEx.pry             # Prints the documentation for IEx pry functionality
       <p>Elixir runs on the Erlang VM giving developers complete access to Erlang's ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="http://www.whatsapp.com">Whatsapp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
 
 {% highlight iex %}
-iex> :application.start(:crypto)
 iex> :crypto.md5("Using crypto from Erlang OTP")
 <<192,223,75,115,...>>
 {% endhighlight %}


### PR DESCRIPTION
Since [[1](https://github.com/elixir-lang/elixir/issues/2593),[2](https://github.com/elixir-lang/elixir/commit/9ba77e1ce6d1ea346d01531385e22541933b4e58)], the `:crypto` application is included as a startup
dependency of Elixir.
