### PR TITLE
Brackets seem to imply something that's not true

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -317,7 +317,7 @@ iex> tuple_size {:ok, "hello"}
 2
 ```
 
-Tuples store elements contiguously in memory. This means accessing a tuple element per index or getting the tuple size is a fast operation (indexes start from zero):
+Tuples store elements contiguously in memory. This means accessing a tuple element per index or getting the tuple size is a fast operation. Indexes start from zero:
 
 ```iex
 iex> tuple = {:ok, "hello"}


### PR DESCRIPTION
To me, those round brackets imply a causal relationship: "it's a fast operation because indexes start from zero". That's definitely not the case, so I think the punctuation should change.