### PR TITLE
Formatting: add white space after comma

### DIFF
--- a/_posts/2013-05-23-elixir-v0-9-0-released.markdown
+++ b/_posts/2013-05-23-elixir-v0-9-0-released.markdown
@@ -55,11 +55,11 @@ A special thanks to [Eric Meadows-Jonsson](https://github.com/ericmj) for implem
 Elixir v0.9.0 changes its main abstraction for enumeration from iterators to reducers. Before Elixir v0.9.0, when you invoked:
 
 ```elixir
-Enum.map([1,2,3], fn(x) -> x * x end)
+Enum.map([1, 2, 3], fn(x) -> x * x end)
 #=> [1, 4, 9]
 ```
 
-It asked the `Enum.Iterator` protocol for instructions on how to iterate the list `[1,2,3]`. This iteration happened by retrieving each item in the list, one by one, until there were no items left.
+It asked the `Enum.Iterator` protocol for instructions on how to iterate the list `[1, 2, 3]`. This iteration happened by retrieving each item in the list, one by one, until there were no items left.
 
 This approach posed many problems:
 
@@ -91,7 +91,7 @@ The implementation above works as a simple `reduce` function (also called `fold`
 
 ```elixir
 # Sum all elements in a list
-Enumerable.reduce([1,2,3], 0, fn(x, acc) -> x + acc end)
+Enumerable.reduce([1, 2, 3], 0, fn(x, acc) -> x + acc end)
 #=> 6
 ```
 

--- a/_posts/2013-07-13-elixir-v0-10-0-released.markdown
+++ b/_posts/2013-07-13-elixir-v0-10-0-released.markdown
@@ -13,17 +13,17 @@ Elixir v0.10.0 is released with support for streams, sets and many improvements 
 The default mechanism for working with collections in Elixir is the `Enum` module. With it, you can map over ranges, lists, sets, dictionaries and any other structure as long as it implements the `Enumerable` protocol:
 
 ```elixir
-Enum.map([1,2,3], fn(x) -> x * 2 end)
-#=> [2,4,6]
+Enum.map([1, 2, 3], fn(x) -> x * 2 end)
+#=> [2, 4, 6]
 ```
 
 The `Enum` module performs eager evaluation. Consider the following example:
 
 ```elixir
-[1,2,3]
+[1, 2, 3]
   |> Enum.take_while(fn(x) -> x < 3 end)
   |> Enum.map(fn(x) -> x * 2 end)
-#=> [2,4]
+#=> [2, 4]
 ```
 
 In the example above, we enumerate the items in list once, taking all elements that are less than 3, and then we enumerate the remaining elements again, multiplying them by two. In order to retrieve the final result, we have created one intermediate list. As we add more operations, more intermediate lists will be generated.
@@ -31,7 +31,7 @@ In the example above, we enumerate the items in list once, taking all elements t
 This approach is simple and efficient for the majority of the cases but, when working with large collections, we can generate many, possibly large, intermediate lists affecting performance. That's one of the problems Streams solve. Let's rewrite the example above using Streams:
 
 ```elixir
-[1,2,3]
+[1, 2, 3]
   |> Stream.take_while(fn(x) -> x < 3 end)
   |> Stream.map(fn(x) -> x * 2 end)
 #=> #Stream.Lazy<...>

--- a/_posts/2013-08-08-elixir-design-goals.markdown
+++ b/_posts/2013-08-08-elixir-design-goals.markdown
@@ -145,7 +145,7 @@ Many language constructs are also inspired by their Erlang counter-parts, like s
 tuple = { 1, 2, 3 }
 
 # Adding two lists
-[1,2,3] ++ [4,5,6]
+[1, 2, 3] ++ [4, 5, 6]
 
 # Case
 case expr do
@@ -161,7 +161,7 @@ maps to Erlang:
 Tuple = { 1, 2, 3 }.
 
 % Adding two lists
-[1,2,3] ++ [4,5,6].
+[1, 2, 3] ++ [4, 5, 6].
 
 % Case
 case Expr of
@@ -189,17 +189,17 @@ And much more.
 Most of the features above provide their own extensibility mechanisms, too. For example, take the `Enum` module. The `Enum` module allow us to enumerate the built-in ranges, lists, sets, etc:
 
 ```elixir
-list = [1,2,3]
+list = [1, 2, 3]
 Enum.map list, fn(x) -> x * 2 end
-#=> [2,4,6]
+#=> [2, 4, 6]
 
 range = 1..3
 Enum.map range, fn(x) -> x * 2 end
-#=> [2,4,6]
+#=> [2, 4, 6]
 
-set = HashSet.new [1,2,3]
+set = HashSet.new [1, 2, 3]
 Enum.map set, fn(x) -> x * 2 end
-#=> [2,4,6]
+#=> [2, 4, 6]
 ```
 
 Not only that, any developer can **extend** the `Enum` module to work with any data type as long as the data type implements [the `Enumerable` protocol](/docs/stable/elixir/Enumerable.html) (protocols in Elixir are based on Clojure's protocol). This is extremely convenient because the developer needs to know only the `Enum` API for enumeration, instead of memorizing specific APIs for sets, lists, dicts, etc.

--- a/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
+++ b/_posts/2013-12-11-elixir-s-new-continuable-enumerators.markdown
@@ -186,7 +186,7 @@ defmodule Interleave do
   end
 end
 
-Interleave.interleave([1,2], [:a, :b, :c, :d])
+Interleave.interleave([1, 2], [:a, :b, :c, :d])
 #=> [1, :a, 2, :b, :c, :d]
 ```
 

--- a/_posts/2014-04-21-elixir-v0-13-0-released.markdown
+++ b/_posts/2014-04-21-elixir-v0-13-0-released.markdown
@@ -212,7 +212,7 @@ As in previous Elixir versions, there is also support for a bitstring generator.
 ```iex
 iex> pixels = <<213, 45, 132, 64, 76, 32, 76, 0, 0, 234, 32, 15>>
 iex> for <<r::8, g::8, b::8 <- pixels>>, do: {r, g, b}
-[{213,45,132}, {64,76,32}, {76,0,0}, {234,32,15}]
+[{213, 45, 132}, {64, 76, 32}, {76, 0, 0}, {234, 32, 15}]
 ```
 
 By default, a comprehension returns a list as a result. However the result of a comprehension can be inserted into different data structures by passing the `:into` option. For example, we can use bitstring generators with the `:into` option to easily remove all spaces in a string:

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -162,13 +162,13 @@ Elixir allows you to omit parentheses in function calls, Erlang does not.
 Invoking a function from a module uses different syntax. In Erlang, you would write
 
 ```erlang
-lists:last([1,2]).
+lists:last([1, 2]).
 ```
 
 to invoke the `last` function from the `List` module. In Elixir, use the dot `.` in place of the colon `:`
 
 ```elixir
-List.last([1,2])
+List.last([1, 2])
 ```
 
 **Note**. Since Erlang modules are represented by atoms, you may invoke Erlang functions in Elixir as follows:
@@ -526,7 +526,7 @@ sum(1, 2).
 %=> 3
 
 sum([1], [2]).
-%=> [1,2]
+%=> [1, 2]
 
 sum("a", "b").
 %=> "ab"
@@ -551,7 +551,7 @@ sum 1, 2
 #=> 3
 
 sum [1], [2]
-#=> [1,2]
+#=> [1, 2]
 
 sum "a", "b"
 #=> "ab"
@@ -613,7 +613,7 @@ F([]).
 %=> "Empty"
 
 F({a, b}).
-%=> "All your {a,b} are belong to us"
+%=> "All your {a, b} are belong to us"
 ```
 
 **Elixir**

--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -12,10 +12,10 @@ In the [previous chapter](/getting-started/basic-types.html), we saw Elixir prov
 Elixir also provides `++` and `--` to manipulate lists:
 
 ```iex
-iex> [1,2,3] ++ [4,5,6]
-[1,2,3,4,5,6]
-iex> [1,2,3] -- [2]
-[1,3]
+iex> [1, 2, 3] ++ [4, 5, 6]
+[1, 2, 3, 4, 5, 6]
+iex> [1, 2, 3] -- [2]
+[1, 3]
 ```
 
 String concatenation is done with `<>`:

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -258,7 +258,7 @@ iex> [1, true, 2, false, 3, true] -- [true, false]
 Throughout the tutorial, we will talk a lot about the head and tail of a list. The head is the first element of a list and the tail is the remainder of a list. They can be retrieved with the functions `hd/1` and `tl/1`. Let's assign a list to a variable and retrieve its head and tail:
 
 ```iex
-iex> list = [1,2,3]
+iex> list = [1, 2, 3]
 iex> hd(list)
 1
 iex> tl(list)

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -178,7 +178,7 @@ Finally, note `cond` considers any value besides `nil` and `false` to be true:
 
 ```iex
 iex> cond do
-...>   hd([1,2,3]) ->
+...>   hd([1, 2, 3]) ->
 ...>     "1 is considered as true"
 ...> end
 "1 is considered as true"

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -116,9 +116,9 @@ defmodule Math do
   end
 end
 
-IO.puts Math.zero?(0)       #=> true
-IO.puts Math.zero?(1)       #=> false
-IO.puts Math.zero?([1,2,3]) #=> ** (FunctionClauseError)
+IO.puts Math.zero?(0)         #=> true
+IO.puts Math.zero?(1)         #=> false
+IO.puts Math.zero?([1, 2, 3]) #=> ** (FunctionClauseError)
 ```
 
 Giving an argument that does not match any of the clauses raises an error.

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -178,7 +178,7 @@ iex> _
 Although pattern matching allows us to build powerful constructs, its usage is limited. For instance, you cannot make function calls on the left side of a match. The following example is invalid:
 
 ```iex
-iex> length([1,[2],3]) = 3
+iex> length([1, [2], 3]) = 3
 ** (CompileError) iex:1: illegal pattern
 ```
 

--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -167,7 +167,7 @@ Elixir ships with some built-in protocols. In previous chapters, we have discuss
 
 ```iex
 iex> Enum.map [1, 2, 3], fn(x) -> x * 2 end
-[2,4,6]
+[2, 4, 6]
 iex> Enum.reduce 1..3, 0, fn(x, acc) -> x + acc end
 6
 ```
@@ -205,7 +205,7 @@ The `Inspect` protocol is the protocol used to transform any data structure into
 
 ```iex
 iex> {1, 2, 3}
-{1,2,3}
+{1, 2, 3}
 iex> %User{}
 %User{name: "john", age: 27}
 ```

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ iex> i "Hello, World"      # Prints information about the given data type
 
 {% highlight iex %}
 iex> :crypto.md5("Using crypto from Erlang OTP")
-<<192,223,75,115,...>>
+<<192, 223, 75, 115, ...>>
 {% endhighlight %}
 
       <p>To learn more about Elixir, check our <a href="/getting-started/introduction.html">getting started guide</a>. We also have <a href="/docs.html">online documentation available</a> and a <a href="/crash-course.html">Crash Course for Erlang developers</a>.</p>


### PR DESCRIPTION
Standardizes the use of comma leaving a white space after it whenever applicable.