### PR TITLE
Several fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,4 +124,3 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  jekyll-redirect-from

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In order to run a development server (with live-reloading on) just run:
 $ bundle exec jekyll serve
 ```
 
-The generated site will be available at http://localhost:4000. You can stop the
+The generated site will be available at [http://localhost:4000](http://localhost:4000). You can stop the
 server with <kbd>Ctrl</kbd>-<kbd>C</kbd>.
 
 #### 5. Make your changes and push them

--- a/_includes/index-redirect.html
+++ b/_includes/index-redirect.html
@@ -57,7 +57,7 @@
   <body>
   {% unless custom_content %}
     <p><strong>The page you have requested has been moved.</strong></p>
-    <p>If you are not redirected automatically, visit <a href="{{redirect_to}}">/getting-started/{{redirect_to}}</a></p>
+    <p>If you are not redirected automatically, visit <a href="{{redirect_to}}">{{redirect_to}}</a></p>
     <script type="text/javascript">
       document.location.href = "{{redirect_to}}";
     </script>


### PR DESCRIPTION
- fix URL in index-redirect
- add anchor to localhost:4000 in README
- remove all plugin dependencies, except "github-pages": We shouldn't install anything, we should leave it all upto github-pages plugin, same as it happens in the github servers. 