### PR TITLE
Fix line number for location of failing test

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -214,7 +214,7 @@ For each failure, ExUnit prints a detailed report, containing the test name with
 In the second line of the failure, right below the test name, there is the location where the test was defined. If you copy the test location in this full second line (including the file and line number) and append it to `mix test`, Mix will load and run just that particular test:
 
 ```bash
-$ mix test test/kv_test.exs:5
+$ mix test test/kv_test.exs:6
 ```
 
 This shortcut will be extremely useful as we build our project, allowing us to quickly iterate by running just a specific test.


### PR DESCRIPTION
The line number for the failing test is `6`, as indicated in the line 207 above...