### PR TITLE
Clarify that underscore would match if it were reached in execution.

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -45,7 +45,7 @@ iex> case {1, 2, 3} do
 ...>   {1, x, 3} when x > 0 ->
 ...>     "Will match"
 ...>   _ ->
-...>     "Won't match"
+...>     "Would match, if guard condition were not satisfied"
 ...> end
 "Will match"
 ```


### PR DESCRIPTION
In the first example for `case`, we learn that underscore "would match any value".
It's then confusing to read in the third example that underscore "won't match".
While this is technically true in the example as written, (since x>0, the first pattern will match,) it's not consistent with the earlier statement.