### PR TITLE
Patch to change 'and' to '\x26'on 'Getting Started#sigils' for better example

### DIFF
--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -98,8 +98,8 @@ Besides lowercase sigils, Elixir supports uppercase sigils to deal with escaping
 ```iex
 iex> ~s(String with escape codes \x26 #{"inter" <> "polation"})
 "String with escape codes & interpolation"
-iex> ~S(String without escape codes and without #{interpolation})
-"String without escape codes and without \#{interpolation}"
+iex> ~S(String without escape codes \x26 without #{interpolation})
+"String without escape codes \\x26 without \#{interpolation}"
 ```
 
 The following escape codes can be used in strings and char lists:


### PR DESCRIPTION
Here is what mentioned on #669, and this is why this pr is sent. :)
"""START"""
Hi. I have one suggestion about one example.

Here is example in [guide](http://elixir-lang.org/getting-started/sigils.html)
```iex
iex> ~s(String with escape codes \x26 #{"inter" <> "polation"})
"String with escape codes & interpolation"
iex> ~S(String without escape codes and without #{interpolation})
"String without escape codes and without \#{interpolation}"
```

This example give comparison between '~s' and '~S', meaning to say,
it may show interpolation and escape work or not clearly on both example.
And to me, this example intend to show how escape work with '\x26',
how interpolation work with '#{"inter" <> "polation"}'.
However, 'and' instead of '\x26' on the second example code, so only reader could see
is  '\#' instead of '#'.

Hence, my suggestion is this,
how about change 'and' to '\x26' like,

```iex
iex> ~s(String with escape codes \x26 #{"inter" <> "polation"})
"String with escape codes & interpolation"
iex> ~S(String without escape codes \x26 without #{interpolation})
"String without escape codes \\x26 without \#{interpolation}"
```

or If this is not intended, inverse is also enable. :)

Thanks in advance.
"""END"""