### PR TITLE
Update fedora install instructions

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -35,6 +35,8 @@ Choose your operating system and tool.
     * Run: `emerge --ask dev-lang/elixir`
   * Fedora 17 and newer
     * Run: `yum install elixir`
+  * Fedora 22 and newer
+    * Run: `dnf install elixir`
   * FreeBSD
     * From ports: `cd /usr/ports/lang/elixir && make install clean`
     * From pkg: `pkg install elixir`


### PR DESCRIPTION
As `yum` is now replaced with `dnf`, the install instructions where not up to date.

It might be considered to remove the fedora 17 section all together, as only Fedora 21 packs it and older versions are [not maintained anymore.](https://fedoraproject.org/wiki/End_of_life?rd=LifeCycle/EOL). Fedora 21 EOL is in less than a week, december 1st.