### PR TITLE
Mention `iex> i` on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@ Interactive Elixir - press Ctrl+C to exit (type h() ENTER for help)
 iex> c "my_file.ex"        # Compiles a file
 iex> t Enum                # Prints types defined in the module Enum
 iex> h IEx.pry             # Prints the documentation for IEx pry functionality
+iex> i "Hello, World"      # Prints information about the given data type
 {% endhighlight %}
     </div>
   </div>


### PR DESCRIPTION
It's featured on http://elixir-lang.org/docs/stable/iex/IEx.Helpers.html of course, but I think it deserves to be on the homepage because it's so convenient 