### PR TITLE
Add reference to capture syntax for anonymous functions

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -233,6 +233,8 @@ iex> x
 42
 ```
 
+Capture syntax `&()`can also be used for creating anonymous functions. This type of syntax will be discussed in Chapter 8.
+
 ## (Linked) Lists
 
 Elixir uses square brackets to specify a list of values. Values can be of any type:

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -233,7 +233,7 @@ iex> x
 42
 ```
 
-Capture syntax `&()`can also be used for creating anonymous functions. This type of syntax will be discussed in Chapter 8.
+The capture syntax [`&()`](/docs/stable/elixir/Kernel.SpecialForms.html) can also be used for creating anonymous functions. This type of syntax will be discussed in [Chapter 8](/getting-started/models.html).
 
 ## (Linked) Lists
 


### PR DESCRIPTION
Add reference to capture syntax for anonymous functions so that when going through 'Getting started' in order, you don't get curious at Keywords and maps - Nested data structures, which uses the capture syntax.