### PR TITLE
Update string guide

### DIFF
--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -55,7 +55,7 @@ iex> String.codepoints("hełło")
 ["h", "e", "ł", "ł", "o"]
 ```
 
-You will see that Elixir has excellent support for working with strings. It also supports many of the Unicode operations. In fact, Elixir passes all but the last test showcased in the article ["The string type is broken"](http://mortoray.com/2013/11/27/the-string-type-is-broken/).
+You will see that Elixir has excellent support for working with strings. It also supports many of the Unicode operations. In fact, Elixir passes all the tests showcased in the article ["The string type is broken"](http://mortoray.com/2013/11/27/the-string-type-is-broken/).
 
 However, strings are just part of the story. If a string is a binary, and we have used the `is_binary/1` function, Elixir must have an underlying type empowering strings. And it does. Let's talk about binaries!
 


### PR DESCRIPTION
Updated to indicate that `String` now passes all the tests in "The string type is broken" (as of Elixir 1.2).