### PR TITLE
add alchemist to the editor support

### DIFF
--- a/_includes/code-editor-support.html
+++ b/_includes/code-editor-support.html
@@ -2,6 +2,7 @@
   <h3 class="widget-title">Code editor support</h3>
   <ul>
     <li><a class="spec" href="https://github.com/elixir-lang/emacs-elixir">Emacs Mode</a></li>
+    <li><a class="spec" href="https://tonini.github.com/alchemist.el">Alchemist (Emacs Elixir Tooling)</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir-tmbundle">Textmate Bundle</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir">Vim Elixir</a></li>
     <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>


### PR DESCRIPTION
@josevalim We already had this discussion about adding it to the elixir-lang website and then it was not really a need.

But since Alchemist really getting to a decent point in case of usefulness I think it would be a good idea to add it.

What do you think?

Cheers

Samuel