### PR TITLE
Mix otp improvents + <abbr> added

### DIFF
--- a/getting_started/11.markdown
+++ b/getting_started/11.markdown
@@ -168,7 +168,7 @@ Function: #Function<20.90072148/0 in :erl_eval.expr/5>
 
 Besides providing better error logging, there are a couple other differences: `start/1` and `start_link/1` return `{:ok, pid}` rather than just the PID. This is what enables Tasks to be used in supervision tree. Furthermore, tasks provides convenience functions, like `Task.async/1` and `Task.await/1`, and functionality to ease distribution.
 
-We will explore those functionalities in the Mix and OTP guide, for now it is enough to remember to use Tasks to get better logging.
+We will explore those functionalities in the ***Mix and OTP guide***, for now it is enough to remember to use Tasks to get better logging.
 
 ## 11.5 State
 
@@ -242,6 +242,6 @@ iex> Agent.get(pid, fn map -> Map.get(map, :hello) end)
 :world
 ```
 
-A `:name` option could also be given to `Agent.start_link/2` and it would be automatically registered. Besides agents, Elixir provides an API for building generic servers (called GenServer), generic event managers and event handlers (called GenEvent), tasks and more, all powered by processes underneath. Those, along with supervision trees, will be explored with more detail in the Mix and OTP guide which will build a complete Elixir application from start to finish.
+A `:name` option could also be given to `Agent.start_link/2` and it would be automatically registered. Besides agents, Elixir provides an API for building generic servers (called GenServer), generic event managers and event handlers (called GenEvent), tasks and more, all powered by processes underneath. Those, along with supervision trees, will be explored with more detail in the ***Mix and OTP guide*** which will build a complete Elixir application from start to finish.
 
 For now, let's move on and explore the world of I/O in Elixir.

--- a/getting_started/12.markdown
+++ b/getting_started/12.markdown
@@ -10,7 +10,7 @@ guide: 12
 
 This chapter is a quick introduction to input/output mechanisms and file-system-related tasks, as well as to related modules like [`IO`](/docs/stable/elixir/IO.html), [`File`](/docs/stable/elixir/File.html) and [`Path`](/docs/stable/elixir/Path.html).
 
-We had originally sketched this chapter to come much earlier in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the VM.
+We had originally sketched this chapter to come much earlier in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the <abbr title="Virtual Machine">VM</abbr>.
 
 ## 12.1 The `IO` module
 
@@ -97,7 +97,7 @@ iex> Path.expand("~/hello")
 
 Using functions from the `Path` module as opposed to just manipulating binaries is preferred since the `Path` module takes care of different operating systems transparently. For example, `Path.join/2` joins a path with slashes (`/`) on Unix-like systems and with backslashes (`\\`) on Windows.
 
-With this we have covered the main modules that Elixir provides for dealing with IO and interacting with the file system. In the next sections, we will discuss some advanced topics regarding IO. Those sections are not necessary in order to write Elixir code, so feel free to skip them, but they do provide a nice overview of how the IO system is implemented in the VM and other curiosities.
+With this we have covered the main modules that Elixir provides for dealing with IO and interacting with the file system. In the next sections, we will discuss some advanced topics regarding IO. Those sections are not necessary in order to write Elixir code, so feel free to skip them, but they do provide a nice overview of how the IO system is implemented in the <abbr title="Virtual Machine">VM</abbr> and other curiosities.
 
 ## 12.4 Processes and group leaders
 
@@ -131,7 +131,7 @@ iex> IO.read(pid, 2)
 "he"
 ```
 
-By modelling IO devices with processes, the Erlang VM allows different nodes in the same network to exchange file processes in order to read/write files in between nodes. Of all IO devices, there is one that is special to each process: the **group leader**.
+By modelling IO devices with processes, the Erlang <abbr title="Virtual Machine">VM</abbr> allows different nodes in the same network to exchange file processes in order to read/write files in between nodes. Of all IO devices, there is one that is special to each process: the **group leader**.
 
 When you write to `:stdio`, you are actually sending a message to the group leader, which writes to the standard-input file descriptor:
 
@@ -167,4 +167,4 @@ On the other hand, `:stdio` and files opened with `:utf8` encoding work with the
 
 Although this is a subtle difference, you only need to worry about those details if you intend to pass lists to those functions. Binaries are already represented by the underlying bytes and as such their representation is always raw.
 
-This finishes our tour of IO devices and IO related functionality. We have learned about four Elixir modules - [`IO`](/docs/stable/elixir/IO.html), [`File`](/docs/stable/elixir/File.html), [`Path`](/docs/stable/elixir/Path.html) and [`StringIO`](/docs/stable/elixir/StringIO.html) - as well as how the VM uses processes for the underlying IO mechanisms and how to use `chardata` and `iodata` for IO operations.
+This finishes our tour of IO devices and IO related functionality. We have learned about four Elixir modules - [`IO`](/docs/stable/elixir/IO.html), [`File`](/docs/stable/elixir/File.html), [`Path`](/docs/stable/elixir/Path.html) and [`StringIO`](/docs/stable/elixir/StringIO.html) - as well as how the <abbr title="Virtual Machine">VM</abbr> uses processes for the underlying IO mechanisms and how to use `chardata` and `iodata` for IO operations.

--- a/getting_started/13.markdown
+++ b/getting_started/13.markdown
@@ -135,7 +135,7 @@ true
 
 By using the `alias/2` directive, we are simply changing what an alias translates to.
 
-Aliases work as described because in the Erlang VM (and consequently Elixir) modules are represented by atoms. For example, that's the mechanism we use to call Erlang modules:
+Aliases work as described because in the Erlang <abbr title="Virtual Machine">VM</abbr> (and consequently Elixir) modules are represented by atoms. For example, that's the mechanism we use to call Erlang modules:
 
 ```iex
 iex> :lists.flatten([1, [2], 3])

--- a/getting_started/14.markdown
+++ b/getting_started/14.markdown
@@ -10,7 +10,7 @@ guide: 14
 
 Module attributes in Elixir serve three purposes:
 
-1. They serve to annotate the module, often with information to be used by the user or the VM.
+1. They serve to annotate the module, often with information to be used by the user or the <abbr title="Virtual Machine">VM</abbr>.
 2. They work as constants.
 3. They work as a temporary module storage to be used during compilation.
 
@@ -26,13 +26,13 @@ defmodule MyServer do
 end
 ```
 
-In the example above, we are explicitly setting the version attribute for that module. `@vsn` is used by the code reloading mechanism in the Erlang VM to check if a module has been updated or not. If no version is specified, the version is set to the MD5 checksum of the module functions.
+In the example above, we are explicitly setting the version attribute for that module. `@vsn` is used by the code reloading mechanism in the Erlang <abbr title="Virtual Machine">VM</abbr> to check if a module has been updated or not. If no version is specified, the version is set to the MD5 checksum of the module functions.
 
 Elixir has a handful of reserved attributes. Here are just a few of them, the most commonly used ones:
 
 * `@moduledoc` - provides documentation for the current module.
 * `@doc` - provides documentation for the function or macro that follows the attribute.
-* `@behaviour` - (notice the British spelling) used for specifying an OTP or user-defined behaviour.
+* `@behaviour` - (notice the British spelling) used for specifying an <abbr title="Open Telecom Platform">OTP</abbr> or user-defined behaviour.
 * `@before_compile` - provides a hook that will be invoked before the module is compiled. This makes it possible to inject functions inside the module exactly before compilation.
 
 `@moduledoc` and `@doc` are by far the most used attributes, and we expect you to use them a lot. Elixir treats documentation as first-class and provides many functions to access documentation.

--- a/getting_started/15.markdown
+++ b/getting_started/15.markdown
@@ -66,7 +66,7 @@ iex> %{meg | oops: :field}
 ** (ArgumentError) argument error
 ```
 
-When using the update syntax (`|`), the VM is aware that no new keys will be added to the struct, allowing the maps underneath to share their structure in memory. In the example above, both `john` and `meg` share the same key structure in memory.
+When using the update syntax (`|`), the <abbr title="Virtual Machine">VM</abbr> is aware that no new keys will be added to the struct, allowing the maps underneath to share their structure in memory. In the example above, both `john` and `meg` share the same key structure in memory.
 
 Structs can also be used in pattern matching, both for matching on the value of specific keys as well as for ensuring that the matching value is a struct of the same type as the matched value.
 

--- a/getting_started/19.markdown
+++ b/getting_started/19.markdown
@@ -141,7 +141,7 @@ iex> try do
 
 Using `try/catch` is already uncommon and using it to catch exits is even more rare.
 
-`exit` signals are an important part of the fault tolerant system provided by the Erlang VM. Processes usually run under supervision trees which are themselves processes that just wait for `exit` signals from the supervised processes. Once an exit signal is received, the supervision strategy kicks in and the supervised process is restarted.
+`exit` signals are an important part of the fault tolerant system provided by the Erlang <abbr title="Virtual Machine">VM</abbr>. Processes usually run under supervision trees which are themselves processes that just wait for `exit` signals from the supervised processes. Once an exit signal is received, the supervision strategy kicks in and the supervised process is restarted.
 
 It is exactly this supervision system that makes constructs like `try/catch` and `try/rescue` so uncommon in Elixir. Instead of rescuing an error, we'd rather "fail fast" since the supervision tree will guarantee our application will go back to a known initial state after the error.
 

--- a/getting_started/21.markdown
+++ b/getting_started/21.markdown
@@ -33,7 +33,7 @@ Don't forget that you can also check the [source code of Elixir itself](https://
 
 As the main page of this site puts it:
 
-> Elixir is a programming language built on top of the Erlang VM.
+> Elixir is a programming language built on top of the Erlang <abbr title="Virtual Machine">VM</abbr>.
 
 Sooner or later, an Elixir developer will want to interface with existing Erlang libraries. Here's a list of online resources that cover Erlang's fundamentals and its more advanced features:
 

--- a/getting_started/5.markdown
+++ b/getting_started/5.markdown
@@ -51,7 +51,7 @@ The first clause above will only match when `x` is positive.
 
 ## 5.2 Expressions in guard clauses.
 
-The Erlang VM only allows a limited set of expressions in guards:
+The Erlang Virtual Machine (VM) only allows a limited set of expressions in guards:
 
 * comparison operators (`==`, `!=`, `===`, `!==`, `>`, `<`, `<=`, `>=`)
 * boolean operators (`and`, `or`) and negation operators (`not`, `!`)

--- a/getting_started/7.markdown
+++ b/getting_started/7.markdown
@@ -170,7 +170,7 @@ Both access and update syntaxes above require the given keys to exist. For examp
 
 Elixir developers typically prefer to use the `map.field` syntax and pattern matching instead of the functions in the `Map` module when working with maps because they lead to an assertive style of programming. [This blog post](http://blog.plataformatec.com.br/2014/09/writing-assertive-code-with-elixir/) provides insight and examples on how you get more concise and faster software by writing assertive code in Elixir.
 
-> Note: Maps were recently introduced into the Erlang VM with [EEP 43](http://www.erlang.org/eeps/eep-0043.html). Erlang 17 provides a partial implementation of the EEP, where only "small maps" are supported. This means maps have good performance characteristics only when storing at maximum a couple of dozens keys. To fill in this gap, Elixir also provides [the `HashDict` module](/docs/stable/elixir/HashDict.html) which uses a hashing algorithm to provide a dictionary that supports hundreds of thousands keys with good performance.
+> Note: Maps were recently introduced into the Erlang <abbr title="Virtual Machine">VM</abbr> with [EEP 43](http://www.erlang.org/eeps/eep-0043.html "Erlang Enhancement Proposal #43: Maps"). Erlang 17 provides a partial implementation of the <abbr title="Erlang Enhancement Proposal">EEP</abbr>, where only "small maps" are supported. This means maps have good performance characteristics only when storing at maximum a couple of dozens keys. To fill in this gap, Elixir also provides [the `HashDict` module](/docs/stable/elixir/HashDict.html) which uses a hashing algorithm to provide a dictionary that supports hundreds of thousands keys with good performance.
 
 ## 7.3 Dicts
 

--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -157,7 +157,18 @@ iex> fun.(1)
 2
 ```
 
-The `&1` represents the first argument passed into the function. `&(&1+1)` above is exactly the same as `fn x -> x + 1 end`. The syntax above is useful for short function definitions. You can read more about the capture operator `&` in [the `Kernel.SpecialForms` documentation](/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
+The `&1` represents the first argument passed into the function. `&(&1+1)` above is exactly the same as `fn x -> x + 1 end`. The syntax above is useful for short function definitions.
+
+In the same fashion if you want to call a function from a module, you can do `&Module.function()`:
+
+```iex
+iex> fun = &List.flatten(&1, &2)
+&List.flatten/2
+iex> fun.([1, [[2], 3]], [4, 5])
+[1, 2, 3, 4, 5]
+```
+
+`&List.flatten(&1, &2)` is the same as writing `fn(list, tail) -> List.flatten(list, tail) end`. You can read more about the capture operator `&` in [the `Kernel.SpecialForms` documentation](/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
 
 ## 8.5 Default arguments
 

--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -157,7 +157,7 @@ iex> fun.(1)
 2
 ```
 
-The `&1` represents the first argument passed into the function. `&(&1+1)` above is exactly the same as `fn x -> x + 1 end`. The syntax above is useful for short function definitions. You can read more about the capture operator `&` in [the `Kernel.SpecialForms` documentation](/docs/stable/elixir/Kernel.SpecialForms.html).
+The `&1` represents the first argument passed into the function. `&(&1+1)` above is exactly the same as `fn x -> x + 1 end`. The syntax above is useful for short function definitions. You can read more about the capture operator `&` in [the `Kernel.SpecialForms` documentation](/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
 
 ## 8.5 Default arguments
 

--- a/getting_started/mix_otp/1.markdown
+++ b/getting_started/mix_otp/1.markdown
@@ -32,13 +32,13 @@ OK
 
 In order to build our key-value application, we are going to use three main tools:
 
-* OTP is a set of libraries that ships with Erlang. Erlang developers use OTP to build robust, fault-tolerant applications. In this chapter we will explore how many aspects from OTP integrate with Elixir, including supervision trees, event managers and more;
+* ***OTP*** _(Open Telecom Platform)_ is a set of libraries that ships with Erlang. Erlang developers use OTP to build robust, fault-tolerant applications. In this chapter we will explore how many aspects from OTP integrate with Elixir, including supervision trees, event managers and more;
 
-* Mix is a build tool that ships with Elixir that provides tasks for creating, compiling, testing your application, managing its dependencies and much more;
+* ***Mix*** is a build tool that ships with Elixir that provides tasks for creating, compiling, testing your application, managing its dependencies and much more;
 
-* ExUnit is a test-unit based framework that ships with Elixir;
+* ***ExUnit*** is a test-unit based framework that ships with Elixir;
 
-In this chapter, we will create our first project using Mix and explore different features in OTP, Mix and ExUnit as we go.
+In this chapter, we will create our first project using Mix and explore different features in  <abbr title="Open Telecom Platform">OTP</abbr>, Mix and ExUnit as we go.
 
 > Note: this guide requires Elixir v0.15.0 or later. You can check your Elixir version with `elixir -v` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting_started/1.html).
 >

--- a/getting_started/mix_otp/1.markdown
+++ b/getting_started/mix_otp/1.markdown
@@ -79,7 +79,7 @@ Let's take a brief look at those generated files.
 
 ## 1.2 Project compilation
 
-A file named `mix.exs` was generated inside our new project and its main responsibility is to configure our project. Let's take a look at it (comments removed):
+A file named `mix.exs` was generated inside our new project folder (`kv`) and its main responsibility is to configure our project. Let's take a look at it (comments removed):
 
 ```elixir
 defmodule KV.Mixfile do
@@ -114,14 +114,15 @@ end
 
 This structure is enough to compile our project:
 
+    $ cd kv
     $ mix compile
 
-Will generate:
+Will output:
 
     Compiled lib/kv.ex
     Generated kv.app
 
-Notice the `lib/kv.ex` file was compiled and `kv.app` file was generated. This `.app` file is generated with the information from the `application/0` function in the `mix.exs` file. We will further explore `mix.exs` configuration features in future chapters.
+Notice the `lib/kv.ex` file was compiled and `kv.app` file was generated. All this took place in a directory structure of its own, inside the `_build` folder. This `.app` file is generated with the information from the `application/0` function in the `mix.exs` file. We will further explore `mix.exs` configuration features in future chapters.
 
 Once the project is compiled, you can start an `iex` session inside the project by running:
 
@@ -174,7 +175,7 @@ Change the assertion in `test/kv_test.exs` to the following:
 assert 1 + 1 == 3
 ```
 
-Now run `mix test` again (notice this time there was no compilation):
+Now run `mix test` again (notice this time there will be no compilation):
 
     1) test the truth (KVTest)
        test/kv_test.exs:4
@@ -190,7 +191,7 @@ Now run `mix test` again (notice this time there was no compilation):
 
 For each failure, ExUnit prints a detailed report, containing the test name with the test case, the code that failed and the values for the left-hand side (lhs) and right-hand side (rhs) of the `==` operator.
 
-In the second line of the failure, right below the test name, there is the location the test was defined. If you copy the test location in the second line, containing the file and line, and paste it in-front of `mix test`, Mix will load and run just that particular test:
+In the second line of the failure, right below the test name, there is the location where the test was defined. If you copy the test location in this full second line (including the file and line number) and append it to `mix test`, Mix will load and run just that particular test:
 
     $ mix test test/kv_test.exs:4
 
@@ -208,7 +209,7 @@ Mix supports the concept of "environments". They allow a developer to customize 
 
 > Note: If you add dependencies to your project, they will not inherit your project's environment, but instead run with their `:prod` environment settings!
 
-By default, these environments behave the same and all configuration we have seen so far will affect all three environments. Customization per environment can be done by accessing [the `Mix.env` function](/docs/stable/mix/Mix.html#env/1) in your `mix.exs` file, which returns the current environment as an atom:
+By default, these environments behave the same and all the configurations we have seen so far will affect all three environments. Customization per environment can be done by accessing [the `Mix.env` function](/docs/stable/mix/Mix.html#env/1) in your `mix.exs` file, which returns the current environment as an atom:
 
 ```elixir
 def project do

--- a/getting_started/mix_otp/10.markdown
+++ b/getting_started/mix_otp/10.markdown
@@ -26,9 +26,9 @@ You may wonder why we don't simply tell the node we find in our routing table to
 
 ## 10.1 Our first distributed code
 
-Elixir ships with facilities to connect nodes and exchange information between them. In fact, we use the same concepts of processes, message passing and receiving messages when working in a distributed environment because Elixir processes are *location transparent*. This means that when sending a message, it doesn't matter if the recipient process is on the same node or on another node, the VM will be able to deliver the message in both cases.
+Elixir ships with facilities to connect nodes and exchange information between them. In fact, we use the same concepts of processes, message passing and receiving messages when working in a distributed environment because Elixir processes are *location transparent*. This means that when sending a message, it doesn't matter if the recipient process is on the same node or on another node, the <abbr title="Virtual Machine">VM</abbr> will be able to deliver the message in both cases.
 
-In order to run distributed code, we need to start the VM with a name. The name can be short (when in the same network) or long (requires the full computer address). Let's start a new IEx session:
+In order to run distributed code, we need to start the <abbr title="Virtual Machine">VM</abbr> with a name. The name can be short (when in the same network) or long (requires the full computer address). Let's start a new IEx session:
 
     $ iex --sname foo
 
@@ -262,7 +262,7 @@ You can read more about filters, tags and the default tags in [`ExUnit.Case` mod
 
 ## 10.6 Application environment and configuration
 
-So far we have hardcoded the routing table into the `KV.Router` module. However, we would like to make the table dynamic. This allows us not only to configure development/test/production, but also to allow different nodes to run with different entries in the routing table. There is a feature of OTP that does exactly that: the application environment.
+So far we have hardcoded the routing table into the `KV.Router` module. However, we would like to make the table dynamic. This allows us not only to configure development/test/production, but also to allow different nodes to run with different entries in the routing table. There is a feature of  <abbr title="Open Telecom Platform">OTP</abbr> that does exactly that: the application environment.
 
 Each application has an environment that stores the application specific configuration by key. For example, we could store the routing table in the `:kv` application environment, giving it a default value and allowing other applications to change the table as needed.
 
@@ -343,8 +343,8 @@ Finally, we have learned some new things in this chapter, and they could be appl
 
 ## 10.7 Summing up
 
-In this chapter we have built a simple router as a way to explore the distributed features of Elixir and the Erlang VM, and learned how to configure its routing table. This is the last chapter in our Mix and OTP guide.
+In this chapter we have built a simple router as a way to explore the distributed features of Elixir and the Erlang <abbr title="Virtual Machine">VM</abbr>, and learned how to configure its routing table. This is the last chapter in our Mix and  <abbr title="Open Telecom Platform">OTP</abbr> guide.
 
 Throughout the guide, we have built a very simple distributed key-value store as an opportunity to explore many constructs like generic servers, event managers, supervisors, tasks, agents, applications and more. Not only that, we have written tests for the whole application, getting familiar with ExUnit, and learned how to use the Mix build tool to accomplish a wide range of tasks.
 
-If you are looking for a distributed key-value store to use in production, you should definitely look into [Riak](http://basho.com/riak/), which also runs in the Erlang VM. In Riak, the buckets are replicated, to avoid data loss, and instead of a router, they use [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing) to map a bucket to a node. A consistent hashing algorithm helps reduce the amount of data that needs to be migrated when new nodes to store buckets are added to your infrastructure.
+If you are looking for a distributed key-value store to use in production, you should definitely look into [Riak](http://basho.com/riak/), which also runs in the Erlang <abbr title="Virtual Machine">VM</abbr>. In Riak, the buckets are replicated, to avoid data loss, and instead of a router, they use [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing) to map a bucket to a node. A consistent hashing algorithm helps reduce the amount of data that needs to be migrated when new nodes to store buckets are added to your infrastructure.

--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -174,9 +174,9 @@ This distinction is important. If there are expensive actions to be done, you mu
 
 ```elixir
 def delete(bucket, key) do
-  :timer.sleep(1000) # puts the client to sleep
+  :timer.sleep(1000) # puts client to sleep
   Agent.get_and_update(bucket, fn dict ->
-    :timer.sleep(1000) # puts the server to sleep
+    :timer.sleep(1000) # puts server to sleep
     HashDict.pop(dict, key)
   end)
 end

--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -19,14 +19,14 @@ Elixir is an immutable language where nothing is shared by default. If we want t
 * Processes
 * [ETS (Erlang Term Storage)](http://www.erlang.org/doc/man/ets.html)
 
-We have talked about processes, while ETS is something new that we will explore later in this guide. When it comes to processes though, we rarely hand-roll our own process, instead we use the abstractions available in Elixir and OTP:
+We have talked about processes, while <abbr title="Erlang Term Storage">ETS</abbr> is something new that we will explore later in this guide. When it comes to processes though, we rarely hand-roll our own process, instead we use the abstractions available in Elixir and  <abbr title="Open Telecom Platform">OTP</abbr>:
 
 * [Agent](/docs/stable/elixir/Agent.html) - Simple wrappers around state
 * [GenServer](/docs/stable/elixir/GenServer.html) - "Generic servers" (processes) that encapsulate state, provide sync and async calls, support code reloading, and more
 * [GenEvent](/docs/stable/elixir/GenEvent.html) - "Generic event" managers that allow publishing events to multiple handlers
 * [Task](/docs/stable/elixir/Task.html) - Asynchronous units of computation that allow spawning a process and easily retrieving its result at a later time
 
-We will explore all of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the VM, like `send`, `receive`, `spawn` and `link`.
+We will explore all of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the <abbr title="Virtual Machine">VM</abbr>, like `send`, `receive`, `spawn` and `link`.
 
 ## 2.2 Agents
 

--- a/getting_started/mix_otp/2.markdown
+++ b/getting_started/mix_otp/2.markdown
@@ -14,17 +14,17 @@ If you have skipped the Getting Started guide or if you have read it long ago, b
 
 ## 2.1 The trouble with state
 
-Elixir is an immutable language where nothing is shared by default. If we want to create buckets, store and access them from multiple places, we have two main options in Elixir:
+Elixir is an immutable language where nothing is shared by default. If we want to create buckets, and store and access them from multiple places, we have two main options in Elixir:
 
 * Processes
 * [ETS (Erlang Term Storage)](http://www.erlang.org/doc/man/ets.html)
 
 We have talked about processes, while <abbr title="Erlang Term Storage">ETS</abbr> is something new that we will explore later in this guide. When it comes to processes though, we rarely hand-roll our own process, instead we use the abstractions available in Elixir and  <abbr title="Open Telecom Platform">OTP</abbr>:
 
-* [Agent](/docs/stable/elixir/Agent.html) - Simple wrappers around state
-* [GenServer](/docs/stable/elixir/GenServer.html) - "Generic servers" (processes) that encapsulate state, provide sync and async calls, support code reloading, and more
-* [GenEvent](/docs/stable/elixir/GenEvent.html) - "Generic event" managers that allow publishing events to multiple handlers
-* [Task](/docs/stable/elixir/Task.html) - Asynchronous units of computation that allow spawning a process and easily retrieving its result at a later time
+* [Agent](/docs/stable/elixir/Agent.html) - Simple wrappers around state.
+* [GenServer](/docs/stable/elixir/GenServer.html) - "Generic servers" (processes) that encapsulate state, provide sync and async calls, support code reloading, and more.
+* [GenEvent](/docs/stable/elixir/GenEvent.html) - "Generic event" managers that allow publishing events to multiple handlers.
+* [Task](/docs/stable/elixir/Task.html) - Asynchronous units of computation that allow spawning a process and easily retrieving its result at a later time.
 
 We will explore all of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the <abbr title="Virtual Machine">VM</abbr>, like `send`, `receive`, `spawn` and `link`.
 
@@ -98,7 +98,10 @@ defmodule KV.Bucket do
 end
 ```
 
-With the `KV.Bucket` module defined, our test should pass! Note that we are using a HashDict to store our state instead of a `Map`, because in the current version of Elixir maps are less efficient when holding a large number of keys.
+Note that we are using a HashDict to store our state instead of a `Map`, because in the current version of Elixir maps are less efficient when holding a large number of keys.
+
+Now that the `KV.Bucket` module has been defined, our test should pass! You can try it yourself by running: `mix test` .
+
 
 ## 2.3 ExUnit callbacks
 
@@ -171,9 +174,9 @@ This distinction is important. If there are expensive actions to be done, you mu
 
 ```elixir
 def delete(bucket, key) do
-  :timer.sleep(1000) # sleeps the client
+  :timer.sleep(1000) # puts the client to sleep
   Agent.get_and_update(bucket, fn dict ->
-    :timer.sleep(1000) # sleeps the server
+    :timer.sleep(1000) # puts the server to sleep
     HashDict.pop(dict, key)
   end)
 end

--- a/getting_started/mix_otp/3.markdown
+++ b/getting_started/mix_otp/3.markdown
@@ -33,13 +33,13 @@ iex> KV.Bucket.get(:shopping, "milk")
 1
 ```
 
-However, this a terrible idea! Local names in Elixir must be atoms, which means we would need to convert the bucket name (often received from an external client) to atoms, and **we should never convert user input to atoms**. This is because atoms are not garbage collected. Once an atom is created, it is never reclaimed. Generating atoms from user input would mean the user can inject enough different names to exhaust our system memory! In practice it is more likely you will reach the Erlang VM limit for the maximum number of atoms before you run out of memory, which will bring your system down regardless.
+However, this a terrible idea! Local names in Elixir must be atoms, which means we would need to convert the bucket name (often received from an external client) to atoms, and **we should never convert user input to atoms**. This is because atoms are not garbage collected. Once an atom is created, it is never reclaimed. Generating atoms from user input would mean the user can inject enough different names to exhaust our system memory! In practice it is more likely you will reach the Erlang <abbr title="Virtual Machine">VM</abbr> limit for the maximum number of atoms before you run out of memory, which will bring your system down regardless.
 
 Instead of abusing the name registry facility, we will instead create our own *registry process* that holds a dictionary that associates the bucket name to the bucket process.
 
 The registry needs to guarantee the dictionary is always up to date. For example, if one of the bucket processes crashes due to a bug, the registry must clean up the dictionary in order to avoid serving stale entries. In Elixir, we describe this by saying that the registry needs to *monitor* each bucket.
 
-We will use a [GenServer](/docs/stable/elixir/GenServer.html) to create a registry process that can monitor the bucket process. GenServers are the go-to abstraction for building generic servers in both Elixir and OTP.
+We will use a [GenServer](/docs/stable/elixir/GenServer.html) to create a registry process that can monitor the bucket process. GenServers are the go-to abstraction for building generic servers in both Elixir and  <abbr title="Open Telecom Platform">OTP</abbr>.
 
 ## 3.1 Our first GenServer
 
@@ -272,6 +272,6 @@ Returning to our `handle_cast/2` implementation, you can see the registry is bot
 ref = Process.monitor(pid)
 ```
 
-This is a bad idea, as we don't want the registry to crash when a bucket crashes! We will explore solutions to this problem when we talk about supervisors. In a nutshell, we typically avoid creating new processes directly. Instead, we delegate this responsibility to supervisors. As we'll see, supervisors work with links, and that explains why link-based APIs (`spawn_link`, `start_link`, etc) are so prevalent in Elixir and OTP.
+This is a bad idea, as we don't want the registry to crash when a bucket crashes! We will explore solutions to this problem when we talk about supervisors. In a nutshell, we typically avoid creating new processes directly. Instead, we delegate this responsibility to supervisors. As we'll see, supervisors work with links, and that explains why link-based APIs (`spawn_link`, `start_link`, etc) are so prevalent in Elixir and <abbr title="Open Telecom Platform">OTP</abbr>.
 
 Before jumping into supervisors, let's first explore event managers and event handlers with GenEvent.

--- a/getting_started/mix_otp/4.markdown
+++ b/getting_started/mix_otp/4.markdown
@@ -8,7 +8,7 @@ guide: 4
 
 {% include toc.html %}
 
-In this chapter, we will explore GenEvent, another behaviour provided by Elixir and OTP that allows us to spawn an event manager that is able to publish events to many handlers.
+In this chapter, we will explore GenEvent, another behaviour provided by Elixir and  <abbr title="Open Telecom Platform">OTP</abbr> that allows us to spawn an event manager that is able to publish events to many handlers.
 
 There are two events we are going to emit: one for every time a bucket is added to the registry and another when it is removed from it.
 

--- a/getting_started/mix_otp/5.markdown
+++ b/getting_started/mix_otp/5.markdown
@@ -173,7 +173,7 @@ Mix makes a distinction between projects and applications. Based on the current 
 
 When we say "project," you should think about Mix. Mix is the tool that manages your project. It knows how to compile your project, test your project and more. It also knows how to compile and start the application relevant to your project.
 
-When we talk about applications, we talk about OTP. Applications are the entities that are started and stopped as a whole by the runtime. You can learn more about applications in the [docs for the Application module](/docs/stable/elixir/Application.html), as well as by running `mix help compile.app` to learn more about the supported options in `def application`.
+When we talk about applications, we talk about  <abbr title="Open Telecom Platform">OTP</abbr>. Applications are the entities that are started and stopped as a whole by the runtime. You can learn more about applications in the [docs for the Application module](/docs/stable/elixir/Application.html), as well as by running `mix help compile.app` to learn more about the supported options in `def application`.
 
 ## 5.3 Simple one for one supervisors
 

--- a/getting_started/mix_otp/8.markdown
+++ b/getting_started/mix_otp/8.markdown
@@ -289,6 +289,6 @@ end
 
 Since we have changed the supervisor specification, we need to ask: is our supervision strategy is still correct?
 
-In this case, the answer is yes: if the acceptor crashes, there is no need to crash the existing connections. On the other hand, if the task supervisor crashes, there is no need to crash the acceptor too. This is a contrast to the registry, where we initially had to crash the supervisor every time the registry crashed, until we used ETS to persist state. However, tasks have no state and nothing will go stale if one of these processes dies.
+In this case, the answer is yes: if the acceptor crashes, there is no need to crash the existing connections. On the other hand, if the task supervisor crashes, there is no need to crash the acceptor too. This is a contrast to the registry, where we initially had to crash the supervisor every time the registry crashed, until we used <abbr title="Erlang Term Storage">ETS</abbr> to persist state. However, tasks have no state and nothing will go stale if one of these processes dies.
 
 In the next chapter we will start parsing the client requests and sending responses, finishing our server.

--- a/getting_started/mix_otp/9.markdown
+++ b/getting_started/mix_otp/9.markdown
@@ -425,7 +425,7 @@ defmodule KVServerTest do
 end
 ```
 
-Our integration test checks all server interaction, including unknown commands and not found errors. It is worth noting that, as with ETS tables and linked processes, there is no need to close the socket. Once the test process exits, the socket is automatically closed.
+Our integration test checks all server interaction, including unknown commands and not found errors. It is worth noting that, as with <abbr title="Erlang Term Storage">ETS</abbr> tables and linked processes, there is no need to close the socket. Once the test process exits, the socket is automatically closed.
 
 This time, since our test relies on global data, we have not given `async: true` to `use ExUnit.Case`. Furthermore, in order to guarantee our test is always in a clean state, we stop and start the `:kv` application before each test. In fact, stopping the `:kv` application even prints a warning on the terminal:
 


### PR DESCRIPTION
* Slight improvements to MIX & OTP Guide, Chapter 1 and 2.
* `<abbr>` added for VM, EEP and OTP. And first time mentioned, give the full meaning in text.
* Capture operator example added when calling Modules.

