### PR TITLE
Use HashDict.has_key? instead of HashDict.get

### DIFF
--- a/getting_started/mix_otp/3.markdown
+++ b/getting_started/mix_otp/3.markdown
@@ -85,7 +85,7 @@ defmodule KV.Registry do
   end
 
   def handle_cast({:create, name}, names) do
-    if HashDict.get(names, name) do
+    if HashDict.has_key?(names, name) do
       {:noreply, names}
     else
       {:ok, bucket} = KV.Bucket.start_link()
@@ -219,7 +219,7 @@ def handle_call(:stop, _from, state) do
 end
 
 def handle_cast({:create, name}, {names, refs}) do
-  if HashDict.get(names, name) do
+  if HashDict.has_key?(names, name) do
     {:noreply, {names, refs}}
   else
     {:ok, pid} = KV.Bucket.start_link()


### PR DESCRIPTION
Because readability and consistency and what happens when the value at the key is FALSE
