### PR TITLE
Add return value for unbound variable example in keywords and maps

### DIFF
--- a/getting-started/keywords-and-maps.markdown
+++ b/getting-started/keywords-and-maps.markdown
@@ -134,6 +134,7 @@ iex> map = %{n => :one}
 iex> map[n]
 :one
 iex> %{^n => :one} = %{1 => :one, 2 => :two, 3 => :three}
+** (CompileError) iex:4: unbound variable ^n
 ```
 
 [The `Map` module](/docs/stable/elixir/Map.html) provides a very similar API to the `Keyword` module with convenience functions to manipulate maps:


### PR DESCRIPTION
Changes this: 
```iex
iex> n = 1
1
iex> map = %{n => :one}
%{1 => :one}
iex> map[n]
:one
iex> %{^n => :one} = %{1 => :one, 2 => :two, 3 => :three}
```
To this:
```iex
iex> n = 1
1
iex> map = %{n => :one}
%{1 => :one}
iex> map[n]
:one
iex> %{^n => :one} = %{1 => :one, 2 => :two, 3 => :three}
** (CompileError) iex:4: unbound variable ^n
```