### PR TITLE
Update ets.markdown

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -86,7 +86,7 @@ defmodule KV.Registry do
 
   ## Server callbacks
 
-  def init(table) do
+  def init(:ok, table) do
     # 3. We have replaced the names map by the ETS table
     names = :ets.new(table, [:named_table, read_concurrency: true])
     refs  = %{}


### PR DESCRIPTION
I'm going through example implementation and stuck following error while running tests: 
`
Compiled lib/registry.ex

=INFO REPORT==== 20-May-2016::19:05:06 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application kv: KV.start(:normal, []) returned an error: shutdown: failed to start child: KV.Registry
    ** (EXIT) an exception was raised:
        ** (ArgumentError) argument error
            (stdlib) :ets.new(KV.Registry, [:named_table, {:read_cuncurrency, true}])
            (kv) lib/registry.ex:31: KV.Registry.init/1
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
`

I'm not sure if that's correct fix but so far it let me proceed further. While I have other issues to address. I'll update that pull request once I resolve it. 