### PR TITLE
docs, name variables consistently across iterations. [ci skip]

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -43,12 +43,12 @@ defp loop_acceptor(socket) do
   loop_acceptor(socket)
 end
 
-defp serve(client) do
-  client
+defp serve(socket) do
+  socket
   |> read_line()
-  |> write_line(client)
+  |> write_line(socket)
 
-  serve(client)
+  serve(socket)
 end
 
 defp read_line(socket) do


### PR DESCRIPTION
The method `defp serve(socket` is shown in a number of code
snippets. The first one uses a variable `client` while every later
version names that variable `socket`:

```
getting-started/mix-otp/docs-tests-and-pipelines.markdown:defp serve(socket) do
getting-started/mix-otp/docs-tests-and-pipelines.markdown:defp serve(socket) do
getting-started/mix-otp/docs-tests-and-pipelines.markdown:defp serve(socket) do
getting-started/mix-otp/task-and-gen-tcp.markdown:defp serve(client) do
getting-started/mix-otp/task-and-gen-tcp.markdown:  defp serve(socket) do
```