### PR TITLE
Fixing compile error

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -289,8 +289,6 @@ The last step is to implement `KVServer.Command.run/1`, to run the parsed comman
 @doc """
 Runs the given command.
 """
-def run(command)
-
 def run({:create, bucket}) do
   KV.Registry.create(KV.Registry, bucket)
   {:ok, "OK\r\n"}


### PR DESCRIPTION
Left over "def run(command)" in the code, makes compilation fail