### PR TITLE
Fix: The ets table here needs `named_table` option

### DIFF
--- a/getting_started/mix_otp/6.markdown
+++ b/getting_started/mix_otp/6.markdown
@@ -408,7 +408,7 @@ Finally, we just need to change the `setup` callback in `test/kv/registry_test.e
 
 ```elixir
 setup do
-  ets = :ets.new(:registry_table, [:set, :public])
+  ets = :ets.new(:registry_table, [:set, :public, :named_table])
   registry = start_registry(ets)
   {:ok, registry: registry, ets: ets}
 end


### PR DESCRIPTION
Without the `named_table` option the tests fail.

Should I also add a `read_concurrency: true` to keep it the same as in the supervisor?
