### PR TITLE
Mandatory function head

### DIFF
--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -219,7 +219,7 @@ hello
 :ok
 ```
 
-If a function with default values has multiple clauses, it is recommended to create a function head (without an actual body), just for declaring defaults:
+If a function with default values has multiple clauses, it is required to create a function head (without an actual body) for declaring defaults:
 
 ```elixir
 defmodule Concat do


### PR DESCRIPTION
Body-less function head is required (not optional) for multiple clauses
with defaults. Without the head following error raised by compiler
```
== Compilation error on file lib/mnesia/key_gen.ex ==
** (CompileError) lib/mnesia/key_gen.ex:18: def slug/3 has default values and multiple clauses, define a function head with the defaults
    lib/mnesia/key_gen.ex:18: (module)
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
```