### PR TITLE
Fix broken link to 'Programming Elixir 1.2'

### DIFF
--- a/learning.markdown
+++ b/learning.markdown
@@ -16,9 +16,7 @@ The Elixir Community has also produced plenty of resources to explore Elixir fro
 
 <h4 class="resource">Programming Elixir 1.2</h4>
 
-<a class="cover" href="https://pragprog.com/book/elixir12/programming-elixir-1-2" title="Programming Elixir 1.2
-: Functional |&gt; Concurrent |&gt; Pragmatic |&gt; Fun :
-– by Dave Thomas"><img src="/images/learning/programming-elixir.jpg" alt="Programming Elixir cover" width="190" /></a>
+<a class="cover" href="https://pragprog.com/book/elixir12/programming-elixir-1-2" title="Programming Elixir 1.2 : Functional |&gt; Concurrent |&gt; Pragmatic |&gt; Fun : – by Dave Thomas"><img src="/images/learning/programming-elixir.jpg" alt="Programming Elixir cover" width="190" /></a>
 
 You want to explore functional programming, but are put off by the academic feel (tell me about monads just one more time). You know you need concurrent applications, but also know these are almost impossible to get right. Meet Elixir, a functional, concurrent language built on the rock-solid Erlang VM.
 


### PR DESCRIPTION
You can see there error live here: http://elixir-lang.org/learning.html#learn-elixir

Before:
<img width="641" alt="2016-02-06 at 10 37 30" src="https://cloud.githubusercontent.com/assets/603846/12865972/b931740c-ccbd-11e5-8a6b-5fe69ecab7e5.png">

After:
<img width="647" alt="2016-02-06 at 10 37 45" src="https://cloud.githubusercontent.com/assets/603846/12865973/bc57b43e-ccbd-11e5-80ae-029216509eaf.png">

I just changed it to one long line, and now it works again.

Looks like it either broke in a6ce245615145daf2e5cfc5ac979d2bf45f386ba or maybe because of https://github.com/blog/2100-github-pages-jekyll-3