### PR TITLE
supervisor-and-application race condition - there is no way to handle…

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -236,8 +236,10 @@ In other words, we want the registry to keep on running even if a bucket crashes
     # Stop the bucket with non-normal reason
     Process.exit(bucket, :shutdown)
 
-    # Do a sync to ensure the registry processed the down message
-    _ = KV.Registry.create(registry, "bogus")
+    # The :DOWN message is handled asynchronously, so we don't  know if it has been handled yet, so give it a chance to run...
+    # We will fix this race condition in the next chapter
+    :timer.sleep(100)
+
     assert KV.Registry.lookup(registry, "shopping") == :error
   end
 ```


### PR DESCRIPTION
… in this chapter so a sleep (hack) is used and with a note to user. I can't think of any better solution, other than a spin-wait for the bucket to disappear. Otherwise you'd need to monitor the supervisor, or have it send another message when the DOWN message has been handled. 