### PR TITLE
Amount/number grammar fix

### DIFF
--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -18,7 +18,7 @@ for(i = 0; i < array.length; i++) {
 }
 ```
 
-In the example above, we are mutating both the array and the variable `i`. Mutating is not possible in Elixir. Instead, functional languages rely on recursion: a function is called recursively until a condition is reached that stops the recursive action from continuing. No data is mutated in this process. Consider the example below that prints a string an arbitrary amount of times:
+In the example above, we are mutating both the array and the variable `i`. Mutating is not possible in Elixir. Instead, functional languages rely on recursion: a function is called recursively until a condition is reached that stops the recursive action from continuing. No data is mutated in this process. Consider the example below that prints a string an arbitrary number of times:
 
 ```elixir
 defmodule Recursion do


### PR DESCRIPTION
"times" in this case are countable (otherwise recursion would be pretty tough), so use "number" instead of "amount".