### PR TITLE
Modify anon func example to better match others

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -619,8 +619,7 @@ F({a, b}).
 **Elixir**
 
 ```elixir
-f = fn
-      {:a, :b} = tuple ->
+f = fn({:a, :b} = tuple) ->
         IO.puts "All your #{inspect tuple} are belong to us"
       [] ->
         "Empty"


### PR DESCRIPTION
The existing version is syntactically valid, but breaks with the usage of parens in all the other examples.