### PR TITLE
Minor grammar fix on processes

### DIFF
--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -76,7 +76,7 @@ iex> receive do
 
 A timeout of 0 can be given when you already expect the message to be in the mailbox.
 
-Let's put all together and send messages between processes:
+Let's put it all together and send messages between processes:
 
 ```iex
 iex> parent = self()


### PR DESCRIPTION
This is super minor, but I figured I'd correct it anyway.