### PR TITLE
Fix warnings generated by layout:nil, and pygments:

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: redcarpet
-pygments: true
+highlighter: true
 permalink: /blog/:year/:month/:day/:title
 redcarpet:
   extensions: ['with_toc_data']

--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 elixir_url: http://elixir-lang.org
 ---
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
This will solve the following warnings thown by `jekyll build`

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.

...

Build Warning: Layout 'nil' requested in atom.xml does not exist.
```
