### PR TITLE
Create an element id for  #stable, in addition to the version number.

### DIFF
--- a/docs.markdown
+++ b/docs.markdown
@@ -8,6 +8,7 @@ layout: default
 
 Choose which version you want documentation for.
 
+<span id="stable"></stable>
 #### v1.0
 
 * [Elixir](/docs/stable/elixir) - standard library


### PR DESCRIPTION
This way we can link to docs.html#stable
in addition to docs.html#v1.0
without having to worry about the version number going up.
