### PR TITLE
Set a default permalink for blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,10 @@ gems:
   - jemoji
   - jekyll-sitemap
   - jekyll-redirect-from
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: post
+      permalink: /blog/:year/:month/:day/:title/

--- a/_posts/2012-04-24-a-peek-inside-elixir-s-parallel-compiler.markdown
+++ b/_posts/2012-04-24-a-peek-inside-elixir-s-parallel-compiler.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: A peek inside Elixir's Parallel Compiler
 author: José Valim
 category: Internals
@@ -28,7 +27,7 @@ In Elixir, we could write this code as follows:
           :erlang.raise(:error, reason, where)
       end
     end
-    
+
     def spawn_compilers([], _output) do
       :done
     end

--- a/_posts/2012-05-25-elixir-v0-5-0-released.markdown
+++ b/_posts/2012-05-25-elixir-v0-5-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.5.0 released
 author: José Valim
 category: Releases

--- a/_posts/2012-08-01-elixir-v0-6-0-released.markdown
+++ b/_posts/2012-08-01-elixir-v0-6-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.6.0 released
 author: José Valim
 category: Releases

--- a/_posts/2012-10-20-elixir-v0-7-0-released.markdown
+++ b/_posts/2012-10-20-elixir-v0-7-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.7.0 released
 author: José Valim
 category: Releases

--- a/_posts/2012-11-18-elixir-v0-7-1-released.markdown
+++ b/_posts/2012-11-18-elixir-v0-7-1-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.7.1 released
 author: José Valim
 category: Releases

--- a/_posts/2012-12-04-elixir-v0-7-2-released.markdown
+++ b/_posts/2012-12-04-elixir-v0-7-2-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.7.2 released
 author: Yurii Rashkovskii
 category: Releases

--- a/_posts/2013-01-27-elixir-v0-8-0-released.markdown
+++ b/_posts/2013-01-27-elixir-v0-8-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.8.0 released
 author: José Valim
 category: Releases

--- a/_posts/2013-04-19-google-summer-of-code-2013.markdown
+++ b/_posts/2013-04-19-google-summer-of-code-2013.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Google Summer of Code 2013
 author: José Valim
 category: Announcements

--- a/_posts/2013-04-29-elixir-v0-8-2-released.markdown
+++ b/_posts/2013-04-29-elixir-v0-8-2-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.8.2 released
 author: José Valim
 category: Releases

--- a/_posts/2013-05-02-elixir-on-xen.markdown
+++ b/_posts/2013-05-02-elixir-on-xen.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir on Xen
 author: José Valim
 category: Announcements

--- a/_posts/2013-05-23-elixir-v0-9-0-released.markdown
+++ b/_posts/2013-05-23-elixir-v0-9-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.9.0 released
 author: José Valim
 category: Releases

--- a/_posts/2013-07-13-elixir-v0-10-0-released.markdown
+++ b/_posts/2013-07-13-elixir-v0-10-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.10.0 released
 author: José Valim
 category: Releases

--- a/_posts/2013-08-08-elixir-design-goals.markdown
+++ b/_posts/2013-08-08-elixir-design-goals.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir Design Goals
 author: José Valim
 category: Internals
@@ -64,7 +63,7 @@ ExUnit.start
 
 defmodule MathTest do
   use ExUnit.Case, async: true
-  
+
   test "adding two numbers" do
     assert 1 + 2 == 4
   end

--- a/_posts/2013-11-05-elixir-v0-11-0-released.markdown
+++ b/_posts/2013-11-05-elixir-v0-11-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.11.0 released
 author: José Valim
 category: Releases

--- a/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
+++ b/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir's new continuable enumerators
 author: Peter Minten
 category: Internals
@@ -113,7 +112,7 @@ same as in the old system. A consumer may return `:halt` to have the producer
 terminate earlier than it normally would.
 
 The real magic is in `:suspend` though. It tells a producer to return the
-accumulator and a continuation function. 
+accumulator and a continuation function.
 
 ```elixir
 { :suspended, n_, cont } = Enumerable.reduce(1..5, { :cont, 0 }, fn x, n ->

--- a/_posts/2013-12-15-elixir-v0-12-0-released.markdown
+++ b/_posts/2013-12-15-elixir-v0-12-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.12.0 released
 author: José Valim
 category: Releases
@@ -11,7 +10,7 @@ Elixir v0.12.0 has been released with improved enumerables, build patterns and w
 
 ## Enumerables
 
-In previous versions, the Enumerable protocol was based on reduce/fold, and while it is very efficient for operations like `map`, `reduce` and `filter`, it was sub-optimal for operations that need to halt, like `take` and `take_while`, and it made it impossible for operations like `zip` to be implemented. 
+In previous versions, the Enumerable protocol was based on reduce/fold, and while it is very efficient for operations like `map`, `reduce` and `filter`, it was sub-optimal for operations that need to halt, like `take` and `take_while`, and it made it impossible for operations like `zip` to be implemented.
 
 In v0.12.0, Elixir's Enumerable protocol has been extended to allow suspension and halting mechanisms, making operations like `take` simpler and operations that require interleaving, like `zip`, possible.
 

--- a/_posts/2014-04-21-elixir-v0-13-0-released.markdown
+++ b/_posts/2014-04-21-elixir-v0-13-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.13.0 released, hex.pm and ElixirConf announced
 author: José Valim
 category: Releases
@@ -37,7 +36,7 @@ In a nutshell, here is what new:
 
 * There are many other changes, like the addition of [StringIO](/docs/stable/elixir/StringIO.html), support for [tags and filters in ExUnit](/docs/stable/ex_unit/ExUnit.Case.html) and more. Please check the [CHANGELOG](https://github.com/elixir-lang/elixir/blob/v0.13.0/CHANGELOG.md) for the complete list.
 
-Even with all those improvements, Elixir v0.13.0 is backwards compatible with Elixir v0.12.5 and upgrading should be a clean process. 
+Even with all those improvements, Elixir v0.13.0 is backwards compatible with Elixir v0.12.5 and upgrading should be a clean process.
 
 ## Maps
 
@@ -238,7 +237,7 @@ This makes comprehensions useful not only for working with in-memory collections
 
 ## Mix workflows
 
-The last big change we want to discuss in this release are the improvements done to Mix, Elixir's build tool. Mix is an essential tool to Elixir developers and helps developers to compile their projects, manage their dependencies, run tests and so on. 
+The last big change we want to discuss in this release are the improvements done to Mix, Elixir's build tool. Mix is an essential tool to Elixir developers and helps developers to compile their projects, manage their dependencies, run tests and so on.
 
 In previous releases, Mix was used to download and compile dependencies per environment. That meant the usual workflow was less than ideal: every time a dependency was updated, developers had to explicitly fetch and compile the dependencies for each environment. The workflow would be something like:
 

--- a/_posts/2014-06-17-elixir-v0-14-0-released.markdown
+++ b/_posts/2014-06-17-elixir-v0-14-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.14.0 released
 author: José Valim
 category: Releases

--- a/_posts/2014-08-07-elixir-v0-15-0-released.markdown
+++ b/_posts/2014-08-07-elixir-v0-15-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v0.15.0 released
 author: José Valim
 category: Releases

--- a/_posts/2014-09-18-elixir-v1-0-0-released.markdown
+++ b/_posts/2014-09-18-elixir-v1-0-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v1.0 released
 author: José Valim
 category: Releases

--- a/_posts/2015-09-28-elixir-v1-1-0-released.markdown
+++ b/_posts/2015-09-28-elixir-v1-1-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v1.1 released
 author: José Valim
 category: Releases

--- a/_posts/2016-01-03-elixir-v1-2-0-released.markdown
+++ b/_posts/2016-01-03-elixir-v1-2-0-released.markdown
@@ -1,6 +1,5 @@
 ---
 layout: post
-permalink: /blog/:year/:month/:day/:title/
 title: Elixir v1.2 released
 author: José Valim
 category: Releases


### PR DESCRIPTION
Due to the recent jekyll changes I noticed that a permalink for each blog post had to be added. Rather than have that added to every blog post file, this `_config.yml` change provides a default permalink for all `post` types.