### PR TITLE
Fix example code in distributed-tasks-and-configuration

### DIFF
--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -142,7 +142,7 @@ iex> Task.await(task)
 Our first distributed task simply retrieves the name of the node the task is running on. Notice we have given an anonymous function to `Task.Supervisor.async/2` but, in distributed cases, it is preferable to give the module, function and arguments explicitly:
 
 ```iex
-iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, [Kernel, :node, []]
+iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, Kernel, :node, []
 %Task{pid: #PID<12467.88.0>, ref: #Reference<0.0.0.400>}
 iex> Task.await(task)
 {:ok, :"foo@computer-name"}


### PR DESCRIPTION
Usage of `Task.Supervisor.async/4` is meant instead.

Result of running existing example

```
iex(bar@Christophs-MBP)1> Task.Supervisor.async {KV.RouterTasks, :"foo@Christophs-MBP"}, [Kernel, :node, []]
** (EXIT from #PID<0.101.0>) an exception was raised:
    ** (BadFunctionError) expected a function, got: [Kernel, :node, []]
        :erlang.apply/2
        (elixir) lib/task/supervised.ex:89: Task.Supervised.do_apply/2
        (elixir) lib/task/supervised.ex:40: Task.Supervised.reply/5
        (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3

Interactive Elixir (1.2.0) - press Ctrl+C to exit (type h() ENTER for help)
```

Result of running changed example

```
iex(bar@Christophs-MBP)2> Task.Supervisor.async {KV.RouterTasks, :"foo@Christophs-MBP"}, Kernel, :node, []
%Task{owner: #PID<0.144.0>, pid: #PID<12960.109.0>, ref: #Reference<0.0.8.533>}
```