### PR TITLE
Redirect old getting started URL

### DIFF
--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -1,6 +1,7 @@
 ---
 layout: getting-started
 title: Introduction
+redirect_from: /getting_started/1.html
 ---
 
 # {{ page.title }}


### PR DESCRIPTION
The Pragmatic "Programming Elixir" book references `http://elixir-lang.org/getting_started/1.html` which has been moved to `http://elixir-lang.org/getting-started/introduction.html`. This PR adds a `redirect_from` on the `introduction.markdown` page to ensure that readers of that book are able to use the URL in the book without getting a 404.