### PR TITLE
Fix getting started supervisor shutdown test

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -233,9 +233,11 @@ In other words, we want the registry to keep on running even if a bucket crashes
     KV.Registry.create(registry, "shopping")
     {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
 
-    # Kill the bucket and wait for the notification
+    # Stop the bucket with non-normal reason
     Process.exit(bucket, :shutdown)
-    assert_receive {:exit, "shopping", ^bucket}
+
+    # Do a sync to ensure the registry processed the down message
+    _ = KV.Registry.create(registry, "bogus")
     assert KV.Registry.lookup(registry, "shopping") == :error
   end
 ```


### PR DESCRIPTION
I have been going through the mix-otp guide and got stuck at the `removes bucket on crash` test. The `assert_receive` fails with the following:

```
  1) test removes bucket on crash (KV.RegistryTest)
     test/kv/registry_test.exs:26
     No message matching {:exit, "shopping", ^bucket} after 100ms.
     The following variables were pinned:
       bucket = #PID<0.117.0>
     The process mailbox is empty.
     stacktrace:
       test/kv/registry_test.exs:31
```

I am super new to Elixir (it is awesome, thank you!) so I may be way off on this, but from a bit of investigating I think that this example previously used `GenEvent` to deliver the :exit message that is being waited on, and there is no need to wait for notification now that `GenServers` have the `stop` function.