### PR TITLE
Point to point to the "Operators" page in the Elixir docs

### DIFF
--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -111,30 +111,6 @@ The reason we can compare different data types is pragmatism. Sorting algorithms
 
 You don't actually need to memorize this ordering, but it is important just to know an order exists.
 
-## Operator table
+For reference information about operators, you can visit the ["Operators" page](/docs/master/elixir/operators.html) in the documentation.
 
-Although we have learned only a handful of operators so far, we present below the complete operator table for Elixir ordered from higher to lower precedence for reference:
-
-Operator | Associativity
--------- | -------------
- `@` | Unary
- `.` | Left to right
- `+` `-` `!` `^` `not` `~~~` | Unary
- `*` `/` | Left to right
- `+` `-` | Left to right
- `++` `--` `..` `<>` | Right to left
- `in` | Left to right
- <code>&#124;></code> `<<<` `>>>` `~>>` `<<~` `~>` `<~` `<~>` <code>&lt;&#124;&gt;</code>  | Left to right
- `<` `>` `<=` `>=` | Left to right
- `==` `!=` `=~` `===` `!==` | Left to right
- `&&` `&&&` `and` | Left to right
- <code>&#124;&#124;</code> <code>&#124;&#124;&#124;</code> `or` | Left to right
- `=` | Right to left
- `=>` | Right to left
- <code>&#124;</code> | Right to left
- `::` | Right to left
- `when` | Right to left
- `<-`, `\\` | Left to right
- `&` | Unary
-
-We will learn the majority of those operators as we go through the getting started guide. In the next chapter, we are going to discuss some basic functions, data type conversions and a bit of control-flow.
+In the next chapter, we are going to discuss some basic functions, data type conversions and a bit of control-flow.


### PR DESCRIPTION
The logical next step after https://github.com/elixir-lang/elixir/pull/5142 :) \cc @josevalim, I opened a PR just to check that it's ok to point to `/docs/master` instead of `/docs/stable` since I assume the new page won't be in `/docs/stable` yet, right?