### PR TITLE
Remove an outdated sentence from chapter 16

### DIFF
--- a/getting_started/16.markdown
+++ b/getting_started/16.markdown
@@ -195,4 +195,4 @@ iex> inspect &(&1+2)
 "#Function<6.71889879/1 in :erl_eval.expr/5>"
 ```
 
-There are other protocols in Elixir but this covers the most common ones. In the next chapter we will learn a bit more about error handling and exceptions in Elixir.
+There are other protocols in Elixir but this covers the most common ones.


### PR DESCRIPTION
PR #421 moved the try/catch/rescue chapter to chapter 19 (it was chapter 17 before), but the last sentence of chapter 16 still mentioned that in the next chapter errors would be covered. That is not true anymore.

(Sorry, my bad :disappointed:)