### PR TITLE
Add a short documentation for `use`

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -118,6 +118,40 @@ In the example above, the imported `List.duplicate/2` is only visible within tha
 
 Note that `import`ing a module automatically `require`s it.
 
+## `use`
+
+`use` allows you to use a module in the current context. It `require`s the given module and then calls the `__using__/1` callback on it allowing the module to inject some code into the current context.
+
+```elixir
+defmodule Example do
+  use Feature, option: :value
+end
+```
+
+is compiled into
+
+```elixir
+defmodule Example do
+  require Feature
+  Feature.__using__(option: :value)
+end
+```
+
+For example, in order to write tests using the ExUnit framework, a developer should use the `ExUnit.Case` module:
+
+```elixir
+defmodule AssertionTest do
+  use ExUnit.Case, async: true
+
+  test "always pass" do
+    assert true
+  end
+end
+```
+
+By calling use, a hook called `__using__` will be invoked in `ExUnit.Case` which will then do the proper setup.
+
+
 ## Aliases
 
 At this point you may be wondering: what exactly an Elixir alias is and how is it represented?

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -191,9 +191,6 @@ end
 
 As we will see in later chapters, aliases also play a crucial role in macros, to guarantee they are hygienic.
 
-With this we are almost finishing our tour about Elixir modules. The last topic to cover is module attributes.
-
-
 ## `use`
 
 Although not a directive, `use` is a macro tightly related to `require` that allows you to use a module in the current context. It `require`s the given module and then calls the `__using__/1` callback on it allowing the module to inject some code into the current context.
@@ -226,4 +223,7 @@ end
 ```
 
 By calling use, a hook called `__using__` will be invoked in `ExUnit.Case` which will then do the proper setup.
+
+
+With this we are almost finishing our tour about Elixir modules. The last topic to cover is module attributes.
 

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -118,7 +118,6 @@ In the example above, the imported `List.duplicate/2` is only visible within tha
 
 Note that `import`ing a module automatically `require`s it.
 
-
 ## Aliases
 
 At this point you may be wondering: what exactly an Elixir alias is and how is it represented?

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -118,39 +118,6 @@ In the example above, the imported `List.duplicate/2` is only visible within tha
 
 Note that `import`ing a module automatically `require`s it.
 
-## `use`
-
-`use` allows you to use a module in the current context. It `require`s the given module and then calls the `__using__/1` callback on it allowing the module to inject some code into the current context.
-
-```elixir
-defmodule Example do
-  use Feature, option: :value
-end
-```
-
-is compiled into
-
-```elixir
-defmodule Example do
-  require Feature
-  Feature.__using__(option: :value)
-end
-```
-
-For example, in order to write tests using the ExUnit framework, a developer should use the `ExUnit.Case` module:
-
-```elixir
-defmodule AssertionTest do
-  use ExUnit.Case, async: true
-
-  test "always pass" do
-    assert true
-  end
-end
-```
-
-By calling use, a hook called `__using__` will be invoked in `ExUnit.Case` which will then do the proper setup.
-
 
 ## Aliases
 
@@ -226,3 +193,38 @@ end
 As we will see in later chapters, aliases also play a crucial role in macros, to guarantee they are hygienic.
 
 With this we are almost finishing our tour about Elixir modules. The last topic to cover is module attributes.
+
+
+## `use`
+
+Although not a directive, `use` is a macro tightly related to `require` that allows you to use a module in the current context. It `require`s the given module and then calls the `__using__/1` callback on it allowing the module to inject some code into the current context.
+
+```elixir
+defmodule Example do
+  use Feature, option: :value
+end
+```
+
+is compiled into
+
+```elixir
+defmodule Example do
+  require Feature
+  Feature.__using__(option: :value)
+end
+```
+
+For example, in order to write tests using the ExUnit framework, a developer should use the `ExUnit.Case` module:
+
+```elixir
+defmodule AssertionTest do
+  use ExUnit.Case, async: true
+
+  test "always pass" do
+    assert true
+  end
+end
+```
+
+By calling use, a hook called `__using__` will be invoked in `ExUnit.Case` which will then do the proper setup.
+

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -226,4 +226,3 @@ By calling use, a hook called `__using__` will be invoked in `ExUnit.Case` which
 
 
 With this we are almost finishing our tour about Elixir modules. The last topic to cover is module attributes.
-


### PR DESCRIPTION
I was reading the "Getting started" guide and one of the things I noticed is that the section where `require`, `alias` and `import` are documented doesn't include any explanation for `use`. In fact, `use` is not mentioned at all in the entire getting started guide.

I know [`import`, `require` and `alias` are `SpecialForm`](http://elixir-lang.org/docs/v1.1/elixir/Kernel.SpecialForms.html) whereas `use` is [defined as `Kernel` macro](http://elixir-lang.org/docs/v1.1/elixir/Kernel.html#use/2), however it's not uncommon to see new users confused by this specific keyword: see [here](http://stackoverflow.com/questions/28491306/elixir-use-vs-import) and [here](http://stackoverflow.com/questions/29097918/elixir-what-does-the-use-keyword-do).

This branch takes bits and pieces from the answers above and the [`use/2` documentation](http://elixir-lang.org/docs/v1.1/elixir/Kernel.html#use/2), and adds a new section in the "getting started" to explain the purpose of `use`.

What do you think?