### PR TITLE
nodejs is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Development is done in the `next` branch, while `master` contains the docs and g
 
 3. Test it locally
 
-   You need to install `jekyll`, `jekyll-redirect-from` and `redcarpet`
+   You need to have ``nodejs`` installed,
+   as well as ruby gems: `jekyll`, `jekyll-redirect-from` and `redcarpet`
 
    ```shell
    $ gem install jekyll jekyll-redirect-from redcarpet


### PR DESCRIPTION
It is a requirement to have NodeJS installed to run jekyll.

http://jekyllrb.com/docs/installation/

> NodeJS, or another JavaScript runtime (for CoffeeScript support).

```
$ jekyll serve/usr/local/lib/ruby/gems/2.0.0/gems/execjs-2.2.2/lib/execjs/runtimes.rb:51:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
  from /usr/local/lib/ruby/gems/2.0.0/gems/execjs-2.2.2/lib/execjs.rb:5:in `<module:ExecJS>'
```

I don't know what is the best way to give a command to install nodejs, maybe just leave it like that
