### PR TITLE
Change `1.2-dev` references to `1.2`

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -159,7 +159,7 @@ defmodule KVServer.Mixfile do
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.2-dev",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]


### PR DESCRIPTION
While working through the example app, I noticed the `1.2-dev` dependency reference uses the `-dev` release. Now that `1.2` has been released, the documentation should reflect the `1.2` version