### PR TITLE
Make correction in “Sigils”

### DIFF
--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -162,14 +162,14 @@ def convert(...)
 
 ## Custom sigils
 
-As hinted at the beginning of this chapter, sigils in Elixir are extensible. In fact, using the sigil `~r/foo/i` is equivalent to calling the `sigil_r` function with a binary and a char list as argument:
+As hinted at the beginning of this chapter, sigils in Elixir are extensible. In fact, using the sigil `~r/foo/i` is equivalent to calling `sigil_r` with a binary and a char list as argument:
 
 ```iex
 iex> sigil_r(<<"foo">>, 'i')
 ~r"foo"i
 ```
 
-We can access the documentation for the `~r` sigil via the `sigil_r` function:
+We can access the documentation for the `~r` sigil via `sigil_r`:
 
 ```iex
 iex> h sigil_r


### PR DESCRIPTION
The macro `sigil_r` was incorrectly identified as a function. One could have merely changed the word _function_ to _macro_. However, the revelation that it is a macro and not a function could pose a distraction and lead to confusion ahead of the final paragraph of the page. Consequently, I chose to remove the word _function_.