### PR TITLE
Unnecessary 'it' removed

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -26,7 +26,7 @@ iex> :ets.lookup(table, "foo")
 [{"foo", #PID<0.41.0>}]
 ```
 
-When creating an ETS table, two arguments are required: the table name and a set of options. From the available options, we passed the table type and its access rules. We have chosen the `:set` type, which means that keys cannot be duplicated. We've also set the table's access to `:protected`, meaning only the process that created the table can write to it, but all processes can read it from it. Those are actually the default values, so we will skip them from now on.
+When creating an ETS table, two arguments are required: the table name and a set of options. From the available options, we passed the table type and its access rules. We have chosen the `:set` type, which means that keys cannot be duplicated. We've also set the table's access to `:protected`, meaning only the process that created the table can write to it, but all processes can read from it. Those are actually the default values, so we will skip them from now on.
 
 ETS tables can also be named, allowing us to access them by a given name:
 


### PR DESCRIPTION
I've interested in elixir about couple of weeks ago and reading through some books and elixir-lang website. I've encountered with this while reading about ETS. I thought the first `it` is unnecessary and removed it.
By the way, thank you for this nice language.