### PR TITLE
Getting started headings

### DIFF
--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -26,7 +26,7 @@
     $(document).ready(function() {
         $('.toc').toc({
           title: '',
-          listType: 'ul',
+          listType: 'ol',
           minimumHeaders: 2,
           headers: 'h2, h3, h4, h5, h6',
           showSpeed: 0,

--- a/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
+++ b/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
@@ -89,7 +89,7 @@ the basis of a zip function. Without interleaving you cannot implement
 
 The underlying problem, in both cases, is that the producer is fully in control.
 The producer simply pushes out as many elements to the consumer as it wants and
-then says "I'm done". There's no way aside from `throw`/`raise` for a consumer
+then says "I'm done". There's no way aside from `throw/raise` for a consumer
 to tell a producer "stop producing". There is definitely no way to tell a
 producer "stop for now but be prepared to continue where you left off later".
 

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: alias, require and import
-redirect_from: "/getting_started/13.html"
+redirect_from: /getting_started/13.html
 ---
 
 # {{ page.title }}

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 13 alias, require and import
-guide: 13
+title: alias, require and import
 redirect_from: "/getting_started/13.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/13.html"
 
 In order to facilitate software reuse, Elixir provides three directives. As we are going to see below, they are called directives because they have **lexical scope**.
 
-## 13.1 alias
+## alias
 
 `alias` allows you to set up aliases for any given module name. Imagine our `Math` module uses a special list implementation for doing math specific operations:
 
@@ -60,7 +59,7 @@ end
 
 In the example above, since we are invoking `alias` inside the function `plus/2`, the alias will just be valid inside the function `plus/2`. `minus/2` won't be affected at all.
 
-## 13.2 require
+## require
 
 Elixir provides macros as a mechanism for meta-programming (writing code that generates code).
 
@@ -79,7 +78,7 @@ In Elixir, `Integer.is_odd/1` is defined as a macro so that it can be used as a 
 
 In general a module does not need to be required before usage, except if we want to use the macros available in that module. An attempt to call a macro that was not loaded will raise an error. Note that like the `alias` directive, `require` is also lexically scoped. We will talk more about macros in a later chapter.
 
-## 13.3 import
+## import
 
 We use `import` whenever we want to easily access functions or macros from other modules without using the fully-qualified name. For instance, if we want to use the `duplicate/2` function from the `List` module several times, we can simply import it:
 
@@ -119,7 +118,7 @@ In the example above, the imported `List.duplicate/2` is only visible within tha
 
 Note that `import`ing a module automatically `require`s it.
 
-## 13.4 Aliases
+## Aliases
 
 At this point you may be wondering: what exactly an Elixir alias is and how is it represented?
 
@@ -154,7 +153,7 @@ iex> mod.flatten([1, [2], 3])
 
 We are simply calling the function `flatten` on the atom `:lists`.
 
-## 13.5 Nesting
+## Nesting
 
 Now that we have talked about aliases, we can talk about nesting and how it works in Elixir. Consider the following example:
 

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -10,7 +10,7 @@ redirect_from: /getting_started/13.html
 
 In order to facilitate software reuse, Elixir provides three directives. As we are going to see below, they are called directives because they have **lexical scope**.
 
-## alias
+## `alias`
 
 `alias` allows you to set up aliases for any given module name. Imagine our `Math` module uses a special list implementation for doing math specific operations:
 
@@ -59,7 +59,7 @@ end
 
 In the example above, since we are invoking `alias` inside the function `plus/2`, the alias will just be valid inside the function `plus/2`. `minus/2` won't be affected at all.
 
-## require
+## `require`
 
 Elixir provides macros as a mechanism for meta-programming (writing code that generates code).
 
@@ -78,7 +78,7 @@ In Elixir, `Integer.is_odd/1` is defined as a macro so that it can be used as a 
 
 In general a module does not need to be required before usage, except if we want to use the macros available in that module. An attempt to call a macro that was not loaded will raise an error. Note that like the `alias` directive, `require` is also lexically scoped. We will talk more about macros in a later chapter.
 
-## import
+## `import`
 
 We use `import` whenever we want to easily access functions or macros from other modules without using the fully-qualified name. For instance, if we want to use the `duplicate/2` function from the `List` module several times, we can simply import it:
 

--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 3 Basic operators
-guide: 3
+title: Basic operators
 redirect_from: "/getting_started/3.html"
 ---
 

--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Basic operators
-redirect_from: "/getting_started/3.html"
+redirect_from: /getting_started/3.html
 ---
 
 # {{ page.title }}

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Basic types
-redirect_from: "/getting_started/2.html"
+redirect_from: /getting_started/2.html
 ---
 
 # {{ page.title }}

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 2 Basic types
-guide: 2
+title: Basic types
 redirect_from: "/getting_started/2.html"
 ---
 
@@ -22,7 +21,7 @@ iex> [1, 2, 3]  # list
 iex> {1, 2, 3}  # tuple
 ```
 
-## 2.1 Basic arithmetic
+## Basic arithmetic
 
 Open up `iex`  and type the following expressions:
 
@@ -79,7 +78,7 @@ iex> trunc 3.58
 3
 ```
 
-## 2.2 Booleans
+## Booleans
 
 Elixir supports `true` and `false` as booleans:
 
@@ -105,7 +104,7 @@ You can also use `is_integer/1`, `is_float/1` or `is_number/1` to check, respect
 
 > Note: At any moment you can type `h` in the shell to print information on how to use the shell. The `h` helper can also be used to access documentation for any function. For example, typing `h is_integer/1` is going to print the documentation for the `is_integer/1` function. It also works with operators and other constructs (try `h ==/2`).
 
-## 2.3 Atoms
+## Atoms
 
 Atoms are constants where their name is their own value. Some other languages call these symbols:
 
@@ -127,7 +126,7 @@ iex> is_boolean(:false)
 true
 ```
 
-## 2.4 Strings
+## Strings
 
 Strings in Elixir are inserted between double quotes, and they are encoded in UTF-8:
 
@@ -194,7 +193,7 @@ iex> String.upcase("hellö")
 "HELLÖ"
 ```
 
-## 2.5 Anonymous functions
+## Anonymous functions
 
 Functions are delimited by the keywords `fn` and `end`:
 
@@ -235,7 +234,7 @@ iex> x
 42
 ```
 
-## 2.6 (Linked) Lists
+## (Linked) Lists
 
 Elixir uses square brackets to specify a list of values. Values can be of any type:
 
@@ -292,7 +291,7 @@ false
 
 Single-quotes are char lists, double-quotes are strings. We will talk more about them in the "Binaries, strings and char lists" chapter.
 
-## 2.7 Tuples
+## Tuples
 
 Elixir uses curly brackets to define tuples. Like lists, tuples can hold any value:
 
@@ -329,7 +328,7 @@ Notice that `put_elem/3` returned a new tuple. The original tuple stored in the 
 
 By being immutable, Elixir also helps eliminate common cases where concurrent code has race conditions because two different entities are trying to change a data structure at the same time.
 
-## 2.8 Lists or tuples?
+## Lists or tuples?
 
 What is the difference between lists and tuples?
 

--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Binaries, strings and char lists
-redirect_from: "/getting_started/6.html"
+redirect_from: /getting_started/6.html
 ---
 
 # {{ page.title }}

--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 6 Binaries, strings and char lists
-guide: 6
+title: Binaries, strings and char lists
 redirect_from: "/getting_started/6.html"
 ---
 
@@ -20,7 +19,7 @@ true
 
 In this chapter, we will understand what binaries are, how they associate with strings, and what a single-quoted value, `'like this'`, means in Elixir.
 
-## 6.1 UTF-8 and Unicode
+## UTF-8 and Unicode
 
 A string is a UTF-8 encoded binary. In order to understand exactly what we mean by that, we need to understand the difference between bytes and code points.
 
@@ -59,7 +58,7 @@ You will see that Elixir has excellent support for working with strings. It also
 
 However, strings are just part of the story. If a string is a binary, and we have used the `is_binary/1` function, Elixir must have an underlying type empowering strings. And it does. Let's talk about binaries!
 
-## 6.2 Binaries (and bitstrings)
+## Binaries (and bitstrings)
 
 In Elixir, you can define a binary using `<<>>`:
 
@@ -154,7 +153,7 @@ iex> rest
 
 This finishes our tour of bitstrings, binaries and strings. A string is a UTF-8 encoded binary, and a binary is a bitstring where the number of bits is divisible by 8. Although this shows the flexibility Elixir provides to work with bits and bytes, 99% of the time you will be working with binaries and using the `is_binary/1` and `byte_size/1` functions.
 
-## 6.3 Char lists
+## Char lists
 
 A char list is nothing more than a list of characters:
 

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: case, cond and if
-redirect_from: "/getting_started/5.html"
+redirect_from: /getting_started/5.html
 ---
 
 # {{ page.title }}

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -49,7 +49,7 @@ iex> case {1, 2, 3} do
 
 The first clause above will only match when `x` is positive.
 
-## Expressions in guard clauses.
+## Expressions in guard clauses
 
 The Erlang Virtual Machine (VM) only allows a limited set of expressions in guards:
 

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -10,7 +10,7 @@ redirect_from: /getting_started/5.html
 
 In this chapter, we will learn about the `case`, `cond` and `if` control-flow structures.
 
-## case
+## `case`
 
 `case` allows us to compare a value against many patterns until we find a matching one:
 
@@ -133,7 +133,7 @@ iex> f.(-1, 3)
 
 The number of arguments in each anonymous function clause needs to be the same, otherwise an error is raised.
 
-## cond
+## `cond`
 
 `case` is useful when you need to match against different values. However, in many circumstances, we want to check different conditions and find the first one that evaluates to true. In such cases, one may use `cond`:
 
@@ -174,7 +174,7 @@ iex> cond do
 "1 is considered as true"
 ```
 
-## if and unless
+## `if` and `unless`
 
 Besides `case` and `cond`, Elixir also provides the macros `if/2` and `unless/2` which are useful when you need to check for just one condition:
 
@@ -204,16 +204,16 @@ iex> if nil do
 
 > Note: An interesting note regarding `if/2` and `unless/2` is that they are implemented as macros in the language; they aren't special language constructs as they would be in many languages. You can check the documentation and the source of `if/2` in [the `Kernel` module docs](/docs/stable/elixir/Kernel.html). The `Kernel` module is also where operators like `+/2` and functions like `is_function/2` are defined, all automatically imported and available in your code by default.
 
-## `do`/`end` blocks
+## `do/end` blocks
 
-At this point, we have learned four control structures: `case`, `cond`, `if` and `unless`, and they were all wrapped in `do`/`end` blocks. It happens we could also write `if` as follows:
+At this point, we have learned four control structures: `case`, `cond`, `if` and `unless`, and they were all wrapped in `do/end` blocks. It happens we could also write `if` as follows:
 
 ```iex
 iex> if true, do: 1 + 2
 3
 ```
 
-In Elixir, `do`/`end` blocks are a convenience for passing a group of expressions to `do:`. These are equivalent:
+In Elixir, `do/end` blocks are a convenience for passing a group of expressions to `do:`. These are equivalent:
 
 ```iex
 iex> if true do
@@ -235,7 +235,7 @@ iex> if false, do: :this, else: :that
 :that
 ```
 
-One thing to keep in mind when using `do`/`end` blocks is they are always bound to the outermost function call. For example, the following expression:
+One thing to keep in mind when using `do/end` blocks is they are always bound to the outermost function call. For example, the following expression:
 
 ```iex
 iex> is_number if true do

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 5 case, cond and if
-guide: 5
+title: case, cond and if
 redirect_from: "/getting_started/5.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/5.html"
 
 In this chapter, we will learn about the `case`, `cond` and `if` control-flow structures.
 
-## 5.1 case
+## case
 
 `case` allows us to compare a value against many patterns until we find a matching one:
 
@@ -50,7 +49,7 @@ iex> case {1, 2, 3} do
 
 The first clause above will only match when `x` is positive.
 
-## 5.2 Expressions in guard clauses.
+## Expressions in guard clauses.
 
 The Erlang Virtual Machine (VM) only allows a limited set of expressions in guards:
 
@@ -134,7 +133,7 @@ iex> f.(-1, 3)
 
 The number of arguments in each anonymous function clause needs to be the same, otherwise an error is raised.
 
-## 5.3 cond
+## cond
 
 `case` is useful when you need to match against different values. However, in many circumstances, we want to check different conditions and find the first one that evaluates to true. In such cases, one may use `cond`:
 
@@ -175,7 +174,7 @@ iex> cond do
 "1 is considered as true"
 ```
 
-## 5.4 if and unless
+## if and unless
 
 Besides `case` and `cond`, Elixir also provides the macros `if/2` and `unless/2` which are useful when you need to check for just one condition:
 
@@ -205,7 +204,7 @@ iex> if nil do
 
 > Note: An interesting note regarding `if/2` and `unless/2` is that they are implemented as macros in the language; they aren't special language constructs as they would be in many languages. You can check the documentation and the source of `if/2` in [the `Kernel` module docs](/docs/stable/elixir/Kernel.html). The `Kernel` module is also where operators like `+/2` and functions like `is_function/2` are defined, all automatically imported and available in your code by default.
 
-## 5.5 `do`/`end` blocks
+## `do`/`end` blocks
 
 At this point, we have learned four control structures: `case`, `cond`, `if` and `unless`, and they were all wrapped in `do`/`end` blocks. It happens we could also write `if` as follows:
 

--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 17 Comprehensions
-guide: 17
+title: Comprehensions
 redirect_from: "/getting_started/17.html"
 ---
 
@@ -20,7 +19,7 @@ iex> for n <- [1, 2, 3, 4], do: n * n
 
 A comprehension is made of three parts: generators, filters and collectables.
 
-## 17.1 Generators and filters
+## Generators and filters
 
 In the expression above, `n <- [1, 2, 3, 4]` is the **generator**. It is literally generating values to be used in the comprehension. Any enumerable can be passed in the right-hand side of the generator expression:
 
@@ -60,7 +59,7 @@ end
 
 Keep in mind that variable assignments inside the comprehension, be it in generators, filters or inside the block, are not reflected outside of the comprehension.
 
-## 17.2 Bitstring generators
+## Bitstring generators
 
 Bitstring generators are also supported and are very useful when you need to comprehend over bitstring streams. The example below receives a list of pixels from a binary with their respective red, green and blue values and converts them into tuples of three elements each:
 
@@ -72,7 +71,7 @@ iex> for <<r::8, g::8, b::8 <- pixels>>, do: {r, g, b}
 
 A bitstring generator can be mixed with the "regular" enumerable generators and provides filters as well.
 
-## 17.3 Results other than lists
+## Results other than lists
 
 In the examples above, all the comprehensions returned lists as their result. However, the result of a comprehension can be inserted into different data structures by passing the `:into` option to the comprehension.
 

--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Comprehensions
-redirect_from: "/getting_started/17.html"
+redirect_from: /getting_started/17.html
 ---
 
 # {{ page.title }}

--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Enumerables and Streams
-redirect_from: "/getting_started/10.html"
+redirect_from: /getting_started/10.html
 ---
 
 # {{ page.title }}

--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 10 Enumerables and Streams
-guide: 10
+title: Enumerables and Streams
 redirect_from: "/getting_started/10.html"
 ---
 
@@ -9,7 +8,7 @@ redirect_from: "/getting_started/10.html"
 
 {% include toc.html %}
 
-## 10.1 Enumerables
+## Enumerables
 
 Elixir provides the concept of enumerables and [the `Enum` module](/docs/stable/elixir/Enum.html) to work with them. We have already learned two enumerables: lists and maps.
 
@@ -35,7 +34,7 @@ Since the Enum module was designed to work across different data types, its API 
 
 We say the functions in the `Enum` module are polymorphic because they can work with diverse data types. In particular, the functions in the `Enum` module can work with any data type that implements [the `Enumerable` protocol](/docs/stable/elixir/Enumerable.html). We are going to discuss Protocols in a later chapter, for now we are going to move on to a specific kind of enumerable called streams.
 
-## 10.2 Eager vs Lazy
+## Eager vs Lazy
 
 All the functions in the `Enum` module are eager. Many functions expect an enumerable and return a list back:
 
@@ -55,7 +54,7 @@ iex> 1..100_000 |> Enum.map(&(&1 * 3)) |> Enum.filter(odd?) |> Enum.sum
 
 The example above has a pipeline of operations. We start with a range and then multiply each element in the range by 3. This first operation will now create and return a list with `100_000` items. Then we keep all odd elements from the list, generating a new list, now with `50_000` items, and then we sum all entries.
 
-### 10.2.1 The pipe operator
+### The pipe operator
 
 The `|>` symbol used in the snippet above is the **pipe operator**: it simply takes the output from the expression on its left side and passes it as the input to the function call on its right side. It's similar to the Unix `|` operator.  Its purpose is to highlight the flow of data being transformed by a series of functions. To see how it can make the code cleaner, have a look at the example above rewritten without using the `|>` operator:
 
@@ -66,7 +65,7 @@ iex> Enum.sum(Enum.filter(Enum.map(1..100_000, &(&1 * 3)), odd?))
 
 Find more about the pipe operator [by reading its documentation](http://elixir-lang.org/docs/stable/elixir/Kernel.html#|>/2).
 
-## 10.3 Streams
+## Streams
 
 As an alternative to `Enum`, Elixir provides [the `Stream` module](/docs/stable/elixir/Stream.html) which supports lazy operations:
 

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Introduction
-redirect_from: "/getting_started/1.html"
+redirect_from: /getting_started/1.html
 ---
 
 # {{ page.title }}

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 1 Introduction
-guide: 1
+title: Introduction
 redirect_from: "/getting_started/1.html"
 ---
 
@@ -22,11 +21,11 @@ Let's get started!
 
 > If you find any errors in the tutorial or on the website, [please report a bug or send a pull request to our issue tracker](https://github.com/elixir-lang/elixir-lang.github.com). If you suspect it is a language bug, [please let us know in the language issue tracker](https://github.com/elixir-lang/elixir/issues).
 
-## 1.1 Installation
+## Installation
 
 If you still haven't installed Elixir, run to our [installation page](/install.html). Once you are done, you can run `elixir -v` to get the current Elixir version.
 
-## 1.2 Interactive mode
+## Interactive mode
 
 When you install Elixir, you will have three new executables: `iex`, `elixir` and `elixirc`. If you compiled Elixir from source or are using a packaged version, you can find these inside the `bin` directory.
 
@@ -43,7 +42,7 @@ iex> "hello" <> " world"
 
 It seems we are ready to go! We will use the interactive shell quite a lot in the next chapters to get a bit more familiar with the language constructs and basic types, starting in the next chapter.
 
-## 1.3 Running scripts
+## Running scripts
 
 After getting familiar with the basics of the language you may want to try writing simple programs. This can be accomplished by putting Elixir code into a file and executing it with `elixir`:
 

--- a/getting-started/io-and-the-file-system.markdown
+++ b/getting-started/io-and-the-file-system.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 12 IO and the file system
-guide: 12
+title: IO and the file system
 redirect_from: "/getting_started/12.html"
 ---
 
@@ -13,7 +12,7 @@ This chapter is a quick introduction to input/output mechanisms and file-system-
 
 We had originally sketched this chapter to come much earlier in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the <abbr title="Virtual Machine">VM</abbr>.
 
-## 12.1 The `IO` module
+## The `IO` module
 
 The `IO` module is the main mechanism in Elixir for reading and writing to standard input/output (`:stdio`), standard error (`:stderr`), files and other IO devices. Usage of the module is pretty straightforward:
 
@@ -34,7 +33,7 @@ hello world
 :ok
 ```
 
-## 12.2 The `File` module
+## The `File` module
 
 The [`File`](/docs/stable/elixir/File.html) module contains functions that allow us to open files as IO devices. By default, files are opened in binary mode, which requires developers to use the specific `IO.binread/2` and `IO.binwrite/2` functions from the `IO` module:
 
@@ -85,7 +84,7 @@ as, in case of an error, `File.read/1` will return `{:error, reason}` and the pa
 
 If you don't want to handle a possible error (i.e., you want it to bubble up), prefer using `File.read!/1`.
 
-## 12.3 The Path module
+## The Path module
 
 The majority of the functions in the `File` module expect paths as arguments. Most commonly, those paths will be regular binaries. The [`Path`](/docs/stable/elixir/Path.html) module provides facilities for working with such paths:
 
@@ -100,7 +99,7 @@ Using functions from the `Path` module as opposed to just manipulating binaries 
 
 With this we have covered the main modules that Elixir provides for dealing with IO and interacting with the file system. In the next sections, we will discuss some advanced topics regarding IO. Those sections are not necessary in order to write Elixir code, so feel free to skip them, but they do provide a nice overview of how the IO system is implemented in the <abbr title="Virtual Machine">VM</abbr> and other curiosities.
 
-## 12.4 Processes and group leaders
+## Processes and group leaders
 
 You may have noticed that `File.open/2` returns a tuple like `{:ok, pid}`:
 
@@ -147,7 +146,7 @@ hello
 
 The group leader can be configured per process and is used in different situations. For example, when executing code in a remote terminal, it guarantees messages in a remote node are redirected and printed in the terminal that triggered the request.
 
-## 12.5 `iodata` and `chardata`
+## `iodata` and `chardata`
 
 In all of the examples above, we used binaries when writing to files. In the chapter ["Binaries, strings and char lists"](/getting-started/binaries-strings-and-char-lists.html), we mentioned how strings are simply bytes while char lists are lists with code points.
 

--- a/getting-started/io-and-the-file-system.markdown
+++ b/getting-started/io-and-the-file-system.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: IO and the file system
-redirect_from: "/getting_started/12.html"
+redirect_from: /getting_started/12.html
 ---
 
 # {{ page.title }}

--- a/getting-started/io-and-the-file-system.markdown
+++ b/getting-started/io-and-the-file-system.markdown
@@ -84,7 +84,7 @@ as, in case of an error, `File.read/1` will return `{:error, reason}` and the pa
 
 If you don't want to handle a possible error (i.e., you want it to bubble up), prefer using `File.read!/1`.
 
-## The Path module
+## The `Path` module
 
 The majority of the functions in the `File` module expect paths as arguments. Most commonly, those paths will be regular binaries. The [`Path`](/docs/stable/elixir/Path.html) module provides facilities for working with such paths:
 

--- a/getting-started/maps-and-dicts.markdown
+++ b/getting-started/maps-and-dicts.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Keywords, maps and dicts
-redirect_from: "/getting_started/7.html"
+redirect_from: /getting_started/7.html
 ---
 
 # {{ page.title }}

--- a/getting-started/maps-and-dicts.markdown
+++ b/getting-started/maps-and-dicts.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 7 Keywords, maps and dicts
-guide: 7
+title: Keywords, maps and dicts
 redirect_from: "/getting_started/7.html"
 ---
 
@@ -13,7 +12,7 @@ So far we haven't discussed any associative data structures, i.e. data structure
 
 In Elixir, we have two main associative data structures: keyword lists and maps. It's time to learn more about them!
 
-## 7.1 Keyword lists
+## Keyword lists
 
 In many functional programming languages, it is common to use a list of 2-item tuples as the representation of an associative data structure. In Elixir, when we have a list of tuples and the first item of the tuple (i.e. the key) is an atom, we call it a keyword list:
 
@@ -92,7 +91,7 @@ iex> [b: b, a: a] = [a: 1, b: 2]
 ** (MatchError) no match of right hand side value: [a: 1, b: 2]
 ```
 
-## 7.2 Maps
+## Maps
 
 Whenever you need a key-value store, maps are the "go to" data structure in Elixir. A map is created using the `%{}` syntax:
 
@@ -173,7 +172,7 @@ Elixir developers typically prefer to use the `map.field` syntax and pattern mat
 
 > Note: Maps were recently introduced into the Erlang <abbr title="Virtual Machine">VM</abbr> with [EEP 43](http://www.erlang.org/eeps/eep-0043.html "Erlang Enhancement Proposal #43: Maps"). Erlang 17 provides a partial implementation of the <abbr title="Erlang Enhancement Proposal">EEP</abbr>, where only "small maps" are supported. This means maps have good performance characteristics only when storing at maximum a couple of dozens keys. To fill in this gap, Elixir also provides [the `HashDict` module](/docs/stable/elixir/HashDict.html) which uses a hashing algorithm to provide a dictionary that supports hundreds of thousands keys with good performance.
 
-## 7.3 Dicts
+## Dicts
 
 In Elixir, both keyword lists and maps are called dictionaries. In other words, a dictionary is like an interface (we call them behaviours in Elixir) and both keyword lists and maps modules implement this interface.
 

--- a/getting-started/meta/domain-specific-languages.markdown
+++ b/getting-started/meta/domain-specific-languages.markdown
@@ -1,8 +1,6 @@
 ---
 layout: getting-started
-title: 3 Domain Specific Languages
-guide: 3
-last: true
+title: Domain Specific Languages
 redirect_from: "/getting_started/meta/3.html"
 ---
 
@@ -32,7 +30,7 @@ MyTest.run
 
 In the example above, by using `TestCase`, we can write tests using the `test` macro, which defines a function named `run` to automatically run all tests for us. Our prototype will simply rely on the match operator (`=`) as a mechanism to do assertions.
 
-## 3.1 The `test` macro
+## The `test` macro
 
 Let's start by creating a module that simply defines and imports the `test` macro when used:
 
@@ -87,7 +85,7 @@ iex> MyTest."test hello"()
 ** (MatchError) no match of right hand side value: "world"
 ```
 
-## 3.2 Storing information with attributes
+## Storing information with attributes
 
 In order to finish our `TestCase` implementation, we need to be able to access all defined test cases. One way of doing this is by retrieving the tests at runtime via `__MODULE__.__info__(:functions)`, which returns a list of all functions in a given module. However, considering that we may want to store more information about each test besides the test name, a more flexible approach is required.
 

--- a/getting-started/meta/domain-specific-languages.markdown
+++ b/getting-started/meta/domain-specific-languages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Domain Specific Languages
-redirect_from: "/getting_started/meta/3.html"
+redirect_from: /getting_started/meta/3.html
 ---
 
 # {{ page.title }}

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Macros
-redirect_from: "/getting_started/meta/2.html"
+redirect_from: /getting_started/meta/2.html
 ---
 
 # {{ page.title }}

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 2 Macros
-guide: 2
+title: Macros
 redirect_from: "/getting_started/meta/2.html"
 ---
 
@@ -13,7 +12,7 @@ Macros can be defined in Elixir using `defmacro/2`.
 
 > For this chapter, we will be using files instead of running code samples in IEx. That's because the code samples will span multiple lines of code and typing them all in IEx can be counter-productive. You should be able to run the code samples by saving them into a `macros.exs` file and running it with `elixir macros.exs` or `iex macros.exs`.
 
-## 2.1 Our first macro
+## Our first macro
 
 In order to better understand how macros work, let's create a new module where we are going to implement `unless`, which does the opposite of `if`, as a macro and as a function:
 
@@ -102,7 +101,7 @@ Constructs such as `unless/2`, `defmacro/2`, `def/2`, `defprotocol/2`, and many 
 
 We can define any function and macro we want, including ones that override the built-in definitions provided by Elixir. The only exceptions are Elixir special forms which are not implemented in Elixir and therefore cannot be overridden, [the full list of special forms is available in `Kernel.SpecialForms`](/docs/stable/elixir/Kernel.SpecialForms.html).
 
-## 2.2 Macros hygiene
+## Macros hygiene
 
 Elixir macros have late resolution. This guarantees that a variable defined inside a quote won't conflict with a variable defined in the context where that macro is expanded. For example:
 
@@ -193,7 +192,7 @@ end
 
 Take note of the second argument to `Macro.var/2`. This is the context being used and will determine hygiene as described in the next section.
 
-## 2.3 The environment
+## The environment
 
 When calling `Macro.expand_once/2` earlier in this chapter, we used the special form `__ENV__`.
 
@@ -214,7 +213,7 @@ iex> __ENV__.requires
 
 Many of the functions in the `Macro` module expect an environment. You can read more about these functions in [the docs for the `Macro` module](/docs/stable/elixir/Macro.html) and learn more about the compilation environment in the [docs for `Macro.Env`](/docs/stable/elixir/Macro.Env.html).
 
-## 2.4 Private macros
+## Private macros
 
 Elixir also supports private macros via `defmacrop`. As private functions, these macros are only available inside the module that defines them, and only at compilation time.
 
@@ -228,7 +227,7 @@ iex> defmodule Sample do
 ** (CompileError) iex:2: function two/0 undefined
 ```
 
-## 2.5 Write macros responsibly
+## Write macros responsibly
 
 Macros are a powerful construct and Elixir provides many mechanisms to ensure they are used responsibly.
 

--- a/getting-started/meta/quote-and-unquote.markdown
+++ b/getting-started/meta/quote-and-unquote.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Quote and unquote
-redirect_from: "/getting_started/meta/1.html"
+redirect_from: /getting_started/meta/1.html
 ---
 
 # {{ page.title }}

--- a/getting-started/meta/quote-and-unquote.markdown
+++ b/getting-started/meta/quote-and-unquote.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 1 Quote and unquote
-guide: 1
+title: Quote and unquote
 redirect_from: "/getting_started/meta/1.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/meta/1.html"
 
 An Elixir program can be represented by its own data structures. In this chapter, we will learn what those structures look like and how to compose them. The concepts learned in this chapter are the building blocks for macros, which we are going to take a deeper look at in the next chapter.
 
-## 1.1 Quoting
+## Quoting
 
 The building block of an Elixir program is a tuple with three elements. For example, the function call `sum(1, 2, 3)` is represented internally as:
 
@@ -85,7 +84,7 @@ Besides the tuple defined above, there are five Elixir literals that, when quote
 
 Most Elixir code has a straight-forward translation to its underlying quoted expression. We recommend you try out different code samples and see what the results are. For example, what does `String.upcase("foo")` expand to? We have also learned that `if(true, do: :this, else: :that)` is the same as `if true do :this else :that end`. How does this affirmation hold with quoted expressions?
 
-## 1.2 Unquoting
+## Unquoting
 
 Quote is about retrieving the inner representation of some particular chunk of code. However, sometimes it may be necessary to inject some other particular chunk of code inside the representation we want to retrieve.
 
@@ -131,7 +130,7 @@ iex> Macro.to_string(quote do: [1, 2, unquote_splicing(inner), 6])
 
 Unquoting is very useful when working with macros. When writing macros, developers are able to receive code chunks and inject them inside other code chunks, which can be used to transform code or write code that generates code during compilation.
 
-## 1.3 Escaping
+## Escaping
 
 As we saw at the beginning of this chapter, only some values are valid quoted expressions in Elixir. For example, a map is not a valid quoted expression. Neither is a tuple with four elements. However, such values *can* be expressed as a quoted expression:
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Agent
-redirect_from: "/getting_started/mix_otp/2.html"
+redirect_from: /getting_started/mix_otp/2.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -139,7 +139,7 @@ end
 
 You can read more about ExUnit cases in the [`ExUnit.Case` module documentation](/docs/stable/ex_unit/ExUnit.Case.html) and more about callbacks in [`ExUnit.Callbacks` docs](/docs/stable/ex_unit/ExUnit.Callbacks.html).
 
-## Other Agent actions
+## Other agent actions
 
 Besides getting a value and updating the agent state, agents allow us to get a value and update the agent state in one function call via `Agent.get_and_update/2`. Let's implement a `KV.Bucket.delete/2` function that deletes a key from the bucket, returning its current value:
 
@@ -154,9 +154,9 @@ def delete(bucket, key) do
 end
 ```
 
-Now it is your turn to write a test for the functionality above! Also, be sure to explore the documentation for Agents to learn more about them.
+Now it is your turn to write a test for the functionality above! Also, be sure to explore the documentation for agents to learn more about them.
 
-## Client/Server in Agents
+## Client/Server in agents
 
 Before we move on to the next chapter, let's discuss the client/server dichotomy in agents. Let's expand the `delete/2` function we have just implemented:
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 2 Agent
-guide: 2
+title: Agent
 redirect_from: "/getting_started/mix_otp/2.html"
 ---
 
@@ -13,7 +12,7 @@ In this chapter, we will create a module named `KV.Bucket`. This module will be 
 
 If you have skipped the Getting Started guide or if you have read it long ago, be sure to re-read the chapter about [Processes](/getting-started/processes.html). We will use it as starting point.
 
-## 2.1 The trouble with state
+## The trouble with state
 
 Elixir is an immutable language where nothing is shared by default. If we want to create buckets, and store and access them from multiple places, we have two main options in Elixir:
 
@@ -29,7 +28,7 @@ We have talked about processes, while <abbr title="Erlang Term Storage">ETS</abb
 
 We will explore all of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the <abbr title="Virtual Machine">VM</abbr>, like `send`, `receive`, `spawn` and `link`.
 
-## 2.2 Agents
+## Agents
 
 [Agents](/docs/stable/elixir/Agent.html) are simple wrappers around state. If all you want from a process is to keep state, agents are a great fit. Let's start an `iex` session inside the project with:
 
@@ -104,7 +103,7 @@ Note that we are using a HashDict to store our state instead of a `Map`, because
 Now that the `KV.Bucket` module has been defined, our test should pass! You can try it yourself by running: `mix test` .
 
 
-## 2.3 ExUnit callbacks
+## ExUnit callbacks
 
 Before moving on and adding more features to `KV.Bucket`, let's talk about ExUnit callbacks. As you may expect, all `KV.Bucket` tests will require a bucket to be started during setup and stopped after the test. Luckily, ExUnit supports callbacks that allow us to skip such repetitive tasks.
 
@@ -140,7 +139,7 @@ end
 
 You can read more about ExUnit cases in the [`ExUnit.Case` module documentation](/docs/stable/ex_unit/ExUnit.Case.html) and more about callbacks in [`ExUnit.Callbacks` docs](/docs/stable/ex_unit/ExUnit.Callbacks.html).
 
-## 2.4 Other Agent actions
+## Other Agent actions
 
 Besides getting a value and updating the agent state, agents allow us to get a value and update the agent state in one function call via `Agent.get_and_update/2`. Let's implement a `KV.Bucket.delete/2` function that deletes a key from the bucket, returning its current value:
 
@@ -157,7 +156,7 @@ end
 
 Now it is your turn to write a test for the functionality above! Also, be sure to explore the documentation for Agents to learn more about them.
 
-## 2.5 Client/Server in Agents
+## Client/Server in Agents
 
 Before we move on to the next chapter, let's discuss the client/server dichotomy in agents. Let's expand the `delete/2` function we have just implemented:
 

--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Dependencies and umbrella projects
-redirect_from: "/getting_started/mix_otp/7.html"
+redirect_from: /getting_started/mix_otp/7.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 7 Dependencies and umbrella projects
-guide: 7
+title: Dependencies and umbrella projects
 redirect_from: "/getting_started/mix_otp/7.html"
 ---
 
@@ -35,7 +34,7 @@ However, instead of adding more code to the `kv` application, we are going to bu
 
 Before creating our new application, we must discuss how Mix handles dependencies. In practice, there are two kinds of dependencies we usually work with: internal and external dependencies. Mix supports mechanisms to work with both of them.
 
-## 7.1 External dependencies
+## External dependencies
 
 External dependencies are the ones not tied to your business domain. For example, if you need a HTTP API for your distributed KV application, you can use the [Plug](http://github.com/elixir-lang/plug) project as an external dependency.
 
@@ -71,7 +70,7 @@ Mix provides many tasks for working with dependencies, which can be seen in `mix
 
 The most common tasks are `mix deps.get` and `mix deps.update`. Once fetched, dependecies are automatically compiled for you. You can read more about deps by typing `mix help deps`, and in the [documentation for the Mix.Tasks.Deps module](/docs/stable/mix/Mix.Tasks.Deps.html).
 
-## 7.2 Internal dependencies
+## Internal dependencies
 
 Internal dependencies are the ones that are specific to your project. They usually don't make sense outside the scope of your project/company/organization. Most of the time, you want to keep them private, whether due to technical, economic or business reasons.
 
@@ -104,7 +103,7 @@ The interesting thing about this approach is that Mix has many conveniences for 
 
 So let's get started!
 
-## 7.3 Umbrella projects
+## Umbrella projects
 
 Let's start a new project using `mix new`. This new project will be named `kv_umbrella` and we need to pass the `--umbrella` option when creating it. Do not create this new project inside the existing `kv` project!
 
@@ -215,7 +214,7 @@ And it works!
 
 Since we want `kv_server` to eventually use the functionality we defined in `kv`, we need to add `kv` as a dependency to our application.
 
-## 7.4 In umbrella dependencies
+## In umbrella dependencies
 
 Mix supports an easy mechanism to make one umbrella child depend on another. Open up `apps/kv_server/mix.exs` and change the `deps/0` function to the following:
 
@@ -254,7 +253,7 @@ Now you can run tests for both projects from the umbrella root with `mix test`. 
 
 Remember that umbrella projects are a convenience to help you organize and manage your applications. Applications inside the `apps` directory are still decoupled from each other. Each application has its independent configuration, and dependencies in between them must be explicitly listed. This allows them to be developed together, but compiled, tested and deployed independently if desired.
 
-## 7.5 Summing up
+## Summing up
 
 In this chapter we have learned more about Mix dependencies and umbrella projects. We have decided to build an umbrella project because we consider `kv` and `kv_server` to be internal dependencies that matter only in the context of this project.
 

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -1,8 +1,6 @@
 ---
 layout: getting-started
-title: 10 Distributed tasks and configuration
-guide: 10
-last: true
+title: Distributed tasks and configuration
 redirect_from: "/getting_started/mix_otp/10.html"
 ---
 
@@ -25,7 +23,7 @@ You may wonder why we don't simply tell the node we find in our routing table to
 
 > Note: we will be using two nodes in the same machine throughout this chapter. You are free to use two (or more) different machines in the same network but you need to do some prep work. First of all, you need to ensure all machines have a `~/.erlang.cookie` file with exactly the same value. Second, you need to guarantee [epmd](http://www.erlang.org/doc/man/epmd.html) is running on a port that is not blocked (you can run `epmd -d` for debug info). Third, if you want to learn more about distribution in general, we recommend [this great Distribunomicon chapter from Learn You Some Erlang](http://learnyousomeerlang.com/distribunomicon).
 
-## 10.1 Our first distributed code
+## Our first distributed code
 
 Elixir ships with facilities to connect nodes and exchange information between them. In fact, we use the same concepts of processes, message passing and receiving messages when working in a distributed environment because Elixir processes are *location transparent*. This means that when sending a message, it doesn't matter if the recipient process is on the same node or on another node, the <abbr title="Virtual Machine">VM</abbr> will be able to deliver the message in both cases.
 
@@ -100,7 +98,7 @@ The options above have different properties. Both `:rpc` and using a GenServer w
 
 For our routing layer, we are going to use tasks, but feel free to explore the other alternatives too.
 
-## 10.2 async/await
+## async/await
 
 So far we have explored tasks that are started and run in isolation, with no regard for their return value. However, sometimes it is useful to run a task to compute a value and read its result later on. For this, tasks also provide the `async/await` pattern:
 
@@ -112,7 +110,7 @@ res + Task.await(task)
 
 `async/await` provides a very simple mechanism to compute values concurrently. Not only that, `async/await` can also be used with the same [`Task.Supervisor`](/docs/stable/elixir/Task.Supervisor.html) we have used in previous chapters. We just need to call `Task.Supervisor.async/2` instead of `Task.Supervisor.start_child/2` and use `Task.await/2` to read the result later on.
 
-## 10.3 Distributed tasks
+## Distributed tasks
 
 Distributed tasks are exactly the same as supervised tasks. The only difference is that we pass the node name when spawning the task on the supervisor. Open up `lib/kv/supervisor.ex` from the `:kv` application. Let's add a task supervisor to the tree:
 
@@ -138,7 +136,7 @@ iex> Task.await(task)
 
 Our first distributed task is straightforward: it simply gets the name of the node the task is running on. With this knowledge in hand, let's finally write the routing code.
 
-## 10.4 Routing layer
+## Routing layer
 
 Create a file at `lib/kv/router.ex` with the following contents:
 
@@ -219,7 +217,7 @@ And now run tests with:
 
 Our test should successfuly pass. Excellent!
 
-## 10.5 Test filters and tags
+## Test filters and tags
 
 Although our tests pass, our testing structure is getting more complex. In particular, running tests with only `mix test` causes failures in our suite, since our test requires a connection to another node.
 
@@ -261,7 +259,7 @@ The `mix test` command also allows us to dynamically include and exclude tags. F
 
 You can read more about filters, tags and the default tags in [`ExUnit.Case` module documentation](/docs/stable/ex_unit/ExUnit.Case.html).
 
-## 10.6 Application environment and configuration
+## Application environment and configuration
 
 So far we have hardcoded the routing table into the `KV.Router` module. However, we would like to make the table dynamic. This allows us not only to configure development/test/production, but also to allow different nodes to run with different entries in the routing table. There is a feature of  <abbr title="Open Telecom Platform">OTP</abbr> that does exactly that: the application environment.
 
@@ -342,7 +340,7 @@ Finally, we have learned some new things in this chapter, and they could be appl
 
 * change and configure the `:kv_server` application to use the routing functionality instead of dispatching directly to the local `KV.Registry`. For `:kv_server` tests, you can make the routing table simply point to the current node itself
 
-## 10.7 Summing up
+## Summing up
 
 In this chapter we have built a simple router as a way to explore the distributed features of Elixir and the Erlang <abbr title="Virtual Machine">VM</abbr>, and learned how to configure its routing table. This is the last chapter in our Mix and  <abbr title="Open Telecom Platform">OTP</abbr> guide.
 

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Distributed tasks and configuration
-redirect_from: "/getting_started/mix_otp/10.html"
+redirect_from: /getting_started/mix_otp/10.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/docs-tests-and-pipelines.markdown
+++ b/getting-started/mix-otp/docs-tests-and-pipelines.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Docs, tests and pipelines
-redirect_from: "/getting_started/mix_otp/9.html"
+redirect_from: /getting_started/mix_otp/9.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/docs-tests-and-pipelines.markdown
+++ b/getting-started/mix-otp/docs-tests-and-pipelines.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 9 Docs, tests and pipelines
-guide: 9
+title: Docs, tests and pipelines
 redirect_from: "/getting_started/mix_otp/9.html"
 ---
 
@@ -31,7 +30,7 @@ OK
 
 After the parsing is done, we will update our server to dispatch the parsed commands to the `:kv` application we built previously.
 
-## 9.1 Doctests
+## Doctests
 
 On the language homepage, we mention that Elixir makes documentation a first-class citizen in the language. We have explored this concept many times throughout this guide, be it via `mix help` or by typing `h Enum` or another module in an IEx console.
 
@@ -163,7 +162,7 @@ iex> KVServer.Command.parse "GET shopping\r\n"
 
 You can read more about doctests in [the `ExUnit.DocTest` docs](/docs/stable/ex_unit/ExUnit.DocTest.html).
 
-## 9.2 Pipelines
+## Pipelines
 
 With our command parser in hand, we can finally start implementing the logic that runs the commands. Let's add a stub definition for this function for now:
 
@@ -291,7 +290,7 @@ With `pipe_matching/3` we can ask Elixir to pipe the value `x` from each step if
 
 Excellent! Feel free to read the [elixir-pipes](https://github.com/batate/elixir-pipes) project documentation to learn about other options for expressing pipelines. Let's continue moving forward with our server implementation.
 
-## 9.3 Running commands
+## Running commands
 
 The last step is to implement `KVServer.Command.run/1`, to run the parsed commands against the `:kv` application. Its implementation is shown below:
 

--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: ETS
-redirect_from: "/getting_started/mix_otp/6.html"
+redirect_from: /getting_started/mix_otp/6.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 6 ETS
-guide: 6
+title: ETS
 redirect_from: "/getting_started/mix_otp/6.html"
 ---
 
@@ -15,7 +14,7 @@ In this chapter we will learn about ETS (Erlang Term Storage), and how to use it
 
 > Warning! Don't use ETS as a cache prematurely! Log and analyze your application performance and identify which parts are bottlenecks, so you know *whether* you should cache, and *what* you should cache. This chapter is merely an example of how ETS can be used, once you've determined the need.
 
-## 6.1 ETS as a cache
+## ETS as a cache
 
 ETS allows us to store any Erlang/Elixir term in an in-memory table. Working with ETS tables is done via [erlang's `:ets` module](http://www.erlang.org/doc/man/ets.html):
 
@@ -196,7 +195,7 @@ The reason those failures are happening is because, for didactic purposes, we ha
 1. We are prematurely optimizing (by adding this cache layer)
 2. We are using `cast/2` (while we should be using `call/2`)
 
-## 6.2 Race conditions?
+## Race conditions?
 
 Developing in Elixir does not make your code free of race conditions. However, Elixir's simple abstractions where nothing is shared by default make it easier to spot a race condition's root cause.
 
@@ -370,7 +369,7 @@ end
 
 Note that we are using `KV.Registry` as name for the ETS table as well, which makes it convenient to debug, as it points to the module using it. ETS names and process names are stored in different registries, so there is no chance of conflicts.
 
-## 6.3 ETS as persistent storage
+## ETS as persistent storage
 
 So far we have created an ETS table during the registry initialization but we haven't bothered to close the table on registry termination. That's because the ETS table is "linked" (in a figure of speech) to the process that creates it. If that process dies, the table is automatically closed.
 

--- a/getting-started/mix-otp/genevent.markdown
+++ b/getting-started/mix-otp/genevent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: GenEvent
-redirect_from: "/getting_started/mix_otp/4.html"
+redirect_from: /getting_started/mix_otp/4.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/genevent.markdown
+++ b/getting-started/mix-otp/genevent.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 4 GenEvent
-guide: 4
+title: GenEvent
 redirect_from: "/getting_started/mix_otp/4.html"
 ---
 
@@ -13,7 +12,7 @@ In this chapter, we will explore GenEvent, another behaviour provided by Elixir 
 
 There are two events we are going to emit: one for every time a bucket is added to the registry and another when it is removed from it.
 
-## 4.1 Event managers
+## Event managers
 
 Let's start a new `iex -S mix` session and explore the GenEvent API a bit:
 
@@ -67,7 +66,7 @@ Therefore, `sync_notify/2` and `notify/2` are similar to `call/2` and `cast/2` i
 
 Be sure to check other functionality provided by GenEvent in its [module documentation](/docs/stable/elixir/GenEvent.html). For now we have enough knowledge to add an event manager to our application.
 
-## 4.2 Registry events
+## Registry events
 
 In order to emit events, we need to change the registry to work with an event manager. While we could automatically start the event manager when the registry is started, for example in the `init/1` callback, it is preferrable to pass the event manager pid/name to `start_link`, decoupling the start of the event manager from the registry.
 
@@ -187,7 +186,7 @@ The changes are straightforward. We now pass the event manager we received as an
 
 Run the test suite, and all tests should be green again.
 
-## 4.3 Event streams
+## Event streams
 
 One last functionality worth exploring from `GenEvent` is the ability to consume its events as a stream:
 

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -245,7 +245,7 @@ Observe that we were able to considerably change the server implementation witho
 
 Finally, different from the other callbacks, we have defined a "catch-all" clause for `handle_info/2` that discards any unknown message. To understand why, let's move on to the next section.
 
-## call, cast or info?
+## `call`, `cast` or `info`?
 
 So far we have used three callbacks: `handle_call/3`, `handle_cast/2` and `handle_info/2`. Deciding when to use each is straightforward:
 

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 3 GenServer
-guide: 3
+title: GenServer
 redirect_from: "/getting_started/mix_otp/3.html"
 ---
 
@@ -42,7 +41,7 @@ The registry needs to guarantee the dictionary is always up to date. For example
 
 We will use a [GenServer](/docs/stable/elixir/GenServer.html) to create a registry process that can monitor the bucket process. GenServers are the go-to abstraction for building generic servers in both Elixir and  <abbr title="Open Telecom Platform">OTP</abbr>.
 
-## 3.1 Our first GenServer
+## Our first GenServer
 
 A GenServer is implemented in two parts: the client API and the server callbacks, all in a single module. Create a new file at `lib/kv/registry.ex` with the following contents:
 
@@ -120,7 +119,7 @@ There are other tuple formats both `handle_call/3` and `handle_cast/2` callbacks
 
 For now, let's write some tests to guarantee our GenServer works as expected.
 
-## 3.2 Testing a GenServer
+## Testing a GenServer
 
 Testing a GenServer is not much different from testing an agent. We will spawn the server on a setup callback and use it throughout our tests. Create a file at `test/kv/registry_test.exs` with the following:
 
@@ -168,7 +167,7 @@ end
 
 In the example above, the new `handle_call/3` clause is returning the atom `:stop`, along side the reason the server is being stopped (`:normal`), the reply `:ok` and the server state.
 
-## 3.3 The need for monitoring
+## The need for monitoring
 
 Our registry is almost complete. The only remaining issue is that the registry may become stale if a bucket stops or crashes. Let's add a test to `KV.RegistryTest` that exposes this bug:
 
@@ -246,7 +245,7 @@ Observe that we were able to considerably change the server implementation witho
 
 Finally, different from the other callbacks, we have defined a "catch-all" clause for `handle_info/2` that discards any unknown message. To understand why, let's move on to the next section.
 
-## 3.4 call, cast or info?
+## call, cast or info?
 
 So far we have used three callbacks: `handle_call/3`, `handle_cast/2` and `handle_info/2`. Deciding when to use each is straightforward:
 
@@ -260,7 +259,7 @@ Since any message, including the ones sent via `send/2`, go to `handle_info/2`, 
 
 We don't need to worry about this for `handle_call/3` and `handle_cast/2` because these requests are only done via the `GenServer` API, so an unknown message is quite likely to be due to a developer mistake.
 
-## 3.5 Monitors or links?
+## Monitors or links?
 
 We have previously learned about links in the [Process chapter](/getting-started/processes.html). Now, with the registry complete, you may be wondering: when should we use monitors and when should we use links?
 

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: GenServer
-redirect_from: "/getting_started/mix_otp/3.html"
+redirect_from: /getting_started/mix_otp/3.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 1 Introduction to Mix
-guide: 1
+title: Introduction to Mix
 redirect_from: "/getting_started/mix_otp/1.html"
 ---
 
@@ -45,7 +44,7 @@ In this chapter, we will create our first project using Mix and explore differen
 >
 > If you have any questions or improvements to the guide, please let us know in [our mailing list](https://groups.google.com/d/forum/elixir-lang-talk) or [issues tracker](http://github.com/elixir-lang/elixir-lang.github.com/issues) respectively. Your input is really important to help us guarantee the guides are accessible and up to date!
 
-## 1.1 Our first project
+## Our first project
 
 When you install Elixir, besides getting the `elixir`, `elixirc` and `iex` executables, you also get an executable Elixir script named `mix`.
 
@@ -78,7 +77,7 @@ Let's take a brief look at those generated files.
 >
 > When using -S, elixir finds the script wherever it is in your PATH and executes it.
 
-## 1.2 Project compilation
+## Project compilation
 
 A file named `mix.exs` was generated inside our new project folder (`kv`) and its main responsibility is to configure our project. Let's take a look at it (comments removed):
 
@@ -129,7 +128,7 @@ Once the project is compiled, you can start an `iex` session inside the project 
 
     $ iex -S mix
 
-## 1.3 Running tests
+## Running tests
 
 Mix also generated the appropriate structure for running our project tests. Mix projects usually follow the convention of having a `<filename>_test.exs` file in the `test` directory for each file in the `lib` directory. For this reason, we can already find a `test/kv_test.exs` corresponding to our `lib/kv.ex` file. It doesn't do much at this point:
 
@@ -200,7 +199,7 @@ This shortcut will be extremely useful as we build our project, allowing us to q
 
 Finally, the stacktrace relates to the failure itself, giving information about the test and often the place the failure was generated from within the source files.
 
-## 1.4 Environments
+## Environments
 
 Mix supports the concept of "environments". They allow a developer to customize compilation and other options for specific scenarios. By default, Mix understands three environments:
 
@@ -225,7 +224,7 @@ Mix will default to the `:dev` environment, except for the `test` task that will
 
     $ MIX_ENV=prod mix compile
 
-## 1.5 Exploring
+## Exploring
 
 There is much more to Mix, and we will continue to explore it as we build our project. A [general overview is available on the Mix documentation](/docs/stable/mix/).
 

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Introduction to Mix
-redirect_from: "/getting_started/mix_otp/1.html"
+redirect_from: /getting_started/mix_otp/1.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Supervisor and Application
-redirect_from: "/getting_started/mix_otp/5.html"
+redirect_from: /getting_started/mix_otp/5.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -14,7 +14,7 @@ When things fail, your first reaction may be: "let's rescue those errors". But, 
 
 In this chapter, we are going to learn about supervisors and also about applications. We are going to create not one, but two supervisors, and use them to supervise our processes.
 
-## Our first Supervisor
+## Our first supervisor
 
 Creating a supervisor is not much different from creating a GenServer. We are going to define a module named `KV.Supervisor`, which will use the [Supervisor](/docs/stable/elixir/Supervisor.html) behaviour, inside the `lib/kv/supervisor.ex` file:
 

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 5 Supervisor and Application
-guide: 5
+title: Supervisor and Application
 redirect_from: "/getting_started/mix_otp/5.html"
 ---
 
@@ -15,7 +14,7 @@ When things fail, your first reaction may be: "let's rescue those errors". But, 
 
 In this chapter, we are going to learn about supervisors and also about applications. We are going to create not one, but two supervisors, and use them to supervise our processes.
 
-## 5.1 Our first Supervisor
+## Our first Supervisor
 
 Creating a supervisor is not much different from creating a GenServer. We are going to define a module named `KV.Supervisor`, which will use the [Supervisor](/docs/stable/elixir/Supervisor.html) behaviour, inside the `lib/kv/supervisor.ex` file:
 
@@ -66,7 +65,7 @@ When we started the supervisor tree, both the event manager and registry worker 
 
 In practice though, we rarely start the application supervisor manually. Instead it is started as part of the application callback.
 
-## 5.2 Understanding applications
+## Understanding applications
 
 We have been working inside an application this entire time. Every time we changed a file and ran `mix compile`, we could see `Generated kv.app` message in the compilation output.
 
@@ -88,7 +87,7 @@ It would be pretty boring to update this file manually every time we add a new m
 
 We can also configure the generated `.app` file by customizing the values returned by the `application/0` inside our `mix.exs` project file. We will get to that in upcoming chapters.
 
-### 5.2.1 Starting applications
+### Starting applications
 
 When we define an `.app` file, which is the application definition, we are able to start and stop the application as a whole. We haven't worried about this so far for two reasons:
 
@@ -126,7 +125,7 @@ Nothing really exciting happens but it shows how we can control our application.
 
 > When you run `iex -S mix`, it is equivalent to running `iex -S mix run`. So whenever you need to pass more options to mix when starting iex, it's just a matter of typing `mix run` and then passing any options the `run` command accepts. You can find more information about `run` by running `mix help run` in your shell.
 
-### 5.2.2 The application callback
+### The application callback
 
 Since we spent all this time talking about how applications are started and stopped, there must be a way to do something useful when the application starts. And indeed, there is!
 
@@ -168,7 +167,7 @@ iex> KV.Registry.lookup(KV.Registry, "shopping")
 
 Excellent!
 
-### 5.2.3 Projects or applications?
+### Projects or applications?
 
 Mix makes a distinction between projects and applications. Based on the current contents of our `mix.exs` file, we would say we have a Mix project that defines the `:kv` application. As we will see in later chapters, there are projects that don't define any application.
 
@@ -176,7 +175,7 @@ When we say "project," you should think about Mix. Mix is the tool that manages 
 
 When we talk about applications, we talk about  <abbr title="Open Telecom Platform">OTP</abbr>. Applications are the entities that are started and stopped as a whole by the runtime. You can learn more about applications in the [docs for the Application module](/docs/stable/elixir/Application.html), as well as by running `mix help compile.app` to learn more about the supported options in `def application`.
 
-## 5.3 Simple one for one supervisors
+## Simple one for one supervisors
 
 We have now successfully defined our supervisor which is automatically started (and stopped) as part of our application lifecycle.
 
@@ -310,7 +309,7 @@ end
 
 Those changes should be enough to make our tests pass! To complete our task, we just need to update our supervisor to also take the buckets supervisor as child.
 
-## 5.4 Supervision trees
+## Supervision trees
 
 In order to use the buckets supervisor in our application, we need to add it as a child of `KV.Supervisor`. Notice we are beginning to have supervisors that supervise other supervisors, forming so-called "supervision trees."
 

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Task and gen_tcp
-redirect_from: "/getting_started/mix_otp/8.html"
+redirect_from: /getting_started/mix_otp/8.html
 ---
 
 # {{ page.title }}

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 8 Task and gen_tcp
-guide: 8
+title: Task and gen_tcp
 redirect_from: "/getting_started/mix_otp/8.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/mix_otp/8.html"
 
 In this chapter, we are going to learn how to use [Erlang's `:gen_tcp` module](http://erlang.org/doc/man/gen_tcp.html) to serve requests. In future chapters we will expand our server so it can actually serve the commands. This will also provide a great opportunity to explore Elixir's `Task` module.
 
-## 8.1 Echo server
+## Echo server
 
 We will start our TCP server by first implementing an echo server. It will simply send a response with the text it received in the request. We will slowly improve our server until it is supervised and ready to handle multiple connections.
 
@@ -126,7 +125,7 @@ That's because we were expecting data from `:gen_tcp.recv/2` but the client clos
 
 For now there is a more important bug we need to fix: what happens if our TCP acceptor crashes? Since there is no supervision, the server dies and we won't be able to serve more requests, because it won't be restarted. That's why we must move our server inside a supervision tree.
 
-## 8.2 Tasks
+## Tasks
 
 We have learned about agents, generic servers, and event managers. They are all meant to work with multiple messages or manage state. But what do we use when we only need to execute some task and that is it?
 
@@ -174,7 +173,7 @@ Try to connect two telnet clients at the same time. When you do so, you will not
 
 It doesn't seem to work at all. That's because we are serving requests in the same process that are accepting connections. When one client is connected, we can't accept another client.
 
-## 8.3 Task supervisor
+## Task supervisor
 
 In order to make our server handle simultaneous connections, we need to have one process working as an acceptor that spawns other processes to serve requests. One solution would be to change:
 

--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Module attributes
-redirect_from: "/getting_started/14.html"
+redirect_from: /getting_started/14.html
 ---
 
 # {{ page.title }}

--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 14 Module attributes
-guide: 14
+title: Module attributes
 redirect_from: "/getting_started/14.html"
 ---
 
@@ -17,7 +16,7 @@ Module attributes in Elixir serve three purposes:
 
 Let's check each case, one by one.
 
-## 14.1 As annotations
+## As annotations
 
 Elixir brings the concept of module attributes from Erlang. For example:
 
@@ -80,7 +79,7 @@ You can take a look at the docs for [Module](/docs/stable/elixir/Module.html) fo
 
 This section covers built-in attributes. However, attributes can also be used by developers or extended by libraries to support custom behaviour.
 
-## 14.2 As constants
+## As constants
 
 Elixir developers will often use module attributes to be used as constants:
 
@@ -118,7 +117,7 @@ MyServer.second_data #=> 13
 
 Notice that reading an attribute inside a function takes a snapshot of its current value. In other words, the value is read at compilation time and not at runtime. As we are going to see, this makes attributes useful to be used as storage during module compilation.
 
-## 14.3 As temporary storage
+## As temporary storage
 
 One of the projects in the Elixir organization is [the `Plug` project](https://github.com/elixir-lang/plug), which is meant to be a common foundation for building web libraries and frameworks in Elixir.
 

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 8 Modules
-guide: 8
+title: Modules
 redirect_from: "/getting_started/8.html"
 ---
 
@@ -31,7 +30,7 @@ iex> Math.sum(1, 2)
 
 In the following sections, our examples are going to get a bit more complex, and it can be tricky to type them all in the shell. It's about time for us to learn how to compile Elixir code and also how to run Elixir scripts.
 
-## 8.1 Compilation
+## Compilation
 
 Most of the time it is convenient to write modules into files so they can be compiled and reused. Let's assume we have a file named `math.ex` with the following contents:
 
@@ -62,7 +61,7 @@ Elixir projects are usually organized into three directories:
 
 When working on actual projects, the build tool called `mix` will be responsible for compiling and setting up the proper paths for you. For learning purposes, Elixir also supports a scripted mode which is more flexible and does not generate any compiled artifacts.
 
-## 8.2 Scripted mode
+## Scripted mode
 
 In addition to the Elixir file extension `.ex`, Elixir also supports `.exs` files for scripting. Elixir treats both files exactly the same way, the only difference is in intention. `.ex` files are meant to be compiled while `.exs` files are used for scripting, without the need for compilation. For instance, we can create a file called `math.exs`:
 
@@ -82,7 +81,7 @@ And execute it as:
 
 The file will be compiled in memory and executed, printing "3" as the result. No bytecode file will be created. In the following examples, we recommend you write your code into script files and execute them as shown above.
 
-## 8.3 Named functions
+## Named functions
 
 Inside a module, we can define functions with `def/2` and private functions with `defp/2`. A function defined with `def/2` can be invoked from other modules while a private function can only be invoked locally.
 
@@ -123,7 +122,7 @@ Math.zero?([1,2,3])
 
 Giving an argument that does not match any of the clauses raises an error.
 
-## 8.4 Function capturing
+## Function capturing
 
 Throughout this tutorial, we have been using the notation `name/arity` to refer to functions. It happens that this notation can actually be used to retrieve a named function as a function type. Let's start `iex` and run the `math.exs` file defined above:
 
@@ -171,7 +170,7 @@ iex> fun.([1, [[2], 3]], [4, 5])
 
 `&List.flatten(&1, &2)` is the same as writing `fn(list, tail) -> List.flatten(list, tail) end`. You can read more about the capture operator `&` in [the `Kernel.SpecialForms` documentation](/docs/stable/elixir/Kernel.SpecialForms.html#&/1).
 
-## 8.5 Default arguments
+## Default arguments
 
 Named functions in Elixir also support default arguments:
 

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Modules
-redirect_from: "/getting_started/8.html"
+redirect_from: /getting_started/8.html
 ---
 
 # {{ page.title }}

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 4 Pattern matching
-guide: 4
+title: Pattern matching
 redirect_from: "/getting_started/4.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/4.html"
 
 In this chapter, we will show how the `=` operator in Elixir is actually a match operator and how to use it to pattern match inside data structures. Finally, we will learn about the pin operator `^` used to access previously bound values.
 
-## 4.1 The match operator
+## The match operator
 
 We have used the `=` operator a couple times to assign variables in Elixir:
 
@@ -42,7 +41,7 @@ iex> 1 = unknown
 
 Since there is no variable `unknown` previously defined, Elixir imagined you were trying to call a function named `unknown/0`, but such a function does not exist.
 
-## 4.2 Pattern matching
+## Pattern matching
 
 The match operator is not only used to match against simple values, but it is also useful for destructuring more complex data types. For example, we can pattern match on tuples:
 
@@ -119,7 +118,7 @@ iex> [0|list]
 
 Pattern matching allows developers to easily destructure data types such as tuples and lists. As we will see in following chapters, it is one of the foundations of recursion in Elixir and applies to other types as well, like maps and binaries.
 
-## 4.3 The pin operator
+## The pin operator
 
 Variables in Elixir can be rebound:
 

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Pattern matching
-redirect_from: "/getting_started/4.html"
+redirect_from: /getting_started/4.html
 ---
 
 # {{ page.title }}

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -4,7 +4,7 @@ title: Pattern matching
 redirect_from: /getting_started/4.html
 ---
 
-# {{ page.title }}
+# {{ page.title }}<span hidden>.</span>
 
 {% include toc.html %}
 

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Processes
-redirect_from: "/getting_started/11.html"
+redirect_from: /getting_started/11.html
 ---
 
 # {{ page.title }}

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 11 Processes
-guide: 11
+title: Processes
 redirect_from: "/getting_started/11.html"
 ---
 
@@ -15,7 +14,7 @@ Elixir's processes should not be confused with operating system processes. Proce
 
 In this chapter, we will learn about the basic constructs for spawning new processes, as well as sending and receiving messages between different processes.
 
-## 11.1 spawn
+## spawn
 
 The basic mechanism for spawning new processes is with the auto-imported `spawn/1` function:
 
@@ -48,7 +47,7 @@ true
 
 Processes get much more interesting when we are able to send and receive messages.
 
-## 11.2 send and receive
+## send and receive
 
 We can send messages to a process with `send/2` and receive them with `receive/1`:
 
@@ -100,7 +99,7 @@ iex> flush()
 :ok
 ```
 
-## 11.3 Links
+## Links
 
 The most common form of spawning in Elixir is actually via `spawn_link/1`. Before we show an example with `spawn_link/1`, let's try to see what happens when a process fails:
 
@@ -141,7 +140,7 @@ While other languages would require us to catch/handle exceptions, in Elixir we 
 
 Before moving to the next chapter, let's see one of the most common use cases for creating processes in Elixir.
 
-## 11.4 Tasks
+## Tasks
 
 When making our processes crash in the previous section, you may have noticed the error messages were rather poor:
 
@@ -171,7 +170,7 @@ Besides providing better error logging, there are a couple other differences: `s
 
 We will explore those functionalities in the ***Mix and OTP guide***, for now it is enough to remember to use Tasks to get better logging.
 
-## 11.5 State
+## State
 
 We haven't talked about state so far in this guide. If you are building an application that requires state, for example, to keep your application configuration, or you need to parse a file and keep it in memory, where would you store it?
 

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -14,7 +14,7 @@ Elixir's processes should not be confused with operating system processes. Proce
 
 In this chapter, we will learn about the basic constructs for spawning new processes, as well as sending and receiving messages between different processes.
 
-## spawn
+## `spawn`
 
 The basic mechanism for spawning new processes is with the auto-imported `spawn/1` function:
 
@@ -47,7 +47,7 @@ true
 
 Processes get much more interesting when we are able to send and receive messages.
 
-## send and receive
+## `send` and `receive`
 
 We can send messages to a process with `send/2` and receive them with `receive/1`:
 

--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Protocols
-redirect_from: "/getting_started/16.html"
+redirect_from: /getting_started/16.html
 ---
 
 # {{ page.title }}

--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -116,9 +116,9 @@ end
 
 If desired, you could come up with your own semantics for a user being blank. Not only that, you could use structs to build more robust data types, like queues, and implement all relevant protocols, such as `Enumerable` and possibly `Blank`, for this data type.
 
-In many cases though, developers may want to provide a default implementation for structs, as explicitly implementing the protocol for all structs can be tedious. That's when falling back to Any comes in handy.
+In many cases though, developers may want to provide a default implementation for structs, as explicitly implementing the protocol for all structs can be tedious. That's when falling back to `Any` comes in handy.
 
-## Falling back to Any
+## Falling back to `Any`
 
 It may be convenient to provide a default implementation for all types. This can be achieved by setting `@fallback_to_any` to `true` in the protocol definition:
 

--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 16 Protocols
-guide: 16
+title: Protocols
 redirect_from: "/getting_started/16.html"
 ---
 
@@ -84,7 +83,7 @@ iex> Blank.blank?("hello")
 ** (Protocol.UndefinedError) protocol Blank not implemented for "hello"
 ```
 
-## 16.1 Protocols and structs
+## Protocols and structs
 
 The power of Elixir's extensibility comes when protocols and structs are used together.
 
@@ -119,7 +118,7 @@ If desired, you could come up with your own semantics for a user being blank. No
 
 In many cases though, developers may want to provide a default implementation for structs, as explicitly implementing the protocol for all structs can be tedious. That's when falling back to Any comes in handy.
 
-## 16.2 Falling back to Any
+## Falling back to Any
 
 It may be convenient to provide a default implementation for all types. This can be achieved by setting `@fallback_to_any` to `true` in the protocol definition:
 
@@ -140,7 +139,7 @@ end
 
 Now all data types (including structs) that we have not implemented the `Blank` protocol for will be considered non-blank.
 
-## 16.3 Built-in protocols
+## Built-in protocols
 
 Elixir ships with some built-in protocols. In previous chapters, we have discussed the `Enum` module which provides many functions that work with any data structure that implements the `Enumerable` protocol:
 

--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Recursion
-redirect_from: "/getting_started/9.html"
+redirect_from: /getting_started/9.html
 ---
 
 # {{ page.title }}

--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -49,9 +49,9 @@ The second definition matches the pattern and has no guard so it will be execute
 Our `msg` is printed and `print_multiple_times/2` is called again this time with the second argument set to `1`.
 Because `n` is now set to `1`, the guard in our first definition of `print_multiple_times/2` evaluates to true, and we execute this particular definition. The `msg` is printed, and there is nothing left to execute.
 
-We defined `print_multiple_times/2` so that no matter what number is passed as the second argument it either triggers our first definition (known as a "base case") or it triggers our second definition which will ensure that we get exactly one step closer to our base case.
+We defined `print_multiple_times/2` so that no matter what number is passed as the second argument it either triggers our first definition (known as a _base case_) or it triggers our second definition which will ensure that we get exactly one step closer to our base case.
 
-## "Reduce" and "map" algorithms
+## Reduce and map algorithms
 
 Let's now see how we can use the power of recursion to sum a list of numbers:
 
@@ -82,7 +82,7 @@ sum_list [], 6
 
 When the list is empty, it will match the final clause which returns the final result of `6`.
 
-The process of taking a list and "reducing" it down to one value is known as a "reduce" algorithm and is central to functional programming.
+The process of taking a list and _reducing_ it down to one value is known as a _reduce algorithm_ and is central to functional programming.
 
 What if we instead want to double all of the values in our list?
 
@@ -100,7 +100,7 @@ end
 Math.double_each([1, 2, 3]) #=> [2, 4, 6]
 ```
 
-Here we have used recursion to traverse a list doubling each element and returning a new list. The process of taking a list and "mapping" over it is known as a "map" algorithm.
+Here we have used recursion to traverse a list doubling each element and returning a new list. The process of taking a list and _mapping_ over it is known as a _map algorithm_.
 
 Recursion and [tail call](http://en.wikipedia.org/wiki/Tail_call) optimization are an important part of Elixir and are commonly used to create loops. However, when programming in Elixir you will rarely use recursion as above to manipulate lists.
 

--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 9 Recursion
-guide: 9
+title: Recursion
 redirect_from: "/getting_started/9.html"
 ---
 
@@ -9,7 +8,7 @@ redirect_from: "/getting_started/9.html"
 
 {% include toc.html %}
 
-## 9.1 Loops through recursion
+## Loops through recursion
 
 Due to immutability, loops in Elixir (and in any functional programming language) are written differently from imperative languages. For example, in an imperative language (like C in the following example), one would write:
 
@@ -52,7 +51,7 @@ Because `n` is now set to `1`, the guard in our first definition of `print_multi
 
 We defined `print_multiple_times/2` so that no matter what number is passed as the second argument it either triggers our first definition (known as a "base case") or it triggers our second definition which will ensure that we get exactly one step closer to our base case.
 
-## 9.2 "Reduce" and "map" algorithms
+## "Reduce" and "map" algorithms
 
 Let's now see how we can use the power of recursion to sum a list of numbers:
 

--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Sigils
-redirect_from: "/getting_started/18.html"
+redirect_from: /getting_started/18.html
 ---
 
 # {{ page.title }}

--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 18 Sigils
-guide: 18
+title: Sigils
 redirect_from: "/getting_started/18.html"
 ---
 
@@ -15,7 +14,7 @@ One of Elixir's goals is extensibility: developers should be able to extend the 
 
 In this chapter, we are going to explore sigils, which are one of the mechanisms provided by the language for working with textual representations. Sigils start with the tilde (`~`) character which is followed by a letter (which identifies the sigil) and then a delimiter; optionally, modifiers can be added after the final delimiter.
 
-## 18.1 Regular expressions
+## Regular expressions
 
 The most common sigil in Elixir is `~r`, which is used to create [regular expressions](https://en.wikipedia.org/wiki/Regular_Expressions):
 
@@ -55,11 +54,11 @@ So far, all examples have used `/` to delimit a regular expression. However sigi
 
 The reason behind supporting different delimiters is that different delimiters can be more suited for different sigils. For example, using parentheses for regular expressions may be a confusing choice as they can get mixed with the parentheses inside the regex. However, parentheses can be handy for other sigils, as we will see in the next section.
 
-## 18.2 Strings, char lists and words sigils
+## Strings, char lists and words sigils
 
 Besides regular expressions, Elixir ships with three other sigils.
 
-### 18.2.1 Strings
+### Strings
 
 The `~s` sigil is used to generate strings, like double quotes are. The `~s` sigil is useful, for example, when a string contains both double and single quotes:
 
@@ -68,7 +67,7 @@ iex> ~s(this is a string with "double" quotes, not 'single' ones)
 "this is a string with \"double\" quotes, not 'single' ones"
 ```
 
-### 18.2.2 Char lists
+### Char lists
 
 The `~c` sigil is used to generate char lists:
 
@@ -77,7 +76,7 @@ iex> ~c(this is a char list containing 'single quotes')
 'this is a char list containing \'single quotes\''
 ```
 
-### 18.2.3 Word lists
+### Word lists
 
 The `~w` sigil is used to generate lists of words (*words* are just regular strings). Inside the `~w` sigil, words are separated by whitespace.
 
@@ -93,7 +92,7 @@ iex> ~w(foo bar bat)a
 [:foo, :bar, :bat]
 ```
 
-## 18.3 Interpolation and escaping in sigils
+## Interpolation and escaping in sigils
 
 Besides lowercase sigils, Elixir supports uppercase sigils to deal with escaping characters and interpolation. While both `~s` and `~S` will return strings, the former allows escape codes and interpolation while the latter does not:
 
@@ -162,7 +161,7 @@ Converts double-quotes to single-quotes.
 def convert(...)
 ```
 
-## 18.4 Custom sigils
+## Custom sigils
 
 As hinted at the beginning of this chapter, sigils in Elixir are extensible. In fact, using the sigil `~r/foo/i` is equivalent to calling the `sigil_r` function with a binary and a char list as argument:
 

--- a/getting-started/struct.markdown
+++ b/getting-started/struct.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 15 Structs
-guide: 15
+title: Structs
 redirect_from: "/getting_started/15.html"
 ---
 
@@ -22,7 +21,7 @@ iex> %{map | a: 3}
 
 Structs are extensions built on top of maps that provide compile-time checks and default values.
 
-## 15.1 Defining structs
+## Defining structs
 
 To define a struct, the `defstruct` construct is used:
 
@@ -52,7 +51,7 @@ iex> %User{oops: :field}
 ** (CompileError) iex:3: unknown key :oops for struct User
 ```
 
-## 15.2 Accessing and updating structs
+## Accessing and updating structs
 
 When we discussed maps, we showed how we can access and update the fields of a map. The same techniques (and the same syntax) apply to structs as well:
 
@@ -80,7 +79,7 @@ iex> %User{} = %{}
 ** (MatchError) no match of right hand side value: %{}
 ```
 
-## 15.3 Structs are just bare maps underneath
+## Structs are just bare maps underneath
 
 In the example above, pattern matching works because underneath structs are just bare maps with a fixed set of fields. As maps, structs store a "special" field named `__struct__` that holds the name of the struct:
 

--- a/getting-started/struct.markdown
+++ b/getting-started/struct.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Structs
-redirect_from: "/getting_started/15.html"
+redirect_from: /getting_started/15.html
 ---
 
 # {{ page.title }}

--- a/getting-started/try-catch-and-rescue.markdown
+++ b/getting-started/try-catch-and-rescue.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 19 try, catch and rescue
-guide: 19
+title: try, catch and rescue
 redirect_from: "/getting_started/19.html"
 ---
 
@@ -11,7 +10,7 @@ redirect_from: "/getting_started/19.html"
 
 Elixir has three error mechanisms: errors, throws and exits. In this chapter we will explore each of them and include remarks about when each should be used.
 
-## 19.1 Errors
+## Errors
 
 Errors (or *exceptions*) are used when exceptional things happen in the code. A sample error can be retrieved by trying to add a number into an atom:
 
@@ -92,7 +91,7 @@ Many functions in the standard library follow the pattern of having a counterpar
 
 In Elixir, we avoid using `try/rescue` because **we don't use errors for control flow**. We take errors literally: they are reserved to unexpected and/or exceptional situations. In case you actually need flow control constructs, *throws* should be used. That's what we are going to see next.
 
-## 19.2 Throws
+## Throws
 
 In Elixir, a value can be thrown and later be caught. `throw` and `catch` are reserved for situations where it is not possible to retrieve a value unless by using `throw` and `catch`.
 
@@ -117,7 +116,7 @@ iex> Enum.find -50..50, &(rem(&1, 13) == 0)
 -39
 ```
 
-## 19.3 Exits
+## Exits
 
 All Elixir code runs inside processes that communicate with each other. When a process dies of "natural causes" (e.g., unhandled exceptions), it sends an `exit` signal. A process can also die by explicitly sending an exit signal:
 
@@ -146,7 +145,7 @@ Using `try/catch` is already uncommon and using it to catch exits is even more r
 
 It is exactly this supervision system that makes constructs like `try/catch` and `try/rescue` so uncommon in Elixir. Instead of rescuing an error, we'd rather "fail fast" since the supervision tree will guarantee our application will go back to a known initial state after the error.
 
-## 19.4 After
+## After
 
 Sometimes it's necessary to ensure that a resource is cleaned up after some action that could potentially raise an error. The `try/after` construct allows you to do that. For example, we can open a file and guarantee it will be closed (even if something goes wrong) with a `try/after` block:
 
@@ -161,7 +160,7 @@ iex> try do
 ** (RuntimeError) oops, something went wrong
 ```
 
-## 19.5 Variables scope
+## Variables scope
 
 It is important to bear in mind that variables defined inside `try/catch/rescue/after` blocks do not leak to the outer context. This is because the `try` block may fail and as such the variables may never be bound in the first place. In other words, this code is invalid:
 

--- a/getting-started/try-catch-and-rescue.markdown
+++ b/getting-started/try-catch-and-rescue.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: try, catch and rescue
-redirect_from: "/getting_started/19.html"
+redirect_from: /getting_started/19.html
 ---
 
 # {{ page.title }}

--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Typespecs and behaviours
-redirect_from: "/getting_started/20.html"
+redirect_from: /getting_started/20.html
 ---
 
 # {{ page.title }}

--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -1,7 +1,6 @@
 ---
 layout: getting-started
-title: 20 Typespecs and behaviours
-guide: 20
+title: Typespecs and behaviours
 redirect_from: "/getting_started/20.html"
 ---
 
@@ -9,14 +8,14 @@ redirect_from: "/getting_started/20.html"
 
 {% include toc.html %}
 
-## 20.1 Types and specs
+## Types and specs
 
 Elixir is a dynamically typed language, so all types in Elixir are inferred by the runtime. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
 
 1. declaring custom data types;
 2. declaring typed function signatures (specifications).
 
-### 20.1.1 Function specifications
+### Function specifications
 
 By default, Elixir provides some basic types, such as `integer` or `pid`, as well as more complex types: for example, the `round/1` function, which rounds a float to its nearest integer, takes a `number` as an argument (an `integer` or a `float`) and returns an `integer`. As you can see [in its documentation](http://elixir-lang.org/docs/stable/elixir/Kernel.html#round/1), `round/1`'s typed signature is written as:
 
@@ -33,7 +32,7 @@ def round(number), do: # implementation...
 
 Elixir supports compound types as well. For example, a list of integers has type `[integer]`. You can see all the types provided by Elixir [in the typespecs docs](http://elixir-lang.org/docs/stable/elixir/Kernel.Typespec.html).
 
-### 20.1.2 Defining custom types
+### Defining custom types
 
 While Elixir provides a lot of useful built-in types, it's convenient to define custom types when appropriate. This can be done when defining modules modules through the `@type` directive.
 
@@ -84,12 +83,12 @@ end
 
 If you want to keep a custom type private, you can use the `@typep` directive instead of `@type`.
 
-### 20.1.3 Static code analysis
+### Static code analysis
 
 Typespecs are not only useful to developers and as additional documentation. The Erlang tool [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html), for example, uses typespecs in order to perform static analysis of code. That's why, in the `PoliteCalculator` example, we wrote a spec for the `make_polite/1` function even if it was defined as a private function.
 
 
-## 20.2 Behaviours
+## Behaviours
 
 Many modules share the same public API. Take a look at [Plug](https://github.com/elixir-lang/plug), which, as it description states, is a **specification** for composable modules in web applications. Each *plug* is a module which **has to** implement at least two public functions: `init/1` and `call/2`.
 
@@ -100,7 +99,7 @@ Behaviors provide a way to:
 
 If you have to, you can think of behaviours like interfaces in object oriented languages like Java: a set of function signatures that a module has to implement.
 
-### 20.2.1 Defining behaviours
+### Defining behaviours
 
 Say we have want to implement a bunch of parsers, each parsing structured data: for example, a JSON parser and a YAML parser. Each of these two parsers will *behave* the same way: both will provide a `parse/1` function and a `extensions/0` function. The `parse/1` function will return an Elixir representation of the structured data, while the `extensions/0` function will return a list of file extensions that can be used for each type of data (e.g., `.json` for JSON files).
 
@@ -117,7 +116,7 @@ end
 
 Modules adopting the `Parser` behaviour will have to implement all the functions defined with `defcallback`. As you can see, `defcallback` expects a function name but also a function specification like the ones used with the `@spec` directive we saw above.
 
-### 20.2.2 Adopting behaviours
+### Adopting behaviours
 
 Adopting a behaviour is straightforward:
 

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -1,7 +1,7 @@
 ---
 layout: getting-started
 title: Where to go next
-redirect_from: "/getting_started/21.html"
+redirect_from: /getting_started/21.html
 ---
 
 # {{ page.title }}

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -1,8 +1,6 @@
 ---
 layout: getting-started
-title: 21 Where to go next
-guide: 21
-last: true
+title: Where to go next
 redirect_from: "/getting_started/21.html"
 ---
 
@@ -12,7 +10,7 @@ redirect_from: "/getting_started/21.html"
 
 Eager to learn more? Keep reading!
 
-## 21.1 Build your first Elixir project
+## Build your first Elixir project
 
 In order to get your first project started, Elixir ships with a build tool called Mix. You can get your new project started by simply running:
 
@@ -22,7 +20,7 @@ We have written a guide that covers how to build an Elixir application, with its
 
 * [Mix and OTP](/getting-started/mix-otp/introduction-to-mix.html)
 
-## 21.2 Community and other resources
+## Community and other resources
 
 On the sidebar, you can find links to Elixir books and screencasts. There are plenty of Elixir resources out there, like conference talks, open source projects, and other learning material produced by the community.
 
@@ -30,7 +28,7 @@ Remember that in case of any difficulties, you can always visit the **#elixir-la
 
 Don't forget that you can also check the [source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](/docs.html).
 
-## 21.3 A Byte of Erlang
+## A Byte of Erlang
 
 As the main page of this site puts it:
 

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -28,7 +28,7 @@ Remember that in case of any difficulties, you can always visit the **#elixir-la
 
 Don't forget that you can also check the [source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](/docs.html).
 
-## A Byte of Erlang
+## A byte of Erlang
 
 As the main page of this site puts it:
 


### PR DESCRIPTION
this removes the numbering from the headings (avoiding internal links to break over time)
and a lot of formatting fiddling in the Getting Started guide 