### PR TITLE
IO: Remove quotes surrounding stdout contents.

### DIFF
--- a/getting_started/12.markdown
+++ b/getting_started/12.markdown
@@ -18,7 +18,7 @@ The `IO` module in Elixir is the main mechanism for reading and writing to the s
 
 ```iex
 iex> IO.puts "hello world"
-"hello world"
+hello world
 :ok
 iex> IO.gets "yes or no? "
 yes or no? yes
@@ -29,7 +29,7 @@ By default, the functions in the IO module use the standard input and output. We
 
 ```iex
 iex> IO.puts :stderr, "hello world"
-"hello world"
+hello world
 :ok
 ```
 


### PR DESCRIPTION
In some IO.puts examples, output was incorrectly quoted.
