### PR TITLE
Replace JavaScript example with C

### DIFF
--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -9,10 +9,10 @@ title: Recursion
 
 ## Loops through recursion
 
-Due to immutability, loops in Elixir (as in any functional programming language) are written differently from imperative languages. For example, in an imperative language like JavaScript, one would write:
+Due to immutability, loops in Elixir (as in any functional programming language) are written differently from imperative languages. For example, in an imperative language like C, one would write:
 
-```javascript
-for(i = 0; i < array.length; i++) {
+```c
+for(i = 0; i < sizeof(array); i++) {
   array[i] = array[i] * 2;
 }
 ```


### PR DESCRIPTION
Because in JavaScript one could write that example in imperative way, but would write that example as
```javascript
array.map(function(el) {
  return el * 2;
});
```

Let's just use pure imperative programming language as an example.