### PR TITLE
Add `spawn_link` script output to example in processes

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -230,7 +230,7 @@ iex> if false, do: :this, else: :that
 :that
 ```
 
-`do/end` blocks are a syntatic convenience built on top of the keywords one. That's why `do/end` blocks do not require a comma between the previous argument the block. They are useful exactly because they remove the verbosity when writing blocks of code. These are equivalent:
+`do/end` blocks are a syntatic convenience built on top of the keywords one. That's why `do/end` blocks do not require a comma between the previous argument and the block. They are useful exactly because they remove the verbosity when writing blocks of code. These are equivalent:
 
 ```iex
 iex> if true do

--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -31,7 +31,7 @@ iex> Enum.reduce(1..3, 0, &+/2)
 
 The functions in the Enum module are limited to, as the name says, enumerating values in data structures. For specific operations, like inserting and updating particular elements, you may need to reach for modules specific to the data type. For example, if you want to insert an element at a given position in a list, you should use the `List.insert_at/3` function from [the `List` module](/docs/stable/elixir/List.html), as it would make little sense to insert a value into, for example, a range.
 
-We say the functions in the `Enum` module are polymorphic because they can work with diverse data types. In particular, the functions in the `Enum` module can work with any data type that implements [the `Enumerable` protocol](/docs/stable/elixir/Enumerable.html). We are going to discuss Protocols in a later chapter, for now we are going to move on to a specific kind of enumerable called streams.
+We say the functions in the `Enum` module are polymorphic because they can work with diverse data types. In particular, the functions in the `Enum` module can work with any data type that implements [the `Enumerable` protocol](/docs/stable/elixir/Enumerable.html). We are going to discuss Protocols in a later chapter, for now we are going to move on to a specific kind of enumerable called a stream.
 
 ## Eager vs Lazy
 

--- a/getting-started/keywords-and-maps.markdown
+++ b/getting-started/keywords-and-maps.markdown
@@ -25,7 +25,7 @@ iex> list[:a]
 1
 ```
 
-As you can see above, Elixir supports a special syntax for defining such lists, and underneath they just map to a list of tuples. Since they are simply lists, all operations available to lists. For example, we can use `++` to add new values to a keyword list:
+As you can see above, Elixir supports a special syntax for defining such lists, and underneath they just map to a list of tuples. Since they are simply lists, we can use all operations available to lists. For example, we can use `++` to add new values to a keyword list:
 
 ```iex
 iex> list ++ [c: 3]
@@ -152,7 +152,7 @@ iex> map = %{a: 1, b: 2}
 %{a: 1, b: 2}
 ```
 
-Another interesting property about maps is that they provide their own syntax for updating and accessing atom keys:
+Another interesting property of maps is that they provide their own syntax for updating and accessing atom keys:
 
 ```iex
 iex> map = %{:a => 1, 2 => :b}

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -132,7 +132,7 @@ defmodule Math do
 end
 ```
 
-And it will provide the same behaviour. You may use `do:` for one-liners but always `do`/`end` for functions spawning multiple lines.
+And it will provide the same behaviour. You may use `do:` for one-liners but always use `do`/`end` for functions spanning multiple lines.
 
 ## Function capturing
 
@@ -173,7 +173,7 @@ iex> fun.(1)
 
 The `&1` represents the first argument passed into the function. `&(&1+1)` above is exactly the same as `fn x -> x + 1 end`. The syntax above is useful for short function definitions.
 
-If you want to call a function from a module, you can do `&Module.function()`:
+If you want to capture a function from a module, you can do `&Module.function()`:
 
 ```iex
 iex> fun = &List.flatten(&1, &2)

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -141,11 +141,11 @@ $ elixir spawn.exs
 
 This time the process failed and brought the parent process down as they are linked. Linking can also be done manually by calling `Process.link/1`. We recommend that you take a look at [the `Process` module](/docs/stable/elixir/Process.html) for other functionality provided by processes.
 
-Process and links play an important role when building fault-tolerant systems. In Elixir applications, we often link our processes to supervisors which will detect when a process dies and start a new process in its place. This is only possible because processes are isolated and don't share anything by default. And if processes are isolated, there is no way a failure in a process will crash or corrupt the state of another.
+Processes and links play an important role when building fault-tolerant systems. In Elixir applications, we often link our processes to supervisors which will detect when a process dies and start a new process in its place. This is only possible because processes are isolated and don't share anything by default. And since processes are isolated, there is no way a failure in a process will crash or corrupt the state of another.
 
 While other languages would require us to catch/handle exceptions, in Elixir we are actually fine with letting processes fail because we expect supervisors to properly restart our systems. "Failing fast" is a common philosophy when writing Elixir software!
 
-`spawn/1` and `spawn_link/1` are the basic primitives for creating processes in Elixir. Although we have used them exclusively so far, most of the times we are going to use abstractions that build on top of them. Let's see the most common one, called tasks.
+`spawn/1` and `spawn_link/1` are the basic primitives for creating processes in Elixir. Although we have used them exclusively so far, most of the time we are going to use abstractions that build on top of them. Let's see the most common one, called tasks.
 
 ## Tasks
 
@@ -164,7 +164,7 @@ Function: #Function<20.90072148/0 in :erl_eval.expr/5>
         (stdlib) proc_lib.erl:239: :proc_lib.init_p_do_apply/3
 ```
 
-Instead of `spawn/1` and `spawn_link/1`, we use `Task.start/1` and `Task.start_link/1` return `{:ok, pid}` rather than just the PID. This is what enables Tasks to be used in supervision trees. Furthermore, Tasks provides convenience functions, like `Task.async/1` and `Task.await/1`, and functionality to ease distribution.
+Instead of `spawn/1` and `spawn_link/1`, we use `Task.start/1` and `Task.start_link/1` to return `{:ok, pid}` rather than just the PID. This is what enables Tasks to be used in supervision trees. Furthermore, `Task` provides convenience functions, like `Task.async/1` and `Task.await/1`, and functionality to ease distribution.
 
 We will explore those functionalities in the ***Mix and OTP guide***, for now it is enough to remember to use Tasks to get better error reports.
 
@@ -240,6 +240,6 @@ iex> Agent.get(pid, fn map -> Map.get(map, :hello) end)
 :world
 ```
 
-A `:name` option could also be given to `Agent.start_link/2` and it would be automatically registered. Besides agents, Elixir provides an API for building generic servers (called GenServer), agents, tasks and more, all powered by processes underneath. Those, along with supervision trees, will be explored with more detail in the ***Mix and OTP guide*** which will build a complete Elixir application from start to finish.
+A `:name` option could also be given to `Agent.start_link/2` and it would be automatically registered. Besides agents, Elixir provides an API for building generic servers (called GenServer), tasks and more, all powered by processes underneath. Those, along with supervision trees, will be explored with more detail in the ***Mix and OTP guide*** which will build a complete Elixir application from start to finish.
 
 For now, let's move on and explore the world of I/O in Elixir.

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -131,7 +131,15 @@ receive do
 end
 ```
 
-This time the process failed and brought the parent process down as they are linked. Linking can also be done manually by calling `Process.link/1`. We recommend you to take a look at [the `Process` module](/docs/stable/elixir/Process.html) for other functionality provided by processes.
+```
+$ elixir spawn.exs
+
+** (EXIT from #PID<0.47.0>) an exception was raised:
+    ** (RuntimeError) oops
+        spawn.exs:1: anonymous fn/0 in :elixir_compiler_0.__FILE__/1
+```
+
+This time the process failed and brought the parent process down as they are linked. Linking can also be done manually by calling `Process.link/1`. We recommend that you take a look at [the `Process` module](/docs/stable/elixir/Process.html) for other functionality provided by processes.
 
 Process and links play an important role when building fault-tolerant systems. In Elixir applications, we often link our processes to supervisors which will detect when a process dies and start a new process in its place. This is only possible because processes are isolated and don't share anything by default. And if processes are isolated, there is no way a failure in a process will crash or corrupt the state of another.
 


### PR DESCRIPTION
The script output was missing from the example.

Also fixes a few conceptual, grammatical, and spelling errors throughout getting-started.