### PR TITLE
Quick typo fix: successfuly -> successfully

### DIFF
--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -225,7 +225,7 @@ And now run tests with:
 $ elixir --sname foo -S mix test
 ```
 
-Our test should successfuly pass. Excellent!
+Our test should successfully pass. Excellent!
 
 ## Test filters and tags
 


### PR DESCRIPTION
Thanks for writing these comprehensive getting-started guides!