### PR TITLE
Set width of the kv-observer image to fit better in the desktop

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -374,7 +374,7 @@ A GUI should pop-up containing all sorts of information about our system, from g
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:
 
-![Accessing the kv application in Observer](/images/contents/kv-observer.png)
+ <img src="/images/contents/kv-observer.png" width="640px">
 
 Not only that, as you create new buckets on the terminal, you should see new processes spawned in the supervision tree shown in Observer:
 


### PR DESCRIPTION
The way it its, the image's width is larger than its `<p>` container:

![image](https://cloud.githubusercontent.com/assets/2719/12234224/78eb9d52-b852-11e5-9e5c-e2acf656e091.png)

I just added a `width=640px` to the image so that it fits into its container:

![image](https://cloud.githubusercontent.com/assets/2719/12234235/8dde35c6-b852-11e5-99c2-2c17e8b130e9.png)
