### PR TITLE
pipe operator clarification

### DIFF
--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -56,7 +56,7 @@ The example above has a pipeline of operations. We start with a range and then m
 
 ### The pipe operator
 
-The `|>` symbol used in the snippet above is the **pipe operator**: it simply takes the output from the expression on its left side and passes it as the input to the function call on its right side. It's similar to the Unix `|` operator.  Its purpose is to highlight the flow of data being transformed by a series of functions. To see how it can make the code cleaner, have a look at the example above rewritten without using the `|>` operator:
+The `|>` symbol used in the snippet above is the **pipe operator**: it simply takes the output from the expression on its left side and passes it as the first argument to the function call on its right side. It's similar to the Unix `|` operator.  Its purpose is to highlight the flow of data being transformed by a series of functions. To see how it can make the code cleaner, have a look at the example above rewritten without using the `|>` operator:
 
 ```iex
 iex> Enum.sum(Enum.filter(Enum.map(1..100_000, &(&1 * 3)), odd?))


### PR DESCRIPTION
A couple coworkers of mine attended the Phoenix training in Austin last week. Prior to that their only Elixir experience was the getting started guide.

One if them mentioned this:

>By the way, about half-way through the second day of the training, Niko and I both had a revelation about understanding the `|>` operator...  The fact that it just passes the value in as the first argument.

>Watching the code and thinking about it, some of the time we passed 3 args, and then sometimes 2 args, and while we got what the pipe operator does (generally speaking), the code was still hard to follow until that revelation...

>The intro docs say "it simply takes the output from the expression on its left side and passes it as the input to the function call on its right side."

>But . . . that really doesn't make it clear.  Especially when a function has multiple arguments...  If they reworded that in the docs to say "it simply takes the output from the expression on its left side and passes it as the first argument to the function call on its right side." it would have made a world of difference in following code early on.

I double checked and the actual `Kernel.|>/2` docs say `This operator introduces the expression on the left as the first argument to the function call on the right.` so this just makes the getting started guide consistent with that.
