### PR TITLE
Add Visual Studio extension for Elixir

### DIFF
--- a/_includes/code-editor-support.html
+++ b/_includes/code-editor-support.html
@@ -8,5 +8,6 @@
     <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>
     <li><a class="spec" href="https://github.com/lucasmazza/language-elixir">Atom Package</a></li>
     <li><a class="spec" href="https://github.com/KronicDeth/intellij-elixir">IntelliJ Elixir</a></li>
+    <li><a class="spec" href="https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir">Visual Studio Elixir</a></li>
   </ul>
 </div>


### PR DESCRIPTION
I just saw that there is no extension for Visual Studio Code users.