### PR TITLE
Rephrase a bit in `Docs, tests and pipelines` (Mix and OTP guide)

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-pipelines.markdown
+++ b/getting-started/mix-otp/docs-tests-and-pipelines.markdown
@@ -353,7 +353,7 @@ And our server functionality is almost complete! We just need to add tests. This
 
 `KVServer.Command.run/1`'s implementation is sending commands directly to the server named `KV.Registry`, which is registered by the `:kv` application. This means this server is global and if we have two tests sending messages to it at the same time, our tests will conflict with each other (and likely fail). We need to decide between having unit tests that are isolated and can run asynchronously, or writing integration tests that work on top of the global state, but exercise our application's full stack as it is meant to be exercised in production.
 
-So far we have been chosing the unit test approach. For example, in order to make `KVServer.Command.run/1` testable as a unit we would need to change its implementation to not send commands directly to the `KV.Registry` process but instead pass a server as argument. This means we would need to change `run`'s signature to `def run(command, pid)` and the implementation for the `:create` command would look like:
+So far we have only been using unit tests. However, in order to make `KVServer.Command.run/1` testable as a unit we would need to change its implementation to not send commands directly to the `KV.Registry` process but instead pass a server as argument. This means we would need to change `run`'s signature to `def run(command, pid)` and the implementation for the `:create` command would look like:
 
 ```elixir
 def run({:create, bucket}, pid) do


### PR DESCRIPTION
I noticed `choosing` had a spelling error.  But then I looked at it a bit more and thought it could use a bit of rephrasing in general in that sentence and the transition to the next.