### PR TITLE
Add IntelliJ Elixir to Code editor support

### DIFF
--- a/_includes/code-editor-support.html
+++ b/_includes/code-editor-support.html
@@ -8,5 +8,6 @@
     <li><a class="spec" href="https://github.com/elixir-lang/vim-elixir">Vim Elixir</a></li>
     <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>
     <li><a class="spec" href="https://github.com/lucasmazza/language-elixir">Atom Package</a></li>
+    <li><a class="spec" href="https://github.com/KronicDeth/intellij-elixir">IntelliJ Elixir</a></li>
   </ul>
 </div>


### PR DESCRIPTION
I just noticed there was a side-menu for editors, so adding my IntelliJ Elixir plugin to the list.