### PR TITLE
add element id v1.0 to fix issue with redcloth replacing Header ID

### DIFF
--- a/docs.markdown
+++ b/docs.markdown
@@ -26,6 +26,7 @@ Choose which version you want documentation for.
 * [Logger](/docs/master/logger/) - builtin Logger
 * [Mix](/docs/master/mix/) - build tool
 
+<span id="v1.0"></span>
 #### v1.0
 
 * [Elixir](/docs/v1.0/elixir/) - standard library


### PR DESCRIPTION
this fixes the issue of 
http://elixir-lang.org/docs/v1.0/
not linking properly to the HEADING