### PR TITLE
Fix a Problematic Link in the Mix & OTP Guide

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -64,7 +64,7 @@ end
 
 We are going to start our server by calling `KVServer.accept(4040)`, where 4040 is the port. The first step in `accept/1` is to listen to the port until the socket becomes available and then call `loop_acceptor/1`. `loop_acceptor/1` is just a loop accepting client connections. For each accepted connection, we call `serve/1`.
 
-`serve/1` is another loop that reads a line from the socket and writes those lines back to the socket. Note that the `serve/1` function uses [the pipe operator `|>`](/docs/stable/elixir/Kernel.html#|>/2) to express this flow of operations. The pipe operator evaluates the left side and passes its result as first argument to the function on the right side. The example above:
+`serve/1` is another loop that reads a line from the socket and writes those lines back to the socket. Note that the `serve/1` function uses [the pipe operator `|>`](/docs/stable/elixir/Kernel.html#%7C%3E/2) to express this flow of operations. The pipe operator evaluates the left side and passes its result as first argument to the function on the right side. The example above:
 
 ```elixir
 socket |> read_line() |> write_line(socket)


### PR DESCRIPTION
The presence of a `|` character in a Markdown link on the _Task and gen_tcp_ page was causing the paragraph it's in to render as a table:

<img width="693" alt="task_and_gen_tcp_-_elixir" src="https://cloud.githubusercontent.com/assets/5639/13500288/8e68d61a-e127-11e5-867a-d8d71a21c7a8.png">

Also, the link didn't properly function for me.

I've escaped the entities in it which fixes the rendering:

<img width="678" alt="task_and_gen_tcp_-_elixir" src="https://cloud.githubusercontent.com/assets/5639/13500390/fa894c9e-e127-11e5-94c1-35dbc298fdad.png">

This also makes the link work in Chrome and Safari.  I was unable to find a way to make Firefox accept it.