### PR TITLE
add border to inline code style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -343,9 +343,10 @@ blockquote pre:last-child {
 /* Code
 -------------------------------------------------------------- */
 code {
-  padding: 0 3px;
+  padding: 1px 3px;
   color: #555;
   background: #fff8ed;
+  border:1px solid #faefe0;
 }
 pre {
   padding: 15px 20px;
@@ -355,6 +356,7 @@ pre {
 pre code {
   padding: 0;
   background: transparent;
+  border:0;
 }
 
 /* Forms


### PR DESCRIPTION
I have stuggled many times to distinguish whether it was inline code or not.
Before:
![code_before](https://cloud.githubusercontent.com/assets/9133420/6001031/af636fc0-ab17-11e4-97a3-b7e13dd4cf41.png)


After:
![code_after](https://cloud.githubusercontent.com/assets/9133420/6001035/b63421d2-ab17-11e4-99f3-4d8fb57de00f.png)

