### PR TITLE
Example of default args being always evaluated (ch. 8, Modules)

### DIFF
--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -185,6 +185,9 @@ end
 ```
 
 ```iex
+iex> DefaultTest.dowork
+hello
+:ok
 iex> DefaultTest.dowork 123
 123
 iex> DefaultTest.dowork


### PR DESCRIPTION
Exactly what @nedzadarek described in #399 :smile:.