### PR TITLE
Proposal to highlight indented code

### DIFF
--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -156,7 +156,9 @@ HygieneTest.go
 
 Variable hygiene only works because Elixir annotates variables with their context. For example, a variable `x` defined on line 3 of a module would be represented as:
 
-    {:x, [line: 3], nil}
+```elixir
+{:x, [line: 3], nil}
+```
 
 However, a quoted variable is represented as:
 


### PR DESCRIPTION
Hi, I'm shia,
This is updated the indented, not syntax highlighted code to be applied syntax highlight.

meaning to say, indent will not be applied syntax highlight, so it look like blocked, strange T-T
![2016-07-08 8 15 33](https://cloud.githubusercontent.com/assets/7338443/16672907/2c7ea92c-44e4-11e6-85a5-2b80814634c1.png)
how about give him to be more beautiful?
I can't find the reason why this snippet onl
y indented, not highlighted.

Thanks to read this. :)