### PR TITLE
Add a "Edit on GitHub" link to the footer

### DIFF
--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -2,6 +2,10 @@
 
       <div class="clear"></div>
 
+      <a id="edit-on-github" href="{{ site.github.repository_url }}/edit/{{ site.branch }}/{{ page.path }}">
+        Something is wrong? Edit this page on GitHub.
+      </a>
+
       <div id="copyright">
         &copy; 2012-2016 <a href="http://plataformatec.com.br/">Plataformatec</a>. All rights reserved.
       </div>

--- a/css/style.css
+++ b/css/style.css
@@ -765,6 +765,12 @@ li.image {
   padding: 0 0 10px;
 }
 
+#edit-on-github {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+}
+
 /*  Media Queries (mobile browsing)
 ----------------------------------------------------- */
 /* Tablet (portrait) */


### PR DESCRIPTION
I love what @lexmag and @josevalim discussed in #696. How does this implementation look? I haven't tested the proper link locally because GH injects the `site.github` data when it builds the site.