### PR TITLE
extract code support widget into partial

### DIFF
--- a/_includes/code-editor-support.html
+++ b/_includes/code-editor-support.html
@@ -1,0 +1,10 @@
+<div class="widget">
+  <h3 class="widget-title">Code editor support</h3>
+  <ul>
+    <li><a class="spec" href="https://github.com/elixir-lang/emacs-elixir">Emacs Mode</a></li>
+    <li><a class="spec" href="https://github.com/elixir-lang/elixir-tmbundle">Textmate Bundle</a></li>
+    <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir">Vim Elixir</a></li>
+    <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>
+    <li><a class="spec" href="https://github.com/lucasmazza/language-elixir">Atom Package</a></li>
+  </ul>
+</div>

--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -19,15 +19,6 @@
 
 {% include learning-resources.html %}
 
-<div class="widget">
-  <h3 class="widget-title">Code editor support</h3>
-  <ul>
-    <li><a class="spec" href="https://github.com/elixir-lang/emacs-elixir">Emacs Mode</a></li>
-    <li><a class="spec" href="https://github.com/elixir-lang/elixir-tmbundle">Textmate Bundle</a></li>
-    <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir">Vim Elixir</a></li>
-    <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>
-    <li><a class="spec" href="https://github.com/lucasmazza/language-elixir">Atom Package</a></li>
-  </ul>
-</div>
+{% include code-editor-support.html %}
 
 {% include sponsors.html %}

--- a/_layouts/getting_started.html
+++ b/_layouts/getting_started.html
@@ -57,6 +57,7 @@ section: getting_started
   </div>
 
   {% include learning-resources.html %}
+  {% include code-editor-support.html %}
   {% include sponsors.html %}
 </div>
 


### PR DESCRIPTION
Hi,

I would like to add the information about elixir-mix.el package for emacs to the code support area.
- add elixir-mix.el code support link
- extract code editor support widget into partial

cheers
