### PR TITLE
The :shutdown signal is sent automatically

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -146,7 +146,7 @@ end
 
 Our test should pass right out of the box!
 
-To shutdown the registry, we are simply sending a `:shutdown` signal to its process when our test finishes. While this solution is ok for tests, if there is a need to stop a `GenServer` as part of the application logic, it is best to define a `stop/1` function that sends a `call` message causing the server to stop:
+We don't need to explictly shut down the registry because it will receive a `:shutdown` signal when our test finishes. While this solution is ok for tests, if there is a need to stop a `GenServer` as part of the application logic, it is best to define a `stop/1` function that sends a `call` message causing the server to stop:
 
 ```elixir
   ## Client API


### PR DESCRIPTION
Working through the docs, I read "To shutdown the registry, we are simply sending a `:shutdown` signal to its process when our test finishes."

However the code doesn't have any explicit :shutdown signal being sent.  

@antipax explained on irc that this happens automatically.