### PR TITLE
Missing s character.

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -265,7 +265,7 @@ def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
   # 5. Delete from the ETS table instead of the HashDict
   {name, refs} = HashDict.pop(state.refs, ref)
   :ets.delete(state.names, name)
-  GenEvent.sync_notify(state.event, {:exit, name, pid})
+  GenEvent.sync_notify(state.events, {:exit, name, pid})
   {:noreply, %{state | refs: refs}}
 end
 ```


### PR DESCRIPTION
I ran into this and it was hard to find the bug, while going through the tutorial.

The error message was not very helpful for me:
(KeyError) key :event not found in: %{buckets: #PID<0.146.0>, events: #PID<0.147.0>, names: 340007, refs: #HashDict<[{#Reference<0.0.4.142>, "shopping"}]>}

I don't understand why it's missing an :event atom instead of an event variable?