### PR TITLE
Use %{} instead of Map.new in genserver docs

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -24,7 +24,7 @@ OK
 Since agents are processes, each bucket has a process identifier (pid) but it doesn't have a name. We have learned about the name registry [in the Process chapter](/getting-started/processes.html) and you could be inclined to solve this problem by using such registry. For example, we could create a bucket as:
 
 ```iex
-iex> Agent.start_link(fn -> Map.new end, name: :shopping)
+iex> Agent.start_link(fn -> %{} end, name: :shopping)
 {:ok, #PID<0.43.0>}
 iex> KV.Bucket.put(:shopping, "milk", 1)
 :ok


### PR DESCRIPTION
I am not sure why we're using `Map.new` here instead of `%{}`. On the previous page we're using `%{}`, but here we're using `Map.new` for apparently no reason at all.