### PR TITLE
Fixing typo in dependency paragraph

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -45,7 +45,7 @@ def deps do
 end
 ```
 
-This dependency refers to the latest version of Plug in the 0.5.x version series that has been pushed to Hex. This is indicated by the `~>` preceding the version number. For more information on specifying version requirements, see the [documentation for the Version module](/docs/stable/elixir/Version.html).
+This dependency refers to the latest version of Plug in the 1.0.x version series that has been pushed to Hex. This is indicated by the `~>` preceding the version number. For more information on specifying version requirements, see the [documentation for the Version module](/docs/stable/elixir/Version.html).
 
 Typically, stable releases are pushed to Hex. If you want to depend on an external dependency still in development, Mix is able to manage git dependencies too:
 


### PR DESCRIPTION
The code example of an external dependency was for `{:plug}, "~> 1.0"}`, but the text said that the dependency referred to the latest version of Plug in the 0.5.x version series, which I think is old and should be updated to reference the 1.0 version series.