### PR TITLE
Brief description of the pipe operator in chapter 10

### DIFF
--- a/getting_started/10.markdown
+++ b/getting_started/10.markdown
@@ -54,18 +54,28 @@ iex> 1..100_000 |> Enum.map(&(&1 * 3)) |> Enum.filter(odd?) |> Enum.sum
 
 The example above has a pipeline of operations. We start with a range and then multiply each element in the range by 3. This first operation will now create and return a list with `100_000` items. Then we keep all odd elements from the list, generating a new list, now with `50_000` items, and then we sum all entries.
 
-As an alternative, Elixir provides [the `Stream` module](/docs/stable/elixir/Stream.html) which supports lazy operations:
+### 10.2.1 The pipe operator
+
+The `|>` symbol used in the snippet above is the **pipe operator**: it simply takes the output from the expression on its left side and passes it as the input to the function call on its right side. It's similar to the Unix `|` operator.  Its purpose is to highlight the flow of data being transformed by a series of functions. To see how it can make the code cleaner, have a look at the example above rewritten without using the `|>` operator:
+
+```iex
+iex> Enum.sum(Enum.filter(Enum.map(1..100_000, &(&1 * 3)), odd?))
+7500000000
+```
+
+Find more about the pipe operator [by reading its documentation](http://elixir-lang.org/docs/stable/elixir/Kernel.html#|>/2).
+
+## 10.3 Streams
+
+As an alternative to `Enum`, Elixir provides [the `Stream` module](/docs/stable/elixir/Stream.html) which supports lazy operations:
 
 ```iex
 iex> 1..100_000 |> Stream.map(&(&1 * 3)) |> Stream.filter(odd?) |> Enum.sum
 7500000000
 ```
 
-Instead of generating intermediate lists, streams create a series of computations that are invoked only when we pass it to the `Enum` module. Streams are useful when working with large, *possibly infinite*, collections.
-
-## 10.3 Streams
-
 Streams are lazy, composable enumerables.
+Instead of generating intermediate lists, streams create a series of computations that are invoked only when we pass it to the `Enum` module. Streams are useful when working with large, *possibly infinite*, collections.
 
 They are lazy because, as shown in the example above, `1..100_000 |> Stream.map(&(&1 * 3))` returns a data type, an actual stream, that represents the `map` computation over the range `1..100_000`:
 


### PR DESCRIPTION
I added a brief description of the pipe operator (`|>`) in chapter 10, when it is first used. This has been suggested by @josevalim in #395.