### PR TITLE
Use typographic punctuation throughout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,6 @@ markdown: redcarpet
 highlighter: pygments
 permalink: /blog/:year/:month/:day/:title/
 redcarpet:
-  extensions: ['with_toc_data', 'tables']
+  extensions: ['with_toc_data', 'tables', 'smart']
 gems:
   - jekyll-redirect-from

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ serve_drinks User.get("John Doe")
 #=> Fails if the user is under 21
 {% endhighlight %}
 
-      <p>Elixir relies heavily on those features to ensure your software is working under the expected constraints. And when it is not, don't worry, supervisors have your back!</p>
+      <p>Elixir relies heavily on those features to ensure your software is working under the expected constraints. And when it is not, don&rsquo;t worry, supervisors have your back!</p>
     </div>
   </div>
 
@@ -103,7 +103,7 @@ serve_drinks User.get("John Doe")
     <div class="entry-summary">
       <p>Elixir has been designed to be extensible, letting developers naturally extend the language to particular domains, in order to increase their productivity.</p>
 
-      <p>As an example, let's write a simple test case using <a href="/docs/stable/ex_unit/">Elixir's test framework called ExUnit</a>:</p>
+      <p>As an example, let&rsquo;s write a simple test case using <a href="/docs/stable/ex_unit/">Elixir&rsquo;s test framework called ExUnit</a>:</p>
 
 {% highlight elixir %}
 defmodule MathTest do
@@ -147,7 +147,7 @@ Finished in 0.04 seconds (0.04s on load, 0.00s on tests)
     <h4>Interactive development</h4>
 
     <div class="entry-summary">
-      <p>Tools like <a href="/docs/stable/iex/">IEx (Elixir's interactive shell)</a> are able to leverage many aspects of the language and platform to provide auto-complete, debugging tools, code reloading, as well as nicely formatted documentation:</p>
+      <p>Tools like <a href="/docs/stable/iex/">IEx (Elixir&rsquo;s interactive shell)</a> are able to leverage many aspects of the language and platform to provide auto-complete, debugging tools, code reloading, as well as nicely formatted documentation:</p>
 
 {% highlight text %}
 $ iex
@@ -163,7 +163,7 @@ iex> h IEx.pry             # Prints the documentation for IEx pry functionality
     <h4>Erlang compatible</h4>
 
     <div class="entry-summary">
-      <p>Elixir runs on the Erlang VM giving developers complete access to Erlang's ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="http://www.whatsapp.com">Whatsapp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
+      <p>Elixir runs on the Erlang VM giving developers complete access to Erlang&rsquo;s ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="http://www.whatsapp.com">Whatsapp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
 
 {% highlight iex %}
 iex> :crypto.md5("Using crypto from Erlang OTP")


### PR DESCRIPTION
This replaces typewriter quotation marks and apostrophes with typographic ones. It uses Redcarpet's _smart_ extension for markdown.

For example:

### They're "here."

would become:

### They&rsquo;re &ldquo;here.&rdquo;