### PR TITLE
index-redirect.html added

### DIFF
--- a/_includes/index-redirect.html
+++ b/_includes/index-redirect.html
@@ -1,0 +1,68 @@
+{% comment%}
+  Description:
+    This include file redirects you from the folder/ to folder/first_page_in_your_series.html
+
+  Usage:
+    Include this file using {% include redirect.html %},
+    You can assign in the Frontmatter two variables:
+    
+    `data_file: getting-started`
+      Specify the name of the file under: _data/
+      The slug for the first article listed in the current folder, will be picked.
+      The redirect_url will be create using: `current_directory + slug + .html`
+
+    `redirect_url: /some_dir/some_page#internal_link`
+      or you can directly set the address.
+
+    Additionally you can set your own custom message, setting the variable `custom_content`.
+    You will have to inclue the links yourself if you want the user to click on the page he/she's being redirected to.
+    Ex: 
+      {% capture _custom_content %}
+        YOU ARE BEING REDIRECTED!
+      {% endcapture %}
+{% endcomment %}
+
+{% if page.redirect_url %}
+  {% assign redirect_to = page.redirect_url %} 
+{% else %}
+  {% assign url_parts = page.url | split: '/' %}
+  {% assign file_name = url_parts | last %}
+  {% assign guide_base_url = page.url | replace: file_name %}
+  {% assign page_slug = file_name | replace: '.html' %}
+
+  {% assign guides = site.data[{{page.data_file}}] }}  %}
+  {% for guide in guides %}
+    {% if guide.dir == guide_base_url %}
+      {% assign redirect_slug = guide.pages | map: 'slug' | first %}
+      {% capture redirect_to %}{{guide.dir}}{{redirect_slug}}.html{% endcapture %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% unless redirect_to %}
+  Error: Unable to redirect.
+  Could not find `redirect_url = {{page.redirect_url}}`
+  or data file `data_file = {{page.data_file}}` 
+  with a proper slug for this folder. 
+{% else %}
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>Redirecting...</title>
+      <link rel="canonical" href="{{redirect_to}}" />
+      <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+      <meta http-equiv="refresh" content="0; url={{redirect_to}}" />
+    </head>
+  <body>
+  {% unless custom_content %}
+    <p><strong>The page you have requested has been moved.</strong></p>
+    <p>If you are not redirected automatically, visit <a href="{{redirect_to}}">/getting-started/{{redirect_to}}</a></p>
+    <script type="text/javascript">
+      document.location.href = "{{redirect_to}}";
+    </script>
+  {% else %}
+    {{custom_content}}
+  {% endunless %}
+  </body>
+  </html>
+{% endunless %}

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -1,0 +1,7 @@
+---
+redirect_from: /getting_started/
+
+data_file: getting-started
+---
+
+{% include index-redirect.html %}

--- a/getting-started/meta/index.html
+++ b/getting-started/meta/index.html
@@ -1,0 +1,7 @@
+---
+redirect_from: /getting_started/meta/
+
+data_file: getting-started
+---
+
+{% include index-redirect.html %}

--- a/getting-started/mix-otp/index.html
+++ b/getting-started/mix-otp/index.html
@@ -1,0 +1,7 @@
+---
+redirect_from: /getting_started/mix_otp/
+
+data_file: getting-started
+---
+
+{% include index-redirect.html %}


### PR DESCRIPTION
This addition solves the issue of visiting a the folder, with no index.html
http://elixir-lang.org/getting_started/mix_otp/ well, now http://elixir-lang.org/getting-started/mix-otp/
where should it go.

This include file read _data/getting-started or whatever file you want, look in the document structure for the current folder, and gives redirects you to the first article.

I created it from scratch. And I think it can be reused in other jekyll projects