### PR TITLE
minor typo in crash-course.markdown

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -95,7 +95,7 @@ Some operators are spelled differently.
 
 ### Delimiters
 
-Erlang expressions are terminated with a dot `.` and comma `,` is used to evaluates multiple expressions within one context (in a function definition, for instance). In Elixir, expressions are delimited by a line break or a semicolon `;`.
+Erlang expressions are terminated with a dot `.` and comma `,` is used to evaluate multiple expressions within one context (in a function definition, for instance). In Elixir, expressions are delimited by a line break or a semicolon `;`.
 
 **Erlang**
 


### PR DESCRIPTION
Just a markdown typo.