### PR TITLE
Promote default values to its own section

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -557,6 +557,8 @@ sum "a", "b"
 #=> "ab"
 ```
 
+### Default values
+
 In addition, Elixir allows for default values for arguments, whereas Erlang does not.
 
 ```elixir


### PR DESCRIPTION
I was trying to understand someone else's code and did not know what `\\` was for.

I had trouble finding this information. When I found it (I think I resorted to Sublime 'Find in files' on the docs repo because I knew it had to be here somewhere) then I wanted to link to it, and I couldn't.

Adding a section header will give it an anchor and make the info on the syntax for default values more prominent.
