### PR TITLE
Fix a typo in Getting Started

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -223,7 +223,7 @@ iex> if true, do: 1 + 2
 3
 ```
 
-Notice how the second example has a comma between `true` and `do:`, that's because it is using Elixir's regular syntax where each argument is separated by comma. We say this syntax is using **keyword lists**. We can pass `else` using keywords too:
+Notice how this example has a comma between `true` and `do:`, that's because it is using Elixir's regular syntax where each argument is separated by comma. We say this syntax is using **keyword lists**. We can pass `else` using keywords too:
 
 ```iex
 iex> if false, do: :this, else: :that


### PR DESCRIPTION
Guides says "second example" here, but there's only one ¯\\\_(ツ)\_/¯