### PR TITLE
Update note about required Elixir version to match the Introduction guide

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -40,7 +40,7 @@ In order to build our key-value application, we are going to use three main tool
 
 In this chapter, we will create our first project using Mix and explore different features in  <abbr title="Open Telecom Platform">OTP</abbr>, Mix and ExUnit as we go.
 
-> Note: this guide requires Elixir v0.15.0 or later. You can check your Elixir version with `elixir -v` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting-started/introduction.html).
+> Note: this guide requires Elixir v1.0.0 or later. You can check your Elixir version with `elixir -v` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting-started/introduction.html).
 >
 > If you have any questions or improvements to the guide, please let us know in [our mailing list](https://groups.google.com/d/forum/elixir-lang-talk) or [issues tracker](https://github.com/elixir-lang/elixir-lang.github.com/issues) respectively. Your input is really important to help us guarantee the guides are accessible and up to date!
 


### PR DESCRIPTION
The Introduction guide sets Elixir version 1.0.0 as the minimum requirement, so the Mix Introduction guide should match the same required version - it's likely what users will have installed anyway.