### PR TITLE
Clarify location of KV.Bucket.Supervisor

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -227,7 +227,7 @@ One possible solution to this issue would be to provide a `KV.Bucket.start/0`, t
 
 We are going to solve this issue by defining a new supervisor that will spawn and supervise all buckets. There is one supervisor strategy, called `:simple_one_for_one`, that is the perfect fit for such situations: it allows us to specify a worker template and supervise many children based on this template.
 
-Let's define our `KV.Bucket.Supervisor` as follows:
+Let's define our `KV.Bucket.Supervisor` in `lib/kv/bucket/supervisor.ex` as follows:
 
 ```elixir
 defmodule KV.Bucket.Supervisor do


### PR DESCRIPTION
Just a little thing. It isn't obvious where this module should be defined. I first tried putting it in `lib/kv/bucket.ex` but the lookup doesn't check there.