### PR TITLE
simplify css border images on widgets + remove border from book covers

### DIFF
--- a/_includes/learning-resources.html
+++ b/_includes/learning-resources.html
@@ -1,7 +1,7 @@
 <div class="widget">
   <h3 class="widget-title">Learning resources</h3>
   <ul>
-    <li class="image"><a href="http://pragprog.com/titles/elixir" title="Programming Elixir"><img src="http://imagery.pragprog.com/products/361/elixir_xlargecover.jpg?1368724397" alt="Programming Elixir cover" width="190" height="228" /></a></li>
+    <li class="image"><a href="http://pragprog.com/titles/elixir" title="Programming Elixir"><img src="http://imagery.pragprog.com/products/361/elixir_xlargecover.jpg?1368724397" alt="Programming Elixir cover" width="190" height="228" class="border" /></a></li>
     <li class="image"><a href="http://elixirsips.com" title="ElixirSips"><img src="http://elixirsips.com/images/ElixirLangAd2_190x160.png" alt="ElixirSips cover" width="190" height="160" /></a></li>
     <li class="image"><a href="http://shop.oreilly.com/product/0636920030584.do" title="Introducing Elixir"><img src="http://akamaicovers.oreilly.com/images/0636920030584/cat.gif" alt="Introducing Elixir cover" width="190" height="249" /></a></li>
     <li class="image"><a href="http://manning.com/juric/" title="Elixir in Action"><img src="http://manning.com/juric/juric_cover150.jpg" alt="Elixir in Action cover" width="190" height="238" /></a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -709,13 +709,18 @@ body.source           div.menu li.source          a {
   margin-bottom: 26px;
   color: #888;
 }
+
 .widget table, .widget ul, .widget ol { margin: 0 0 0 16px; }
 
 li.image {
   list-style: none;
   margin-bottom: 10px;
 }
-#sponsors li.image img { border:0; }
+.widget li.image img { border-width: 0; }
+.widget li.image img.border {
+  border-width: 1px;
+  padding: 0;
+}
 
 /* Widget titles
 -------------------------------------------------------------- */


### PR DESCRIPTION
Remove the border from the images on the right-hand side-bar (some book covers end up with a double border), and only add it through a "border" class  to the ones that needed.