### PR TITLE
Fixes #370 missing logger app in KV Server

### DIFF
--- a/getting_started/mix_otp/7.markdown
+++ b/getting_started/mix_otp/7.markdown
@@ -155,7 +155,7 @@ defmodule KVServer.Mixfile do
   end
 
   def application do
-    [applications: [],
+    [applications: [:logger],
      mod: {KVServer, []}]
   end
 
@@ -178,7 +178,7 @@ The second change is in the `application` function inside `mix.exs`:
 
 ```elixir
 def application do
-  [applications: [],
+  [applications: [:logger],
    mod: {KVServer, []}]
 end
 ```
@@ -228,7 +228,7 @@ The line above makes `:kv` available as a dependency inside `:kv_server`. We can
 
 ```elixir
 def application do
-  [applications: [:kv],
+  [applications: [:logger, :kv],
    mod: {KVServer, []}]
 end
 ```

--- a/getting_started/mix_otp/9.markdown
+++ b/getting_started/mix_otp/9.markdown
@@ -259,7 +259,7 @@ Open up your `apps/kv_server/mix.exs` file and change both `application/0` and `
 
 ```elixir
 def application do
-  [applications: [:pipe, :kv],
+  [applications: [:logger, :pipe, :kv],
    mod: {KVServer, []}]
 end
 


### PR DESCRIPTION
This pull request fixes #370.

The end of chapter 9 suggests suppressing the logger during the KV
Server restart in the test setup, but :logger was not included as
an OTP application dependency in the mix.exs file, resulting in an
error.

This commit adds the :logger dependency back to the kv_server
applications.
