### PR TITLE
Fix windows set environment cmd

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -255,7 +255,7 @@ $ MIX_ENV=prod mix compile
 Or on Windows:
 
 ```batch
-> set /a "MIX_ENV=prod" && mix compile
+> set "MIX_ENV=prod" && mix compile
 ```
 
 ## Exploring


### PR DESCRIPTION
Great project, thank you!

The example for setting a session based environment variable for establishing your Elixir environment is incorrect. 

It uses the `-A` flag which [is for expressions](http://ss64.com/nt/set.html) like setting a variable to the result of '1 + 2'

If you try to use batch with the existing cmd using the /a flag, the output in windows cli is `0` - not set.  My revision will resolve this and is tested on Windows 8.1