### PR TITLE
simplify the pattern match example

### DIFF
--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -63,8 +63,8 @@ iex> {a, b, c} = {:hello, "world"}
 And also when comparing different types:
 
 ```iex
-iex> {a, b, c} = [:hello, "world", "!"]
-** (MatchError) no match of right hand side value: [:hello, "world", "!"]
+iex> {a, b, c} = [:hello, "world", 42]
+** (MatchError) no match of right hand side value: [:hello, "world", 42]
 ```
 
 More interestingly, we can match on specific values. The example below asserts that the left side will only match the right side when the right side is a tuple that starts with the atom `:ok`:


### PR DESCRIPTION
I spent a while trying to figure out why the pattern would match `42` but not `"!"`.  Turns out my browser doesn't show much difference between `[` and `{` so I was concentrating on the more obvious -- but irrelevant -- change.