### PR TITLE
Clearer, working examples for "case, cond and if" chapter

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -251,7 +251,7 @@ One thing to keep in mind when using `do/end` blocks is they are always bound to
 iex> Integer.to_string if true do
 ...>  1 + 2
 ...> end
-** (CompileError) undefined function if/1
+** (CompileError) undefined function: if/1
 ```
 
 Would be parsed as:
@@ -260,7 +260,7 @@ Would be parsed as:
 iex> Integer.to_string(if true) do
 ...>  1 + 2
 ...> end
-** (CompileError) undefined function if/1
+** (CompileError) undefined function: if/1
 ```
 
 Which leads to an undefined function error as Elixir attempts to invoke `if/1`. Adding explicit parentheses is enough to resolve the ambiguity:

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -248,28 +248,28 @@ iex> if true, do: (
 One thing to keep in mind when using `do/end` blocks is they are always bound to the outermost function call. For example, the following expression:
 
 ```iex
-iex> is_number if true do
+iex> Integer.to_string if true do
 ...>  1 + 2
 ...> end
-** (CompileError) undefined function: is_number/2
+** (CompileError) undefined function if/1
 ```
 
 Would be parsed as:
 
 ```iex
-iex> is_number(if true) do
+iex> Integer.to_string(if true) do
 ...>  1 + 2
 ...> end
-** (CompileError) undefined function: is_number/2
+** (CompileError) undefined function if/1
 ```
 
-which leads to an undefined function error as Elixir attempts to invoke `is_number/1`, but passing it *two* arguments (the `if true` expression - which would throw an undefined function error itself as `if` needs a second argument, the `do/end` block - and the `do/end` block). Adding explicit parentheses is enough to resolve the ambiguity:
+Which leads to an undefined function error as Elixir attempts to invoke `if/1`. Adding explicit parentheses is enough to resolve the ambiguity:
 
 ```iex
-iex> is_number(if true do
+iex> Integer.to_string(if true do
 ...>  1 + 2
 ...> end)
-true
+"3"
 ```
 
 Keyword lists play an important role in the language and are quite common in many functions and macros. We will explore them a bit more in a future chapter. Now it is time to talk about "Binaries, strings and char lists".


### PR DESCRIPTION
Fix for #727 that once again clearly demonstrates the ambiguity in the arguments to `if/2`. Still learning Elixir, but I'm guessing the original examples with `is_number/1` didn't produce the same output as shown on the page because of how the compiler handles macros vs. regular functions.

Ref: Issue #727, PR #729 
![screen shot 2016-04-18 at 11 34 10 pm](https://cloud.githubusercontent.com/assets/9465511/14627538/5f32d722-05c3-11e6-88f3-a0adf7cf3c13.png)
