### PR TITLE
Fix html

### DIFF
--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -4,7 +4,7 @@
       </div>
 
       <div id="copyright">
-        © 2012-2014 <a href="http://plataformatec.com.br/">Plataformatec</a>. All rights reserved.
+        &copy; 2012-2014 <a href="http://plataformatec.com.br/">Plataformatec</a>. All rights reserved.
       </div>
     </div><!-- .wrap -->
   </div><!-- #container -->

--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -5,7 +5,7 @@
 
       <div id="copyright">
         © 2012-2014 <a href="http://plataformatec.com.br/">Plataformatec</a>. All rights reserved.
-      </p>
+      </div>
     </div><!-- .wrap -->
   </div><!-- #container -->
 

--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -1,7 +1,6 @@
       </div><!-- #main -->
 
-      <div class="clear">
-      </div>
+      <div class="clear"></div>
 
       <div id="copyright">
         &copy; 2012-2014 <a href="http://plataformatec.com.br/">Plataformatec</a>. All rights reserved.

--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -13,7 +13,7 @@
   <h3 class="widget-title">Important links</h3>
   <ul>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/wiki">Wiki with events, resources and talks organized by the community</a></li>
-    <li><a class="spec" href="http://elixir-lang.org/crash-course.html">Crash course for Erlang developers</a></li>
+    <li><a class="spec" href="/crash-course.html">Crash course for Erlang developers</a></li>
   </ul>
 </div>
 

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -1,6 +1,6 @@
-<div class="widget">
+<div id="sponsors" class="widget">
   <h3 class="widget-title">Sponsors</h3>
   <ul>
-    <li class="image"><a href="http://plataformatec.com.br" title="Plataformatec"><img class="no-border" src="/images/logo/plataformatec.png" /></a></li>
+    <li class="image"><a href="http://plataformatec.com.br" title="Plataformatec"><img src="/images/logo/plataformatec.png" alt="Plataformatec Logo" width="190" height="74" /></a></li>
   </ul>
 </div>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,1 @@
+<div class="toc"></div>

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <title>{% if page.title %}{{ page.title }} - {% endif %}Elixir</title>
   <link href="http://feeds.feedburner.com/ElixirLang" rel="alternate" title="Elixir's Blog" type="application/atom+xml" />
-  <link rel="stylesheet" type="text/css" href="/css/style.css">
-  <link rel="stylesheet" type="text/css" href="/css/syntax.css">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" id="font-bitter-css" href="http://fonts.googleapis.com/css?family=Bitter&amp;ver=1" type="text/css" media="screen">
+  <link rel="stylesheet" type="text/css" href="/css/style.css" />
+  <link rel="stylesheet" type="text/css" href="/css/syntax.css" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" id="font-bitter-css" href="http://fonts.googleapis.com/css?family=Bitter&amp;ver=1" type="text/css" media="screen" />
 </head>
 
 <body class="{{ page.section }}">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,7 +7,7 @@
 <div id="sidebar-primary" class="sidebar">
   {% include search.html %}
   <div class="rss-button">
-    <a href="http://feeds.feedburner.com/ElixirLang" target="_blank"><img src="/images/social/RSSButton.png" /></a>
+    <a href="http://feeds.feedburner.com/ElixirLang" target="_blank"><img src="/images/social/RSSButton.png" alt="RSS button" /></a>
   </div>
   {% include categories-list.html %}
   {% include important-links.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@ layout: blog
         {% if page.subtitle %}
         <h2>{{ page.subtitle }}</h2>
         {% endif %}
-        <div class="byline">{{ page.date | date: "%B %d, %Y" }}{% if page.author %} · by {{ page.author}}{% endif %} . in {% for category in page.categories %}<span class="category"><a href="/blog/categories.html#{{category}}">{{ category }}</a>{% endfor %}</div>
+        <div class="byline">{{ page.date | date: "%B %d, %Y" }}{% if page.author %} · by {{ page.author}}{% endif %} . in {% for category in page.categories %}<a href="/blog/categories.html#{{category}}" class="category">{{ category }}</a>{% endfor %}</div>
       </div>
 
       <div class="entry-content">

--- a/_posts/2012-05-25-elixir-v0-5-0-released.markdown
+++ b/_posts/2012-05-25-elixir-v0-5-0-released.markdown
@@ -7,9 +7,9 @@ excerpt: We have finally released Elixir v0.5.0! This marks the first release si
 
 ---
 
-We have finally released [Elixir](http://elixir-lang.org/) v0.5.0! This marks the first release since the language was rewritten. In this blog post, we will discuss what we achieved during this time and what are the next steps!
+We have finally released [Elixir](/) v0.5.0! This marks the first release since the language was rewritten. In this blog post, we will discuss what we achieved during this time and what are the next steps!
 
-If you don't care about any of these, you can go straight to our [Getting Started guide](http://elixir-lang.org/getting_started/1.html). If you do, keep on reading!
+If you don't care about any of these, you can go straight to our [Getting Started guide](/getting_started/1.html). If you do, keep on reading!
 
 ## Looking back
 
@@ -27,7 +27,7 @@ Around February of that year, feeling confident enough about the direction the l
 
 One of the goals we have set was to have a good website and documentation before the next official release. With the help of the Plataformatec team, we created a logo for Elixir and put this website live.
 
-At the same time, [we were working on pygments support](https://bitbucket.org/birkenfeld/pygments-main/pull-request/57/add-elixir-and-elixir-console-lexers), a [documentation generation tool](https://github.com/elixir-lang/ex_doc) and many others. Soon, Github was able to syntax highlight Elixir code and [our API documentation was online](http://elixir-lang.org).
+At the same time, [we were working on pygments support](https://bitbucket.org/birkenfeld/pygments-main/pull-request/57/add-elixir-and-elixir-console-lexers), a [documentation generation tool](https://github.com/elixir-lang/ex_doc) and many others. Soon, Github was able to syntax highlight Elixir code and [our API documentation was online](/).
 
 At the same time, people started to gather around #elixir-lang channel on irc.freenode.net and [play with Elixir](http://github.com/elixir-lang/mix), [start their](https://github.com/guedes/exdate) [own projects](https://github.com/yrashk/validatex) and [tutorials](https://github.com/alco/elixir/wiki/Erlang-Syntax:-A-Crash-Course).
 
@@ -45,4 +45,4 @@ In parallel, we will improve our [documentation generation tool](https://github.
 
 Finally, we will continue improving the Standard Library. Although Elixir's goal is to rely on Erlang the most as possible, we also want to provide a small Standard Library which makes better use of Elixir semantics. For the next weeks, we will focus on improving the IO and File manipulation modules. New data types may also appear, for example, ranges come to my mind.
 
-Check out our [home page](http://elixir-lang.org/) and the [getting started guide](http://elixir-lang.org/getting_started/1.html) for more information. Welcome aboard and grab a cup of Elixir, because you are certainly going to enjoy the ride!
+Check out our [home page](/) and the [getting started guide](/getting_started/1.html) for more information. Welcome aboard and grab a cup of Elixir, because you are certainly going to enjoy the ride!

--- a/_posts/2012-08-01-elixir-v0-6-0-released.markdown
+++ b/_posts/2012-08-01-elixir-v0-6-0-released.markdown
@@ -21,7 +21,8 @@ We have not only achieved those goals for this release, as we have added much mo
 
 Our interactive shell (IEx) also had many improvements, thanks to the Elixir developer community. We now have easy access to documentation, remote shells, autocomplete and much more. In order to show you a bit of what you can do in this release, we have prepared a short (~6 min) screencast:
 
-<iframe src="http://player.vimeo.com/video/46709928" width="600" height="337" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe> <p><a href="http://vimeo.com/46709928">Elixir v0.6 quick tour - Mix and IEx</a> from <a href="http://vimeo.com/user3182384">Plataformatec</a> on <a href="http://vimeo.com">Vimeo</a>.</p>
+<iframe src="http://player.vimeo.com/video/46709928" class="video" width="600" height="337" allowfullscreen></iframe>
+<a href="http://vimeo.com/46709928">Elixir v0.6 quick tour - Mix and IEx</a> from <a href="http://vimeo.com/user3182384">Plataformatec</a> on <a href="http://vimeo.com">Vimeo</a>.
 
 That's it. Of course the documentation was also improved in the process, including two brand new getting started chapters on [Mix](/getting_started/mix/1.html) and [ExUnit](/getting_started/ex_unit/1.html). For the next months, we will continue improving Elixir (you can see some ideas floating around in the [issues tracker](github.com/elixir-lang/elixir/issues)) but we will start to focus on other tools and libraries for the community.
 

--- a/_posts/2012-08-01-elixir-v0-6-0-released.markdown
+++ b/_posts/2012-08-01-elixir-v0-6-0-released.markdown
@@ -7,17 +7,17 @@ excerpt: We have finally released Elixir v0.6.0! This release includes a build t
 
 ---
 
-We have finally released [Elixir](http://elixir-lang.org/) v0.6.0! This release includes a build tool called Mix, support for Erlang typespecs, many improvements to IEx and improved IO, File and Macro support.
+We have finally released [Elixir](/) v0.6.0! This release includes a build tool called Mix, support for Erlang typespecs, many improvements to IEx and improved IO, File and Macro support.
 
 ## What's new
 
-When [we released version v0.5.0](http://elixir-lang.org/blog/2012/05/25/elixir-v0-5-0-released/), we have set three major goals for release v0.6.0:
+When [we released version v0.5.0](/blog/2012/05/25/elixir-v0-5-0-released/), we have set three major goals for release v0.6.0:
 
 1. Provide a build tool that makes it easy to create, compile and test Elixir projects;
 2. Support [Erlang typespecs](http://www.erlang.org/doc/reference_manual/typespec.html);
 3. Improve IO and File modules to be more robust and complete.
 
-We have not only achieved those goals for this release, as we have added much more! A couple weeks ago, we have covered some of these unscheduled improvements, as improved Macro handling and Range support, which you can read more about in the ["What's new in Elixir #5" post](http://elixir-lang.org/blog/2012/07/05/what-s-new-in-elixir-5/).
+We have not only achieved those goals for this release, as we have added much more! A couple weeks ago, we have covered some of these unscheduled improvements, as improved Macro handling and Range support, which you can read more about in the ["What's new in Elixir #5" post](/blog/2012/07/05/what-s-new-in-elixir-5/).
 
 Our interactive shell (IEx) also had many improvements, thanks to the Elixir developer community. We now have easy access to documentation, remote shells, autocomplete and much more. In order to show you a bit of what you can do in this release, we have prepared a short (~6 min) screencast:
 

--- a/_posts/2013-01-27-elixir-v0-8-0-released.markdown
+++ b/_posts/2013-01-27-elixir-v0-8-0-released.markdown
@@ -30,7 +30,7 @@ String.capitalize("ﬁN") #=> "Fin"
 
 The example above contains a string with only two codepoints, [the codepoint ﬁ](http://www.fileformat.info/info/unicode/char/FB01/index.htm) and [the codepoint n](http://www.fileformat.info/info/unicode/char/006E/index.htm). Look how Elixir properly capitalizes the string, returning a new string made of three codepoints (all ascii letters).
 
-Learn more about [Unicode support with the String module](http://elixir-lang.org/docs/master/String.html).
+Learn more about [Unicode support with the String module](/docs/master/String.html).
 
 ## AST metadata
 
@@ -70,11 +70,11 @@ When some code call the `unless` macro above, in previous Elixir versions, it wo
 
 Elixir v0.8 ensures that the `unless` macro above will expand to the same `if` macro available when quoted, guaranteeing different libraries can integrate easily without imposing hidden requirements.
 
-You can read more about [macros in the getting started guide](http://elixir-lang.org/getting_started/5.html) or [go deep into the quote macro docs](http://elixir-lang.org/docs/master/Kernel.SpecialForms.html#quote/2).
+You can read more about [macros in the getting started guide](/getting_started/5.html) or [go deep into the quote macro docs](/docs/master/Kernel.SpecialForms.html#quote/2).
 
 ## A new way to manipulate pathnames
 
-Elixir v0.8 contains a bit of house cleaning too. We have created [the Path module](http://elixir-lang.org/docs/master/Path.html) to accommodate functions used to manipulate filesystem paths and have also added functions like [`System.tmp_dir` and `System.user_home`](http://elixir-lang.org/docs/master/System.html) which are meant to work accross different operating systems and are very handy when scripting.
+Elixir v0.8 contains a bit of house cleaning too. We have created [the Path module](/docs/master/Path.html) to accommodate functions used to manipulate filesystem paths and have also added functions like [`System.tmp_dir` and `System.user_home`](/docs/master/System.html) which are meant to work accross different operating systems and are very handy when scripting.
 
 ## The new HashDict
 

--- a/_posts/2013-04-29-elixir-v0-8-2-released.markdown
+++ b/_posts/2013-04-29-elixir-v0-8-2-released.markdown
@@ -44,6 +44,6 @@ defmodule MathTest do
 end
 ```
 
-You can learn more about [doctests on our documentation page](http://elixir-lang.org/docs/stable/ex_unit/ExUnit.DocTest.html) and get more information about our latest release [on the CHANGELOG](https://github.com/elixir-lang/elixir/blob/ed27611f48ba150404c95fe15f1d6058a4287330/CHANGELOG.md).
+You can learn more about [doctests on our documentation page](/docs/stable/ex_unit/ExUnit.DocTest.html) and get more information about our latest release [on the CHANGELOG](https://github.com/elixir-lang/elixir/blob/ed27611f48ba150404c95fe15f1d6058a4287330/CHANGELOG.md).
 
 If you are new to Elixir, [it's easy to get started with](/getting_started/1.html)!

--- a/_posts/2013-05-23-elixir-v0-9-0-released.markdown
+++ b/_posts/2013-05-23-elixir-v0-9-0-released.markdown
@@ -121,11 +121,11 @@ A special thanks to [Eric Meadows-Jonsson](https://github.com/ericmj) for implem
 We have also many other smaller improvements:
 
 * Our CLI now supports `--hidden` and `--cookie` flags which are useful for distributed modes;
-* Our test framework, ExUnit, is now able to capture all the communication that happens with a registed IO device, like `:stdio` and `:stderr`, via [`ExUnit.CaptureIO`](http://elixir-lang.org/docs/master/ExUnit.CaptureIO.html). This is very useful for testing how your software reacts to some inputs and what it prints to the terminal;
+* Our test framework, ExUnit, is now able to capture all the communication that happens with a registed IO device, like `:stdio` and `:stderr`, via [`ExUnit.CaptureIO`](/docs/master/ExUnit.CaptureIO.html). This is very useful for testing how your software reacts to some inputs and what it prints to the terminal;
 * `IEx` now allows files to be imported into the shell with `import_file` and also loads `~/.iex` on startup for custom configuration;
 * The `String`, `Enum` and `Dict` modules got more convenience functions that goes from checking unicode character validity to taking values out of a dictionary;
 * And many, many more!
 
 A huge thank you to our community for sending bug reports, providing bug fixes and contributing all those amazing features. And when are **you** joining us? :)
 
-Give Elixir a try! You can start with our [getting started guide](http://elixir-lang.org/getting_started/1.html), or [check this 30 minute video from PragProg](http://www.youtube.com/watch?v=a-off4Vznjs&feature=youtu.be) or buy the beta version of [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir).
+Give Elixir a try! You can start with our [getting started guide](/getting_started/1.html), or [check this 30 minute video from PragProg](http://www.youtube.com/watch?v=a-off4Vznjs&feature=youtu.be) or buy the beta version of [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir).

--- a/_posts/2013-07-13-elixir-v0-10-0-released.markdown
+++ b/_posts/2013-07-13-elixir-v0-10-0-released.markdown
@@ -54,11 +54,11 @@ Stream.repeatedly(fn -> :random.uniform end) |> Enum.take(3)
 #=> [0.4435846174457203, 0.7230402056221108, 0.94581636451987]
 ```
 
-`Stream.repeatedly/1` returns an infinite stream but that's ok we just need its first three elements. You can learn more about [stream and related functions in `Stream` module documentation](http://elixir-lang.org/docs/stable/elixir/Stream.html).
+`Stream.repeatedly/1` returns an infinite stream but that's ok we just need its first three elements. You can learn more about [stream and related functions in `Stream` module documentation](/docs/stable/elixir/Stream.html).
 
 ## Sets
 
-This release also adds [the Sets API](http://elixir-lang.org/docs/stable/elixir/Set.html) to Elixir and a HashSet implementation. The HashSet implementation follows [the same design goals as the HashDict implementation](http://elixir-lang.org/blog/2013/01/27/elixir-v0-8-0-released/) released at the beginning of this year, starting with a compact representation and expanding and contracting as needed.
+This release also adds [the Sets API](/docs/stable/elixir/Set.html) to Elixir and a HashSet implementation. The HashSet implementation follows [the same design goals as the HashDict implementation](/blog/2013/01/27/elixir-v0-8-0-released/) released at the beginning of this year, starting with a compact representation and expanding and contracting as needed.
 
 This feature was a contribution from [Joseph Wilk](https://github.com/josephwilk) and he talks about its implementation and provides some benchmarks [on his blog](http://blog.josephwilk.net/elixir/sets-in-elixir.html).
 
@@ -66,7 +66,7 @@ This feature was a contribution from [Joseph Wilk](https://github.com/josephwilk
 
 Another addition to this release is pretty printing. The pretty printing started as an implementation of the [Wadler paper](http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf) by [Jonns Mostovoys](https://github.com/manpages) which was then improved by [Gustavo Brunoro](https://github.com/brunoro) under his Google Summer of Code project as described in [Lindig's _Strictly Prettier_ paper](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.34.2200).
 
-As soon as you upgrade to Elixir v0.10.0 and start IEx, you will get pretty printing for all data structures provided by Elixir. We have also added documentation to the `Inspect` module about [adding pretty printing to your own structures](http://elixir-lang.org/docs/stable/elixir/Inspect.html) as well as [using the document algebra for any other kind of formatting](http://elixir-lang.org/docs/stable/elixir/Inspect.Algebra.html).
+As soon as you upgrade to Elixir v0.10.0 and start IEx, you will get pretty printing for all data structures provided by Elixir. We have also added documentation to the `Inspect` module about [adding pretty printing to your own structures](/docs/stable/elixir/Inspect.html) as well as [using the document algebra for any other kind of formatting](/docs/stable/elixir/Inspect.Algebra.html).
 
 ## Other improvements
 
@@ -78,8 +78,8 @@ Other notable improvements are:
 
 * We are also working hard on Windows support, improving its command-line tools and working towards a green test suite, thanks to [Tom Jansens](https://github.com/tojans);
 
-* Meta-programming in Elixir was also improved by the addition of the `binding/0` and `binding/1` macros plus the additions of `Macro.expand_once/2` and `Macro.expand_all/2` to the [`Macro` module](http://elixir-lang.org/docs/stable/elixir/Macro.html);
+* Meta-programming in Elixir was also improved by the addition of the `binding/0` and `binding/1` macros plus the additions of `Macro.expand_once/2` and `Macro.expand_all/2` to the [`Macro` module](/docs/stable/elixir/Macro.html);
 
 There are also improvements to typespecs, error messages, many bug fixes and some backwards incompatible changes. We have posted a detailed [upgrade instructions on the mailing list](https://groups.google.com/forum/?fromgroups#!topic/elixir-lang-talk/ksrefrgK1eY). For a general overview, [check out the CHANGELOG](https://github.com/elixir-lang/elixir/blob/v0.10.0/CHANGELOG.md).
 
-Give Elixir a try! You can start with our [getting started guide](http://elixir-lang.org/getting_started/1.html), or check out our sidebar for other learning resources.
+Give Elixir a try! You can start with our [getting started guide](/getting_started/1.html), or check out our sidebar for other learning resources.

--- a/_posts/2013-08-08-elixir-design-goals.markdown
+++ b/_posts/2013-08-08-elixir-design-goals.markdown
@@ -202,9 +202,9 @@ Enum.map set, fn(x) -> x * 2 end
 #=> [2,4,6]
 ```
 
-Not only that, any developer can **extend** the `Enum` module to work with any data type as long as the data type implements [the `Enumerable` protocol](http://elixir-lang.org/docs/stable/elixir/Enumerable.html) (protocols in Elixir are based on Clojure's protocol). This is extremely convenient because the developer needs to know only the `Enum` API for enumeration, instead of memorizing specific APIs for sets, lists, dicts, etc.
+Not only that, any developer can **extend** the `Enum` module to work with any data type as long as the data type implements [the `Enumerable` protocol](/docs/stable/elixir/Enumerable.html) (protocols in Elixir are based on Clojure's protocol). This is extremely convenient because the developer needs to know only the `Enum` API for enumeration, instead of memorizing specific APIs for sets, lists, dicts, etc.
 
-There are many other protocols exposed by the language, like [the `Inspect` protocol](http://elixir-lang.org/docs/stable/elixir/Inspect.html) for pretty printing data structures and [the `Access` protocol](http://elixir-lang.org/docs/stable/elixir/Access.html) for accessing key-value data by key. By being extensible, Elixir ensures developers can work **with** the language, instead of **against** the language.
+There are many other protocols exposed by the language, like [the `Inspect` protocol](/docs/stable/elixir/Inspect.html) for pretty printing data structures and [the `Access` protocol](/docs/stable/elixir/Access.html) for accessing key-value data by key. By being extensible, Elixir ensures developers can work **with** the language, instead of **against** the language.
 
 ## Summing up
 
@@ -212,4 +212,4 @@ The goal of this post was to sumarize the language goals: compatibility, product
 
 We also hope to have clarified what Elixir brings to the Erlang VM, in particular, meta-programming through macros, polymorphic constructs for extensibility and a data-focused standard library with extensible and consistent APIs for diverse types, including strict and lazy enumeration, unicode handling, a test framework and more.
 
-Give Elixir a try! You can start with our [getting started guide](http://elixir-lang.org/getting_started/1.html), or check out our sidebar for other learning resources.
+Give Elixir a try! You can start with our [getting started guide](/getting_started/1.html), or check out our sidebar for other learning resources.

--- a/_posts/2013-11-05-elixir-v0-11-0-released.markdown
+++ b/_posts/2013-11-05-elixir-v0-11-0-released.markdown
@@ -22,11 +22,11 @@ In this new release, IEx also supports a very simple debugging mechanism called 
 
 ![IEx pry example](/images/contents/iex-pry.png)
 
-In Elixir, your code runs in many processes that talk to each other and the Elixir shell is no different. `IEx.pry` allows another process to take over the shell, allowing the developer to inspect the binding and halt the execution of the process being "pried" (i.e. the one that invoked `IEx.pry`). We called this feature `pry` as a gentle reminder that you can only inspect existing information, you cannot change the binding over a pried process. For more information, check the docs for [`IEx.pry/1`](http://elixir-lang.org/docs/stable/iex/IEx.html#pry/1).
+In Elixir, your code runs in many processes that talk to each other and the Elixir shell is no different. `IEx.pry` allows another process to take over the shell, allowing the developer to inspect the binding and halt the execution of the process being "pried" (i.e. the one that invoked `IEx.pry`). We called this feature `pry` as a gentle reminder that you can only inspect existing information, you cannot change the binding over a pried process. For more information, check the docs for [`IEx.pry/1`](/docs/stable/iex/IEx.html#pry/1).
 
 ## ExUnit
 
-[In the previous release](http://elixir-lang.org/blog/2013/07/13/elixir-v0-10-0-released/), we introduced great changes to ExUnit, like the support for the `--trace` option. This time we continued pushing improvements, like adding profiling to test cases (times can be seen with the `--trace` option), paving the way for other features like emitting warnings for test cases that are too slow.
+[In the previous release](/blog/2013/07/13/elixir-v0-10-0-released/), we introduced great changes to ExUnit, like the support for the `--trace` option. This time we continued pushing improvements, like adding profiling to test cases (times can be seen with the `--trace` option), paving the way for other features like emitting warnings for test cases that are too slow.
 
 Another simple but significant change in ExUnit was the change in the default formatter to print changes as they come, instead of waiting until the suite is done running:
 
@@ -36,7 +36,7 @@ This change allows developer to get faster feedback from their test suites.
 
 ## Mix
 
-Since the early days, Elixir took ahold of the compilation process in order to provide a seamless compilation experience. [Elixir's ParallelCompiler](http://elixir-lang.org/blog/2012/04/24/a-peek-inside-elixir-s-parallel-compiler/) was introduced even before the first official release, allowing developers to harness all the cores in their computer to compile Elixir code. However, once the first release came out, every time you changed any file, the whole project had to be recompiled.
+Since the early days, Elixir took ahold of the compilation process in order to provide a seamless compilation experience. [Elixir's ParallelCompiler](/blog/2012/04/24/a-peek-inside-elixir-s-parallel-compiler/) was introduced even before the first official release, allowing developers to harness all the cores in their computer to compile Elixir code. However, once the first release came out, every time you changed any file, the whole project had to be recompiled.
 
 In the past releases we have improved this process to only compile files that changed and their dependencies. For v0.11.0, we have improved this process to be faster and less conservative than the previous version.
 
@@ -59,14 +59,14 @@ fun.(1..3)
 #=> true
 ```
 
-You can learn more about the [new capture operator in our docs](http://elixir-lang.org/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
+You can learn more about the [new capture operator in our docs](/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
 
-We have also pushed improvements to [the String module](http://elixir-lang.org/docs/stable/elixir/String.html), including new APIs. In particular, in order to know that `String.length("josé")` has length 4 (even though it takes 5 bytes to be represented in UTF-8), we need to use some algorithms defined by the Unicode Standard. These have been implemented as specified in the [extended grapheme cluster algorithm, defined in the version 6.3.0 of the Unicode Standard](http://www.unicode.org/reports/tr29/).
+We have also pushed improvements to [the String module](/docs/stable/elixir/String.html), including new APIs. In particular, in order to know that `String.length("josé")` has length 4 (even though it takes 5 bytes to be represented in UTF-8), we need to use some algorithms defined by the Unicode Standard. These have been implemented as specified in the [extended grapheme cluster algorithm, defined in the version 6.3.0 of the Unicode Standard](http://www.unicode.org/reports/tr29/).
 
 In the optimization front, we have pushed the first iteration of a [feature called Protocol consolidation](https://groups.google.com/forum/#!topic/elixir-lang-core/RoXAUtoyjk4), which speeds up the polymorphic dispatch done by protocols, sometimes reducing the dispatching time to 10% of the original time. We will continue working in upcoming releases to integrate protocol consolidation as a regular part of the developer workflow.
 
 And finally, a minor but frequently asked feature has finally arrived into Elixir: variables follow the same rules as other identifiers in the language, which means developers can now name their variables `is_atom?`. For a general overview, [check out the CHANGELOG](https://github.com/elixir-lang/elixir/blob/v0.11.0/CHANGELOG.md).
 
-Give Elixir a try! You can start with our [getting started guide](http://elixir-lang.org/getting_started/1.html), or check out our sidebar for other learning resources.
+Give Elixir a try! You can start with our [getting started guide](/getting_started/1.html), or check out our sidebar for other learning resources.
 
 **PS:** We have just released v0.11.1 which addresses a regression in Mix and improves the dependencies update process.

--- a/_posts/2013-12-15-elixir-v0-12-0-released.markdown
+++ b/_posts/2013-12-15-elixir-v0-12-0-released.markdown
@@ -49,4 +49,4 @@ Eric is also maintainer of both [Ecto](https://github.com/elixir-lang/ecto) and 
 
 There were other small changes, like additions to the `Float` module and improvements the to the typespec syntax. To see the full list, please [see the CHANGELOG](https://github.com/elixir-lang/elixir/blob/v0.12.0/CHANGELOG.md).
 
-Give Elixir a try! You can start with our [getting started guide](http://elixir-lang.org/getting_started/1.html), or check out our sidebar for other learning resources.
+Give Elixir a try! You can start with our [getting started guide](/getting_started/1.html), or check out our sidebar for other learning resources.

--- a/_posts/2014-04-21-elixir-v0-13-0-released.markdown
+++ b/_posts/2014-04-21-elixir-v0-13-0-released.markdown
@@ -28,7 +28,7 @@ In a nutshell, here is what new:
 
 * Elixir v0.13 also provides structs, an alternative to Elixir records. Structs are more flexible than records, provide faster polymorphic operations, and still provide the same compile-time guarantees many came to love in records;
 
-* The [Getting Started guide](http://elixir-lang.org/getting_started/1.html) was rewritten from scratch. The previous guide was comprised of 7 chapters and was about to become 2 years old. The new guide features 20 chapters, it explores the new maps and structs (which are part of this release), and it goes deeper into topics like IO and File handling. It also includes an extra guide, still in development, about [Meta-Programming in Elixir](http://elixir-lang.org/getting_started/meta/1.html);
+* The [Getting Started guide](/getting_started/1.html) was rewritten from scratch. The previous guide was comprised of 7 chapters and was about to become 2 years old. The new guide features 20 chapters, it explores the new maps and structs (which are part of this release), and it goes deeper into topics like IO and File handling. It also includes an extra guide, still in development, about [Meta-Programming in Elixir](/getting_started/meta/1.html);
 
 * Elixir v0.13 provides a new comprehension syntax that not only works with lists, but with any [`Enumerable`](/docs/stable/elixir/Enumerable.html). The output of a comprehension is also extensible via the [`Collectable`](/docs/stable/elixir/Collectable.html) protocol;
 

--- a/_posts/2014-08-07-elixir-v0-15-0-released.markdown
+++ b/_posts/2014-08-07-elixir-v0-15-0-released.markdown
@@ -16,7 +16,7 @@ If you are interested in the specific details for this release, [please check ou
 
 ## Logger
 
-Elixir now ships with a new application called logger. This application provides [the Logger module](http://elixir-lang.org/docs/master/logger/Logger.html), which is the main API developers will use for logging:
+Elixir now ships with a new application called logger. This application provides [the Logger module](/docs/master/logger/Logger.html), which is the main API developers will use for logging:
 
 ```elixir
 require Logger
@@ -70,7 +70,7 @@ Function: #Function<20.90072148/0 in :erl_eval.expr/5>
 As soon as we started working on Logger, we realized we could go further than simply translating Erlang messages and provide a fully featured logger library. At this moment, Logger also supports:
 
   * 4 log levels: debug, info, warn and error
-  * Custom formatting: you can specify a format string that tells exactly how messages should be logged. The default string is: "$time $metadata[$level] $message\n" but [many attributes are supported](http://elixir-lang.org/docs/master/logger/Logger.Formatter.html)
+  * Custom formatting: you can specify a format string that tells exactly how messages should be logged. The default string is: "$time $metadata[$level] $message\n" but [many attributes are supported](/docs/master/logger/Logger.Formatter.html)
   * Custom translators: so you can translate log messages coming from any Erlang application into Elixir syntax
   * Metadata: metadata allows developers to store information in the current process that will be available to all logged messages. For example, a web application can generate a `request_id`, store it as metadata, and all messages logged during that request will be properly identified with `request_id=...` in the log
 
@@ -136,7 +136,7 @@ In other words, aliases can be three different structures:
   2. An anonymous function (that is invoked passing the task arguments)
   3. A list containing strings or anonymous functions
 
-You can find more information about aliases by reading the [Mix documentation](http://elixir-lang.org/docs/master/mix/) (there is a section about Aliases around the middle).
+You can find more information about aliases by reading the [Mix documentation](/docs/master/mix/) (there is a section about Aliases around the middle).
 
 We also would like to thank [Anthony Grimes](https://github.com/raynes) for the support and [Phil Halgelberg](https://github.com/technomancy) for [the work on Lein](https://github.com/technomancy/leiningen) which Mix borrows a lot from.
 

--- a/blog/categories.html
+++ b/blog/categories.html
@@ -8,7 +8,8 @@ layout: blog
   <h2>Posts by category:</h2>
   <ul>
   {% for category in site.categories %}
-    <h5 id="#{{ category | first }}">&raquo; {{ category | first | capitalize }}</h5>
+    <li>
+      <h5 id="#{{ category | first }}">&raquo; {{ category | first | capitalize }}</h5>
       <ul>
       {% for posts in category %}
         {% for post in posts %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -9,7 +9,7 @@ layout: blog
     <div class="hentry post">
       <div class="sticky-header">
         <h2 class="entry-title"><a class="spec" href="{{ post.url }}" title="{{ post.title }}" rel="bookmark">{{ post.title }}</a></h2>
-        <div class="byline">{{ post.date | date: "%B %d, %Y" }}{% if post.author %} · by {{ post.author}}{% endif %} . in {% for category in post.categories %}<span class="category"><a href="/blog/categories.html#{{category}}">{{ category }}</a>{% endfor %}</div>
+        <div class="byline">{{ post.date | date: "%B %d, %Y" }}{% if post.author %} · by {{ post.author}}{% endif %} . in {% for category in post.categories %}<a href="/blog/categories.html#{{category}}" class="category">{{ category }}</a>{% endfor %}</div>
       </div><!-- .sticky-header -->
 
       <div class="entry-summary">

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -857,7 +857,7 @@ This should be enough to invoke Elixir functions straight from your Erlang code.
 
 ### Manual integration
 
-If you are not using rebar, the easiest approach to use Elixir in your existing Erlang software is to install Elixir using one of the different ways specified in the [Getting Started guide](http://elixir-lang.org/getting_started/1.html) and add the `lib` directory in your checkout to `ERL_LIBS`.
+If you are not using rebar, the easiest approach to use Elixir in your existing Erlang software is to install Elixir using one of the different ways specified in the [Getting Started guide](/getting_started/1.html) and add the `lib` directory in your checkout to `ERL_LIBS`.
 
 <div id="further_reading"></div>
 
@@ -869,5 +869,5 @@ Elixir also provides a [Getting Started Guide][6] and has [documentation availab
 
 [4]: http://www.erlang.org/doc/programming_examples/users_guide.html
 [5]: http://schemecookbook.org/Erlang/TOC
-[6]: http://elixir-lang.org/getting_started/1.html
-[7]: http://elixir-lang.org/docs.html
+[6]: /getting_started/1.html
+[7]: /docs.html

--- a/css/style.css
+++ b/css/style.css
@@ -274,6 +274,7 @@ img.alignleft, img.alignright {
 blockquote.alignleft, blockquote .alignright { width: 33%; }
 .byline abbr, .entry-meta abbr, .comment-meta abbr { border: none; }
 .clear { clear: both; }
+.no-border { border: 0 };
 
 /* Tables
 -------------------------------------------------------------- */
@@ -404,7 +405,6 @@ a:hover img, #slider-nav li a:hover img { opacity: 0.85; }
   border: 1px solid #e5e5e5;
 }
 .rss-button { margin-bottom: 25px; }
-img.no-border { border: 0 };
 
 /* Layout
 -------------------------------------------------------------- */
@@ -569,7 +569,6 @@ body.source           div.menu li.source          a {
   height: 150px;
   margin: 3px 25px 20px 0;
 }
-.no-border { border: 0 };
 
 /* Post titles
 -------------------------------------------------------------- */
@@ -704,6 +703,7 @@ li.image {
   list-style: none;
   margin-bottom: 10px;
 }
+#sponsors li.image img { border:0; }
 
 /* Widget titles
 -------------------------------------------------------------- */

--- a/css/style.css
+++ b/css/style.css
@@ -396,7 +396,7 @@ input[type="submit"]:hover { cursor: pointer }
 -------------------------------------------------------------- */
 a:hover img, #slider-nav li a:hover img { opacity: 0.85; }
 #site-title a:hover img { border: none; opacity: 1; }
-.hentry img, .entry-content img, .widget img, .hentry embed, .entry-content embed, .widget embed, .hentry object, .entry-content object, .widget object, .hentry video, .entry-content video, .widget video {
+.hentry img, .entry-content img, .widget img, .hentry embed, .entry-content embed, .widget embed, .hentry object, .entry-content object, .widget object, .hentry video, .entry-content video, .widget video, iframe.video {
   max-width: 100%;
 }
 .hentry img, .entry-content img, .widget img {
@@ -405,7 +405,7 @@ a:hover img, #slider-nav li a:hover img { opacity: 0.85; }
   border: 1px solid #e5e5e5;
 }
 .rss-button { margin-bottom: 25px; }
-
+iframe.video { border:0; }
 /* Layout
 -------------------------------------------------------------- */
 #main {

--- a/docs.markdown
+++ b/docs.markdown
@@ -8,7 +8,7 @@ layout: default
 
 Choose which version you want documentation for.
 
-<span id="stable"></stable>
+<span id="stable"></span>
 #### v1.0
 
 * [Elixir](/docs/stable/elixir) - standard library

--- a/getting_started/1.markdown
+++ b/getting_started/1.markdown
@@ -6,7 +6,7 @@ guide: 1
 
 # {{ page.title }}
 
-<div class="toc"></div>
+{% include toc.html %}
 
 Welcome!
 

--- a/getting_started/1.markdown
+++ b/getting_started/1.markdown
@@ -6,7 +6,7 @@ guide: 1
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+<div class="toc"></div>
 
 Welcome!
 

--- a/getting_started/10.markdown
+++ b/getting_started/10.markdown
@@ -6,7 +6,7 @@ guide: 10
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
   <p></p>
 
 ## 10.1 Enumerables

--- a/getting_started/10.markdown
+++ b/getting_started/10.markdown
@@ -7,7 +7,6 @@ guide: 10
 # {{ page.title }}
 
 {% include toc.html %}
-  <p></p>
 
 ## 10.1 Enumerables
 

--- a/getting_started/11.markdown
+++ b/getting_started/11.markdown
@@ -6,7 +6,7 @@ guide: 11
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In Elixir, all code runs inside processes. Processes are isolated from each other, run concurrent to one another and communicate via message passing. Processes are not only the basis for concurrency in Elixir, but they also provide the means for building distributed and fault-tolerant programs.
 

--- a/getting_started/12.markdown
+++ b/getting_started/12.markdown
@@ -6,7 +6,7 @@ guide: 12
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 This chapter is a quick introduction to input/output mechanisms in Elixir and related modules, like [`IO`](/docs/stable/elixir/IO.html), [`File`](/docs/stable/elixir/File.html) and [`Path`](/docs/stable/elixir/Path.html).
 

--- a/getting_started/13.markdown
+++ b/getting_started/13.markdown
@@ -6,7 +6,7 @@ guide: 13
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In order to facilitate software reuse, Elixir provides three directives. As we are going to see below, they are called directives because they have **lexical scope**.
 

--- a/getting_started/14.markdown
+++ b/getting_started/14.markdown
@@ -6,7 +6,7 @@ guide: 14
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Module attributes in Elixir serve three purposes:
 

--- a/getting_started/15.markdown
+++ b/getting_started/15.markdown
@@ -6,7 +6,7 @@ guide: 15
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In earlier chapters, we learned about maps:
 

--- a/getting_started/16.markdown
+++ b/getting_started/16.markdown
@@ -6,7 +6,7 @@ guide: 16
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Protocols are a mechanism to achieve polymorphism in Elixir. Dispatching on a protocol is available to any data type as long as it implements the protocol. Let's see an example.
 

--- a/getting_started/17.markdown
+++ b/getting_started/17.markdown
@@ -6,7 +6,7 @@ guide: 17
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Elixir has three error mechanisms: errors, throws and exits. In this chapter we will explore each of them and include remarks about when each should be used.
 

--- a/getting_started/18.markdown
+++ b/getting_started/18.markdown
@@ -6,7 +6,7 @@ guide: 18
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In Elixir, it is common to loop over Enumerables, often filtering some results, and mapping to another list of values. Comprehensions are syntax sugar for such constructs, grouping those common tasks into the `for` special form.
 

--- a/getting_started/19.markdown
+++ b/getting_started/19.markdown
@@ -6,7 +6,7 @@ guide: 19
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 We have already learned Elixir provides double-quoted strings and single-quoted char lists. However, this only covers the surface of structures that have textual representation in the language. Atoms are, for example, another structure which are mostly created via the `:atom` representation.
 

--- a/getting_started/2.markdown
+++ b/getting_started/2.markdown
@@ -6,7 +6,7 @@ guide: 2
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter we will learn more about Elixir basic types: integers, floats, booleans, atoms, strings, lists and tuples. Some basic types are:
 

--- a/getting_started/20.markdown
+++ b/getting_started/20.markdown
@@ -7,7 +7,7 @@ last: true
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Eager to learn more? Keep on reading!
 

--- a/getting_started/20.markdown
+++ b/getting_started/20.markdown
@@ -25,9 +25,9 @@ We have written a guide that covers how to build an Elixir application, with its
 
 On the sidebar, you can find the link to some Elixir books and screencasts. There are plenty of Elixir resources out there, like conference talks, open source projects, and other learning materials produced by the community.
 
-Remember that in case of any difficulties, you can always visit the **#elixir-lang** channel on **irc.freenode.net** or send a message to the [mailing list](http://groups.google.com/group/elixir-lang-talk). You can be sure that there will be someone willing to help. And to keep posted on the latest news and announcements, follow the [blog](http://elixir-lang.org/blog/) and follow language developments on the [elixir-core mailing list](http://groups.google.com/group/elixir-lang-core).
+Remember that in case of any difficulties, you can always visit the **#elixir-lang** channel on **irc.freenode.net** or send a message to the [mailing list](http://groups.google.com/group/elixir-lang-talk). You can be sure that there will be someone willing to help. And to keep posted on the latest news and announcements, follow the [blog](/blog/) and follow language developments on the [elixir-core mailing list](http://groups.google.com/group/elixir-lang-core).
 
-Don't forget [you can also check the source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](http://elixir-lang.org/docs.html).
+Don't forget [you can also check the source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](/docs.html).
 
 ## 20.3 A Byte of Erlang
 
@@ -37,7 +37,7 @@ As the main page of this site puts it:
 
 Sooner or later, an Elixir developer will want to interface with existing Erlang libraries. Here's a list of online resources that cover Erlang's fundamentals and its more advanced features:
 
-* This [Erlang Syntax: A Crash Course](http://elixir-lang.org/crash-course.html) provides a concise intro to Erlang's syntax. Each code snippet is accompanied by equivalent code in Elixir. This is an opportunity for you to not only get some exposure to Erlang's syntax but also review some of the things you have learned in this guide.
+* This [Erlang Syntax: A Crash Course](/crash-course.html) provides a concise intro to Erlang's syntax. Each code snippet is accompanied by equivalent code in Elixir. This is an opportunity for you to not only get some exposure to Erlang's syntax but also review some of the things you have learned in this guide.
 
 * Erlang's official website has a short [tutorial](http://www.erlang.org/course/concurrent_programming.html) with pictures that briefly describe Erlang's primitives for concurrent programming.
 

--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -6,7 +6,7 @@ guide: 3
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+<div class="toc"></div>
 
 In the previous chapter, we saw Elixir provides `+`, `-`, `*`, `/` as arithmetic operators, plus the functions `div/2` and `rem/2` for integer division and remainder.
 

--- a/getting_started/3.markdown
+++ b/getting_started/3.markdown
@@ -6,7 +6,7 @@ guide: 3
 
 # {{ page.title }}
 
-<div class="toc"></div>
+{% include toc.html %}
 
 In the previous chapter, we saw Elixir provides `+`, `-`, `*`, `/` as arithmetic operators, plus the functions `div/2` and `rem/2` for integer division and remainder.
 

--- a/getting_started/4.markdown
+++ b/getting_started/4.markdown
@@ -6,7 +6,7 @@ guide: 4
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will show how the `=` operator in Elixir is actually a match operator and how to use it to pattern match inside data structures. Finally, we will learn about the pin operator `^` used to access previously bound values.
 

--- a/getting_started/5.markdown
+++ b/getting_started/5.markdown
@@ -6,7 +6,7 @@ guide: 5
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will learn about the `case`, `cond` and `if` control-flow structures.
 

--- a/getting_started/6.markdown
+++ b/getting_started/6.markdown
@@ -6,7 +6,7 @@ guide: 6
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In "Basic types", we learned about strings and used the `is_binary/1` function for checks:
 

--- a/getting_started/7.markdown
+++ b/getting_started/7.markdown
@@ -6,7 +6,7 @@ guide: 7
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 So far we haven't discussed any associative data structures, i.e. data structures that are able to associate a certain value (or multiple values) to a key. Different languages call these different names like dictionaries, hashes, associative arrays, maps, etc.
 

--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -6,7 +6,7 @@ guide: 8
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In Elixir we group several functions into modules. We've already used many different modules in the previous chapters like [the `String` module](/docs/stable/elixir/String.html):
 

--- a/getting_started/9.markdown
+++ b/getting_started/9.markdown
@@ -6,7 +6,7 @@ guide: 9
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Due to immutability, loops in Elixir (and in functional programming languages) are written differently from conventional imperative languages. For example, in an imperative language, one would write:
 

--- a/getting_started/meta/1.markdown
+++ b/getting_started/meta/1.markdown
@@ -6,7 +6,7 @@ guide: 1
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 An Elixir program can be represented by its own data structures. In this chapter, we will learn what those structures look like and how to compose them. The concepts learned in this chapter are the building blocks for macros, which we are going to take a deeper look at in the next chapter.
 

--- a/getting_started/meta/2.markdown
+++ b/getting_started/meta/2.markdown
@@ -6,7 +6,7 @@ guide: 2
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Macros can be defined in Elixir using `defmacro/2`.
 

--- a/getting_started/meta/3.markdown
+++ b/getting_started/meta/3.markdown
@@ -7,7 +7,7 @@ last: true
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 [Domain Specific Languages](https://en.wikipedia.org/wiki/Domain-specific_language) allow developers to tailor their application to a particular domain. There are many language features that, when used in combination, can aid developers to write Domain Specific Languages. In this chapter we will focus on how macros and module attributes can be used together to create domain specific modules that are focused on solving one particular problem. As an example, we will write a very simple module to define and run tests.
 

--- a/getting_started/mix_otp/1.markdown
+++ b/getting_started/mix_otp/1.markdown
@@ -6,7 +6,7 @@ guide: 1
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this guide, we will learn how to build a complete Elixir application, with its own supervision tree, configuration, tests and more.
 

--- a/getting_started/mix_otp/1.markdown
+++ b/getting_started/mix_otp/1.markdown
@@ -225,7 +225,7 @@ Mix will default to the `:dev` environment, except for the `test` task that will
 
 ## 1.5 Exploring
 
-There is much more to Mix, and we will continue to explore it as we build our project. A [general overview is available on the Mix documentation](http://elixir-lang.org/docs/stable/mix).
+There is much more to Mix, and we will continue to explore it as we build our project. A [general overview is available on the Mix documentation](/docs/stable/mix).
 
 Keep in mind that you can always invoke the help task to list all available tasks:
 

--- a/getting_started/mix_otp/10.markdown
+++ b/getting_started/mix_otp/10.markdown
@@ -7,7 +7,7 @@ last: true
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this last chapter, we will go back to the `:kv` application and add a routing layer that allows us to distribute requests between nodes based on the bucket name.
 

--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -6,7 +6,7 @@ guide: 2
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way that allows reading and modification by different processes.
 

--- a/getting_started/mix_otp/3.markdown
+++ b/getting_started/mix_otp/3.markdown
@@ -6,7 +6,7 @@ guide: 3
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In the previous chapter we used agents to represent our buckets. In the first chapter, we specified we would like to name each bucket so we can do the following:
 

--- a/getting_started/mix_otp/4.markdown
+++ b/getting_started/mix_otp/4.markdown
@@ -6,7 +6,7 @@ guide: 4
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will explore GenEvent, another behaviour provided by Elixir and OTP that allows us to spawn an event manager that is able to publish events to many handlers.
 

--- a/getting_started/mix_otp/5.markdown
+++ b/getting_started/mix_otp/5.markdown
@@ -6,7 +6,7 @@ guide: 5
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 So far our application requires an event manager and a registry. It may potentially use dozens, if not hundreds, of buckets. While we may think our implementation so far is quite good, no software is bug free, and failures are definitely going to happen.
 

--- a/getting_started/mix_otp/6.markdown
+++ b/getting_started/mix_otp/6.markdown
@@ -6,7 +6,7 @@ guide: 6
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 Every time we need to look up a bucket, we need to send a message to the registry. In some applications, this means the registry may become a bottleneck!
 

--- a/getting_started/mix_otp/7.markdown
+++ b/getting_started/mix_otp/7.markdown
@@ -6,7 +6,7 @@ guide: 7
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will briefly discuss how to manage dependencies in Mix.
 

--- a/getting_started/mix_otp/7.markdown
+++ b/getting_started/mix_otp/7.markdown
@@ -46,7 +46,7 @@ def deps do
 end
 ```
 
-This dependency refers to the latest version of plug in the 0.5.x version series that has been pushed to Hex. This is indicated by the `~>` preceding the version number. For more information on specifying version requirements, see the [documentation for the Version module](http://elixir-lang.org/docs/stable/elixir/Version.html).
+This dependency refers to the latest version of plug in the 0.5.x version series that has been pushed to Hex. This is indicated by the `~>` preceding the version number. For more information on specifying version requirements, see the [documentation for the Version module](/docs/stable/elixir/Version.html).
 
 Typically, stable releases are pushed to Hex. If you want to depend on an external dependency still in development, Mix is able to manage git dependencies, too:
 
@@ -68,7 +68,7 @@ Mix provides many tasks for working with dependencies, which can be seen in `mix
     mix deps.unlock       # Unlock the given dependencies
     mix deps.update       # Update the given dependencies
 
-The most common tasks are `mix deps.get` and `mix deps.update`. Once fetched, dependecies are automatically compiled for you. You can read more about deps by typing `mix help deps`, and in the [documentation for the Mix.Tasks.Deps module](http://elixir-lang.org/docs/stable/mix/Mix.Tasks.Deps.html).
+The most common tasks are `mix deps.get` and `mix deps.update`. Once fetched, dependecies are automatically compiled for you. You can read more about deps by typing `mix help deps`, and in the [documentation for the Mix.Tasks.Deps module](/docs/stable/mix/Mix.Tasks.Deps.html).
 
 ## 7.2 Internal dependencies
 

--- a/getting_started/mix_otp/8.markdown
+++ b/getting_started/mix_otp/8.markdown
@@ -6,7 +6,7 @@ guide: 8
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we are going to learn how to use [Erlang's `:gen_tcp` module](http://erlang.org/doc/man/gen_tcp.html) to serve requests. In future chapters we will expand our server so it can actually serve the commands. This will also provide a great opportunity to explore Elixir's `Task` module.
 

--- a/getting_started/mix_otp/9.markdown
+++ b/getting_started/mix_otp/9.markdown
@@ -6,7 +6,7 @@ guide: 9
 
 # {{ page.title }}
 
-  <div class="toc"></div>
+{% include toc.html %}
 
 In this chapter, we will implement the code that parses the commands we described in the first chapter:
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ serve_drinks User.get("John Doe")
     <div class="entry-summary">
       <p>Elixir has been designed to be extensible, letting developers naturally extend the language to particular domains, in order to increase their productivity.</p>
 
-      <p>As an example, let's write a simple test case using <a href="http://elixir-lang.org/docs/stable/ex_unit/">Elixir's test framework called ExUnit</a>:</p>
+      <p>As an example, let's write a simple test case using <a href="/docs/stable/ex_unit/">Elixir's test framework called ExUnit</a>:</p>
 
 {% highlight elixir %}
 defmodule MathTest do
@@ -127,7 +127,7 @@ end
     <h4>A growing ecosystem</h4>
 
     <div class="entry-summary">
-      <p>Elixir ships with a great set of tools to ease development. <a href="http://elixir-lang.org/docs/stable/mix/">Mix is a build tool</a> that allows you to easily create projects, manage tasks, run tests and more:</p>
+      <p>Elixir ships with a great set of tools to ease development. <a href="/docs/stable/mix/">Mix is a build tool</a> that allows you to easily create projects, manage tasks, run tests and more:</p>
 
 {% highlight text %}
 $ mix new my_app
@@ -147,7 +147,7 @@ Finished in 0.04 seconds (0.04s on load, 0.00s on tests)
     <h4>Interactive development</h4>
 
     <div class="entry-summary">
-      <p>Tools like <a href="http://elixir-lang.org/docs/stable/iex/">IEx (Elixir's interactive shell)</a> are able to leverage many aspects of the language and platform to provide auto-complete, debugging tools, code reloading, as well as nicely formatted documentation:</p>
+      <p>Tools like <a href="/docs/stable/iex/">IEx (Elixir's interactive shell)</a> are able to leverage many aspects of the language and platform to provide auto-complete, debugging tools, code reloading, as well as nicely formatted documentation:</p>
 
 {% highlight text %}
 $ iex


### PR DESCRIPTION
Fixes several broken HTML issues, based on tidy-html5 validator,
and other improvements

One issue is now that the html is fixed, 
the titles for the entries in http://elixir-lang.org/blog/
look different,
now they look a bit smaller (16px, vs 24px before)
so If we want bitter titles, I  need to patch the css