### PR TITLE
update url to use https. standardize erlang.org/doc links to use www

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This projects holds the contents for Elixir website hosted at elixir-lang.org.
 
-It is automatically transformed by [Jekyll](http://github.com/mojombo/jekyll) into a static site.
+It is automatically transformed by [Jekyll](https://github.com/mojombo/jekyll) into a static site.
 
 ## Contributing
 

--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -3,10 +3,10 @@
   <ul>
     <li><a class="spec" href="irc://irc.freenode.net/elixir-lang">#elixir-lang on freenode IRC</a></li>
     <li><a class="spec" href="http://elixir.meetup.com">Elixir meetups around the world</a></li>
-    <li><a class="spec" href="http://groups.google.com/group/elixir-lang-talk">elixir-talk mailing list (questions)</a></li>
-    <li><a class="spec" href="http://groups.google.com/group/elixir-lang-core">elixir-core mailing list (development)</a></li>
+    <li><a class="spec" href="https://groups.google.com/group/elixir-lang-talk">elixir-talk mailing list (questions)</a></li>
+    <li><a class="spec" href="https://groups.google.com/group/elixir-lang-core">elixir-core mailing list (development)</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/issues">Issue tracker</a></li>
-    <li><a class="spec" href="http://twitter.com/elixirlang">@elixirlang on Twitter</a></li>
+    <li><a class="spec" href="https://twitter.com/elixirlang">@elixirlang on Twitter</a></li>
   </ul>
 </div>
 

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -5,7 +5,7 @@
 </div>
 
 <div class="widget search">
-  <form method="get" class="search-form" action="http://www.google.com/search">
+  <form method="get" class="search-form" action="https://www.google.com/search">
 		<div>
 			<input class="search-text" type="text" name="q" placeholder="Search..." id="searchfield">
 			<input type="hidden" name="sitesearch" value="elixir-lang.org">

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -46,7 +46,7 @@
             <li class="menu-item learning"><a class="spec" href="/learning.html">Learning</a></li>
             <li class="menu-item docs"><a class="spec" href="/docs.html">Docs</a></li>
             <li class="menu-item blog"><a class="spec" href="/blog/">Blog</a></li>
-            <li class="menu-item packages"><a class="spec" href="http://hex.pm/">Packages</a></li>
+            <li class="menu-item packages"><a class="spec" href="https://hex.pm/">Packages</a></li>
           </ul>
         </div>
       </div>

--- a/_posts/2012-04-24-a-peek-inside-elixir-s-parallel-compiler.markdown
+++ b/_posts/2012-04-24-a-peek-inside-elixir-s-parallel-compiler.markdown
@@ -74,7 +74,7 @@ In order to customize this process, we are going to take a look at Erlang's erro
 
 ## Custom error handler
 
-By default, Elixir (and Erlang) code is autoloaded. This means that, if we invoke `List.delete` and the module `List` was not loaded yet, the Erlang VM is going to look into the `ebin` directory (the directory where we put compiled files) and try to load it. This process is controlled by the [`error_handler` module in Erlang](http://erlang.org/doc/man/error_handler.html) via two callback functions: `undefined_function` and `undefined_lambda`.
+By default, Elixir (and Erlang) code is autoloaded. This means that, if we invoke `List.delete` and the module `List` was not loaded yet, the Erlang VM is going to look into the `ebin` directory (the directory where we put compiled files) and try to load it. This process is controlled by the [`error_handler` module in Erlang](http://www.erlang.org/doc/man/error_handler.html) via two callback functions: `undefined_function` and `undefined_lambda`.
 
 As discussed in the previous section, we want to extend the error handler to actually stop the currently running process whenever a module is not found and resume the process only after we ensure the module is compiled. To do that, we can simply define our own error handler and ask Erlang to use it. Our custom error handler is defined as follows:
 

--- a/_posts/2012-05-25-elixir-v0-5-0-released.markdown
+++ b/_posts/2012-05-25-elixir-v0-5-0-released.markdown
@@ -37,9 +37,9 @@ With v0.5.0 finally out, we are committing to a stable syntax and a basic standa
 
 ## Looking forward
 
-There are still many, many things to do! In the next months, we will continue working on growing our community, talks and other documentation material. A huge thanks to [Alexei Sholik](http://twitter.com/true_droid) who is moving this area forward.
+There are still many, many things to do! In the next months, we will continue working on growing our community, talks and other documentation material. A huge thanks to [Alexei Sholik](https://twitter.com/true_droid) who is moving this area forward.
 
-We will also work on better integration and documentation on building Erlang systems. Erlang ships with the [Open Telecom Platform](http://en.wikipedia.org/wiki/Open_Telecom_Platform) which provides many tools to build distributed applications. In v0.5.0, all these tools are already available but we want to make the build process even simpler.
+We will also work on better integration and documentation on building Erlang systems. Erlang ships with the [Open Telecom Platform](https://en.wikipedia.org/wiki/Open_Telecom_Platform) which provides many tools to build distributed applications. In v0.5.0, all these tools are already available but we want to make the build process even simpler.
 
 In parallel, we will improve our [documentation generation tool](https://github.com/elixir-lang/ex_doc) and [build tool](https://github.com/elixir-lang/elixir/tree/master/lib/mix) which will likely be merged into core when they are solid enough.
 

--- a/_posts/2012-08-01-elixir-v0-6-0-released.markdown
+++ b/_posts/2012-08-01-elixir-v0-6-0-released.markdown
@@ -19,8 +19,8 @@ When [we released version v0.5.0](/blog/2012/05/25/elixir-v0-5-0-released/), we 
 
 Our interactive shell (IEx) also had many improvements, thanks to the Elixir developer community. We now have easy access to documentation, remote shells, autocomplete and much more. In order to show you a bit of what you can do in this release, we have prepared a short (~6 min) screencast:
 
-<iframe src="http://player.vimeo.com/video/46709928" class="video" width="600" height="337" allowfullscreen></iframe>
-<a href="http://vimeo.com/46709928">Elixir v0.6 quick tour - Mix and IEx</a> from <a href="http://vimeo.com/user3182384">Plataformatec</a> on <a href="http://vimeo.com">Vimeo</a>.
+<iframe src="https://player.vimeo.com/video/46709928" class="video" width="600" height="337" allowfullscreen></iframe>
+<a href="https://vimeo.com/46709928">Elixir v0.6 quick tour - Mix and IEx</a> from <a href="https://vimeo.com/user3182384">Plataformatec</a> on <a href="https://vimeo.com">Vimeo</a>.
 
 That's it. For the next months, we will continue improving Elixir (you can see some ideas floating around in the [issues tracker](https://github.com/elixir-lang/elixir/issues)) but we will start to focus on other tools and libraries for the community.
 

--- a/_posts/2012-11-18-elixir-v0-7-1-released.markdown
+++ b/_posts/2012-11-18-elixir-v0-7-1-released.markdown
@@ -13,7 +13,7 @@ This is a minor release that contains a couple enhancements regarding UTF-8, [di
 
 During this time traveling around, we have spoken at many conferences, as [Strange Loop](http://thestrangeloop.com/), [Øredev](http://oredev.org/), [QCon SP](http://qconsp.com/) and [Rupy](http://rupy.eu/) as well as at different companies. Developers from different backgrounds have shown interest in Elixir, [written about it](http://spin.atomicobject.com/2012/10/31/elixir-erlang-and-the-dining-philosophers/), joined us at #elixir-lang on freenode and contributed to the language. As of today, Elixir is powered by 51 different contributors!
 
-In case you missed any of those conferences, [the talk I presented at Øredev is available and you can watch it now](http://vimeo.com/53221562). The slides are also available below.
+In case you missed any of those conferences, [the talk I presented at Øredev is available and you can watch it now](https://vimeo.com/53221562). The slides are also available below.
 
 If you want to hear more about Elixir at a conference or an event, please let us know. Thank you and don't forget to [give Elixir a try](/getting-started/introduction.html)!
 

--- a/_posts/2013-05-02-elixir-on-xen.markdown
+++ b/_posts/2013-05-02-elixir-on-xen.markdown
@@ -18,7 +18,7 @@ You can learn more about Xen and the LING VM on the [Erlang on Xen website](http
 
 ## Getting started
 
-In order to run Elixir on the LING VM, you need to produce a Xen image of your Elixir project. This can be done with the help of the [lingex project](http://github.com/maximk/lingex), created by the LING VM team.
+In order to run Elixir on the LING VM, you need to produce a Xen image of your Elixir project. This can be done with the help of the [lingex project](https://github.com/maximk/lingex), created by the LING VM team.
 
 Producing an Elixir image using the free Erlang on Xen Build Service requires just a few steps:
 

--- a/_posts/2013-05-23-elixir-v0-9-0-released.markdown
+++ b/_posts/2013-05-23-elixir-v0-9-0-released.markdown
@@ -6,7 +6,7 @@ category: Releases
 excerpt: Elixir v0.9.0 is released with support for reducers, umbrella projects, faster compilation times and dropped support for R15 and earlier OTP versions.
 ---
 
-While [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir) was being announced, we have been working on Elixir v0.9.0 which is finally out. This release contains new features, important performance optimizations and bug fixes.
+While [Programming Elixir](https://pragprog.com/book/elixir/programming-elixir) was being announced, we have been working on Elixir v0.9.0 which is finally out. This release contains new features, important performance optimizations and bug fixes.
 
 Elixir v0.9.0 also removes support for Erlang R15 and earlier versions. In case you still need to run Elixir software on R15, we have also released Elixir v0.8.3, which contains many of the enhancements in v0.9.0. Check the [CHANGELOG for more details for both releases](https://github.com/elixir-lang/elixir/blob/v0.9.0/CHANGELOG.md).
 
@@ -130,4 +130,4 @@ We have also many other smaller improvements:
 
 A huge thank you to our community for sending bug reports, providing bug fixes and contributing all those amazing features. And when are **you** joining us? :)
 
-Give Elixir a try! You can start with our [getting started guide](/getting-started/introduction.html), or [check this 30 minute video from PragProg](http://www.youtube.com/watch?v=a-off4Vznjs&feature=youtu.be) or buy the beta version of [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir).
+Give Elixir a try! You can start with our [getting started guide](/getting-started/introduction.html), or [check this 30 minute video from PragProg](https://www.youtube.com/watch?v=a-off4Vznjs&feature=youtu.be) or buy the beta version of [Programming Elixir](https://pragprog.com/book/elixir/programming-elixir).

--- a/_posts/2013-08-08-elixir-design-goals.markdown
+++ b/_posts/2013-08-08-elixir-design-goals.markdown
@@ -6,7 +6,7 @@ category: Internals
 excerpt: Highlight of Elixir design goals.
 ---
 
-During the last year, we have spoken at many conferences spreading the word about Elixir. We [usually started with introducing the Erlang VM](http://vimeo.com/53221562), then went on to talk about Elixir goals, saving some time at the end to do a live demo, showing some goodies like exchanging information between remote nodes and even hot code swapping.
+During the last year, we have spoken at many conferences spreading the word about Elixir. We [usually started with introducing the Erlang VM](https://vimeo.com/53221562), then went on to talk about Elixir goals, saving some time at the end to do a live demo, showing some goodies like exchanging information between remote nodes and even hot code swapping.
 
 This post is a summary of those talks, focusing on the language goals: compatibility, productivity and extensibility.
 

--- a/_posts/2014-04-21-elixir-v0-13-0-released.markdown
+++ b/_posts/2014-04-21-elixir-v0-13-0-released.markdown
@@ -8,7 +8,7 @@ excerpt: "Elixir v0.13.0 comes with substantial improvements to the language: ma
 
 Hello folks!
 
-Elixir v0.13.0 has been released. It contains changes that will effectively shape how developers will write Elixir code from now on, making it an important milestone towards v1.0! On this post we are going to cover some of those changes, the road to Elixir v1.0, as well as the announcement of [hex.pm](http://hex.pm).
+Elixir v0.13.0 has been released. It contains changes that will effectively shape how developers will write Elixir code from now on, making it an important milestone towards v1.0! On this post we are going to cover some of those changes, the road to Elixir v1.0, as well as the announcement of [hex.pm](https://hex.pm).
 
 Before we go into the changes, let's briefly talk about ElixirConf!
 
@@ -261,7 +261,7 @@ Dependencies now are also automatically compiled before you run a command. For e
 
 ## hex.pm
 
-This release also marks the announcement of [hex.pm](http://hex.pm/), a package manager for the Erlang VM. Hex allows you to package and publish your projects while fetching them and performing dependency resolution in your applications.
+This release also marks the announcement of [hex.pm](https://hex.pm/), a package manager for the Erlang VM. Hex allows you to package and publish your projects while fetching them and performing dependency resolution in your applications.
 
 Currently Hex only integrates with Mix and contributions to extend it to other tools and other languages in the Erlang VM are welcome!
 
@@ -269,14 +269,14 @@ Currently Hex only integrates with Mix and contributions to extend it to other t
 
 As seen in this announcement, this release dictates many of the developments that will happen in Elixir and its community in the following weeks. All projects are recommended to start moving from records to structs, paving the way for the deprecation of records before 1.0.
 
-The next months will also focus on integrating Elixir more tightly to OTP. During the keynote at Erlang Factory, [Catalyse Change](http://www.youtube.com/watch?v=Djv4C9H9yz4), Dave Thomas and I argued that there are many useful patterns, re-implemented everyday by developers, that could make development more productive within the Erlang VM if exposed accordingly.
+The next months will also focus on integrating Elixir more tightly to OTP. During the keynote at Erlang Factory, [Catalyse Change](https://www.youtube.com/watch?v=Djv4C9H9yz4), Dave Thomas and I argued that there are many useful patterns, re-implemented everyday by developers, that could make development more productive within the Erlang VM if exposed accordingly.
 
 That said, in the next months we plan to:
 
 * Integrate applications configuration (provided by OTP) right into Mix;
 * Provide an Elixir logger that knows how to print and format Elixir exceptions and stacktraces;
 * Properly expose the functionality provided by Applications, Supervisors, GenServers and GenEvents and study how they can integrate with Elixir. For example, how to consume events from GenEvent as a [stream of data](/docs/stable/elixir/#!Stream.html)?
-* Study how patterns like tasks and agents can be integrated into the language, often picking up the lessons learned by libraries like [e2](http://e2project.org/erlang.html) and [functionality exposed by OTP itself](http://erlang.org/doc/man/rpc.html);
+* Study how patterns like tasks and agents can be integrated into the language, often picking up the lessons learned by libraries like [e2](http://e2project.org/erlang.html) and [functionality exposed by OTP itself](http://www.erlang.org/doc/man/rpc.html);
 * Rewrite the Mix and ExUnit guides to focus on applications and OTP as a whole, rebranding it to "Building Apps with Mix and OTP";
 
-You can learn more about Elixir in our [Getting Started guide](/getting-started/introduction.html) and download this release in the [v0.13 announcement](https://github.com/elixir-lang/elixir/releases/tag/v0.13.0). We hope to see you at [ElixirConf](http://elixirconf.com/) as well as pushing your packages to [hex.pm](http://hex.pm/).
+You can learn more about Elixir in our [Getting Started guide](/getting-started/introduction.html) and download this release in the [v0.13 announcement](https://github.com/elixir-lang/elixir/releases/tag/v0.13.0). We hope to see you at [ElixirConf](http://elixirconf.com/) as well as pushing your packages to [hex.pm](https://hex.pm/).

--- a/_posts/2014-08-07-elixir-v0-15-0-released.markdown
+++ b/_posts/2014-08-07-elixir-v0-15-0-released.markdown
@@ -29,7 +29,7 @@ By default, the code above will log the following message to your console:
 10:27:39.083 [debug] hello
 ```
 
-Logger provides multiple backends to where messages are logged. For now Elixir ships only with a console backend but there are developers already working on file (with support to external log rotation) and [syslog](http://en.wikipedia.org/wiki/Syslog) backends.
+Logger provides multiple backends to where messages are logged. For now Elixir ships only with a console backend but there are developers already working on file (with support to external log rotation) and [syslog](https://en.wikipedia.org/wiki/Syslog) backends.
 
 When we started Logger, the main objective was to translate Erlang messages into Elixir, so terms are formatted in Elixir syntax. Before this release, the following code
 
@@ -74,7 +74,7 @@ As soon as we started working on Logger, we realized we could go further than si
   * Custom translators: so you can translate log messages coming from any Erlang application into Elixir syntax
   * Metadata: metadata allows developers to store information in the current process that will be available to all logged messages. For example, a web application can generate a `request_id`, store it as metadata, and all messages logged during that request will be properly identified with `request_id=...` in the log
 
-We have also relied a lot on the [research and work done by Andrew Thompson and the folks at Basho behind Lager](http://www.youtube.com/watch?v=8BNpOHFvg_Q) to ensure our logger is performant and robust. On this front, Logger
+We have also relied a lot on the [research and work done by Andrew Thompson and the folks at Basho behind Lager](https://www.youtube.com/watch?v=8BNpOHFvg_Q) to ensure our logger is performant and robust. On this front, Logger
 
   * alternates between sync and async modes when logging messages to keep it performant when required but also apply back-pressure when under stress
   * formats and truncates messages on the client to avoid clogging the backends
@@ -142,7 +142,7 @@ We also would like to thank [Anthony Grimes](https://github.com/raynes) for the 
 
 ## Elixir Web Installer for Windows
 
-At the beginning of this summer, [Chris Hyndman](http://github.com/chyndman) joined us as a Google Summer of Code student to help us improve the Elixir story on Windows. Chris has been essential in:
+At the beginning of this summer, [Chris Hyndman](https://github.com/chyndman) joined us as a Google Summer of Code student to help us improve the Elixir story on Windows. Chris has been essential in:
 
   * Guaranteeing our test suite is green on Windows, fixing many bugs in the process;
   * [Documenting how to compile Elixir from source on Windows](https://github.com/elixir-lang/elixir/wiki/Windows)

--- a/_posts/2014-09-18-elixir-v1-0-0-released.markdown
+++ b/_posts/2014-09-18-elixir-v1-0-0-released.markdown
@@ -33,7 +33,7 @@ Elixir is composed of 6 applications, all under the same versioning constraints:
 
 With v1.0, we are providing a stable platform for the community to leverage and extend, and we are extremely excited with the projects and possibilities that are ahead of us!
 
-We hope the [Hex package manager](http://hex.pm) will be the home of many of those projects and remember the whole Erlang ecosystem is also available to Elixir developers.
+We hope the [Hex package manager](https://hex.pm) will be the home of many of those projects and remember the whole Erlang ecosystem is also available to Elixir developers.
 
 ## Expectations
 

--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -36,9 +36,9 @@ Before creating our new application, we must discuss how Mix handles dependencie
 
 ## External dependencies
 
-External dependencies are the ones not tied to your business domain. For example, if you need a HTTP API for your distributed KV application, you can use the [Plug](http://github.com/elixir-lang/plug) project as an external dependency.
+External dependencies are the ones not tied to your business domain. For example, if you need a HTTP API for your distributed KV application, you can use the [Plug](https://github.com/elixir-lang/plug) project as an external dependency.
 
-Installing external dependencies is simple. Most commonly, we use the [Hex Package Manager](http://hex.pm), by listing the dependency inside the deps function in our `mix.exs` file:
+Installing external dependencies is simple. Most commonly, we use the [Hex Package Manager](https://hex.pm), by listing the dependency inside the deps function in our `mix.exs` file:
 
 ```elixir
 def deps do
@@ -272,6 +272,6 @@ Here are a couple questions you can ask yourself when working with dependencies.
 * If no, use an umbrella project with umbrella children.
 * If yes, can this project be shared outside your company / organization?
   * If no, use a private git repository.
-  * If yes, push your code to a git repository and do frequent releases using [Hex](http://hex.pm).
+  * If yes, push your code to a git repository and do frequent releases using [Hex](https://hex.pm).
 
 With our umbrella project up and running, it is time to start writing our server.

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -92,7 +92,7 @@ From our quick exploration, we could conclude that we should simply use `Node.sp
 
 There are three better alternatives to `Node.spawn_link/2` that we could use in our implementation:
 
-1. We could use Erlang's [:rpc](http://erlang.org/doc/man/rpc.html) module to execute functions on a remote node. Inside the `bar@computer-name` shell above, you can call `:rpc.call(:"foo@computer-name", Hello, :world, [])` and it will print "hello world"
+1. We could use Erlang's [:rpc](http://www.erlang.org/doc/man/rpc.html) module to execute functions on a remote node. Inside the `bar@computer-name` shell above, you can call `:rpc.call(:"foo@computer-name", Hello, :world, [])` and it will print "hello world"
 
 2. We could have a server running on the other node and send requests to that node via the [GenServer](/docs/stable/elixir/#!GenServer.html) API. For example, you can call a remote named server using `GenServer.call({name, node}, arg)` or simply passing the remote process PID as first argument
 
@@ -362,4 +362,4 @@ In this chapter we have built a simple router as a way to explore the distribute
 
 Throughout the guide, we have built a very simple distributed key-value store as an opportunity to explore many constructs like generic servers, event managers, supervisors, tasks, agents, applications and more. Not only that, we have written tests for the whole application, got familiar with ExUnit, and learned how to use the Mix build tool to accomplish a wide range of tasks.
 
-If you are looking for a distributed key-value store to use in production, you should definitely look into [Riak](http://basho.com/riak/), which also runs in the Erlang <abbr title="Virtual Machine">VM</abbr>. In Riak, the buckets are replicated, to avoid data loss, and instead of a router, they use [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing) to map a bucket to a node. A consistent hashing algorithm helps reduce the amount of data that needs to be migrated when new nodes to store buckets are added to your infrastructure.
+If you are looking for a distributed key-value store to use in production, you should definitely look into [Riak](http://basho.com/riak/), which also runs in the Erlang <abbr title="Virtual Machine">VM</abbr>. In Riak, the buckets are replicated, to avoid data loss, and instead of a router, they use [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) to map a bucket to a node. A consistent hashing algorithm helps reduce the amount of data that needs to be migrated when new nodes to store buckets are added to your infrastructure.

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -42,7 +42,7 @@ In this chapter, we will create our first project using Mix and explore differen
 
 > Note: this guide requires Elixir v0.15.0 or later. You can check your Elixir version with `elixir -v` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting-started/introduction.html).
 >
-> If you have any questions or improvements to the guide, please let us know in [our mailing list](https://groups.google.com/d/forum/elixir-lang-talk) or [issues tracker](http://github.com/elixir-lang/elixir-lang.github.com/issues) respectively. Your input is really important to help us guarantee the guides are accessible and up to date!
+> If you have any questions or improvements to the guide, please let us know in [our mailing list](https://groups.google.com/d/forum/elixir-lang-talk) or [issues tracker](https://github.com/elixir-lang/elixir-lang.github.com/issues) respectively. Your input is really important to help us guarantee the guides are accessible and up to date!
 
 ## Our first project
 

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -8,7 +8,7 @@ redirect_from: /getting_started/mix_otp/8.html
 
 {% include toc.html %}
 
-In this chapter, we are going to learn how to use [Erlang's `:gen_tcp` module](http://erlang.org/doc/man/gen_tcp.html) to serve requests. In future chapters we will expand our server so it can actually serve the commands. This will also provide a great opportunity to explore Elixir's `Task` module.
+In this chapter, we are going to learn how to use [Erlang's `:gen_tcp` module](http://www.erlang.org/doc/man/gen_tcp.html) to serve requests. In future chapters we will expand our server so it can actually serve the commands. This will also provide a great opportunity to explore Elixir's `Task` module.
 
 ## Echo server
 
@@ -98,7 +98,7 @@ Start an IEx session inside the `kv_server` application with `iex -S mix`. Insid
 iex> KVServer.accept(4040)
 ```
 
-The server is now running, and you will even notice the console is blocked. Let's use [a `telnet` client](http://en.wikipedia.org/wiki/Telnet) to access our server. There are clients available on most operating systems, and their command lines are generally similar:
+The server is now running, and you will even notice the console is blocked. Let's use [a `telnet` client](https://en.wikipedia.org/wiki/Telnet) to access our server. There are clients available on most operating systems, and their command lines are generally similar:
 
 ```bash
 $ telnet 127.0.0.1 4040

--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -108,7 +108,7 @@ iex> Math.double_each([1, 2, 3]) #=> [2, 4, 6]
 
 Here we have used recursion to traverse a list doubling each element and returning a new list. The process of taking a list and _mapping_ over it is known as a _map algorithm_.
 
-Recursion and [tail call](http://en.wikipedia.org/wiki/Tail_call) optimization are an important part of Elixir and are commonly used to create loops. However, when programming in Elixir you will rarely use recursion as above to manipulate lists.
+Recursion and [tail call](https://en.wikipedia.org/wiki/Tail_call) optimization are an important part of Elixir and are commonly used to create loops. However, when programming in Elixir you will rarely use recursion as above to manipulate lists.
 
 The [`Enum` module](/docs/stable/elixir/#!Enum.html), which we're going to see in the next chapter, already provides many conveniences for working with lists. For instance, the examples above could be written as:
 

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -30,7 +30,7 @@ Elixir is an extensible and very customizable programming language thanks to its
 
 We have a [Learning](/learning.html) section that explores books, screencasts and other resources for learning Elixir and explore the ecosystem. There are also plenty of Elixir resources out there, like conference talks, open source projects, and other learning material produced by the community.
 
-Remember that in case of any difficulties, you can always visit the **#elixir-lang** channel on **irc.freenode.net** or send a message to the [mailing list](http://groups.google.com/group/elixir-lang-talk). You can be sure that there will be someone willing to help. To keep posted on the latest news and announcements, follow the [blog](/blog/) and follow the language development on the [elixir-core mailing list](http://groups.google.com/group/elixir-lang-core).
+Remember that in case of any difficulties, you can always visit the **#elixir-lang** channel on **irc.freenode.net** or send a message to the [mailing list](https://groups.google.com/group/elixir-lang-talk). You can be sure that there will be someone willing to help. To keep posted on the latest news and announcements, follow the [blog](/blog/) and follow the language development on the [elixir-core mailing list](https://groups.google.com/group/elixir-lang-core).
 
 Don't forget that you can also check the [source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](/docs.html).
 

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@ Finished in 0.04 seconds (0.04s on load, 0.00s on tests)
 1 tests, 0 failures
 {% endhighlight %}
 
-      <p>Mix is also able to manage dependencies and integrates nicely with the <a href="http://hex.pm/">Hex package manager</a>, which provides dependency resolution and the ability to remotely fetch packages.</p>
+      <p>Mix is also able to manage dependencies and integrates nicely with the <a href="https://hex.pm/">Hex package manager</a>, which provides dependency resolution and the ability to remotely fetch packages.</p>
     </div>
   </div>
 


### PR DESCRIPTION
* update URL where the used http link redirects to https, and as well when a package is provided and the https link is available.
* standardize erlang.org/doc links to use www