### PR TITLE
Resolve ambiguous grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ serve_drinks User.get("John Doe")
 #=> Fails if the user is under 21
 {% endhighlight %}
 
-      <p>Elixir relies heavily on those features to ensure your software is working under the expected constraints. And when it is not, don't worry, supervisors got your back!</p>
+      <p>Elixir relies heavily on those features to ensure your software is working under the expected constraints. And when it is not, don't worry, supervisors have your back!</p>
     </div>
   </div>
 


### PR DESCRIPTION
This could have alternatively been changed to: `Supervisor's got your back!` However, it seemed more likely to me that it was intended to refer to supervisor processes and not the Supervisor module.