### PR TITLE
Update 17.markdown - Errors are structs.

### DIFF
--- a/getting_started/17.markdown
+++ b/getting_started/17.markdown
@@ -54,7 +54,7 @@ iex> try do
 ...> rescue
 ...>   e in RuntimeError -> e
 ...> end
-RuntimeError[message: "oops"]
+%RuntimeError{message: "oops"}
 ```
 
 The example above rescues the runtime error and returns the error itself which is then printed in the `iex` session. In practice Elixir developers rarely use the `try/rescue` construct though. For example, many languages would force you to rescue an error when a file cannot open successfully. Elixir instead provides a `File.read/1` function which returns a tuple containing information if the file was opened with success or not:


### PR DESCRIPTION
Changed the documentation in getting_started/17 to reflect that Exceptions are structs.  I'm still learning the language, so if I'm wrong on this bear with me :smile: 

**Old Example:**

``` iex
iex> try do
...>   raise "oops"
...> rescue
...>   e in RuntimeError -> e
...> end
RuntimeError[message: "oops"]
```

**Local Result:**

``` iex
iex> try do
...>   raise "oops"
...> rescue
...>   e in RuntimeError -> e
...> end
%RuntimeError{message: "oops"}
```
