### PR TITLE
Mark "Mix & OTP" chapters as part of the guide

### DIFF
--- a/_includes/mix-otp-preface.html
+++ b/_includes/mix-otp-preface.html
@@ -1,0 +1,2 @@
+This chapter is part of the <i>Mix and OTP guide</i> and it depends on previous chapters in this guide.
+For more information, <a href="/getting-started/mix-otp/introduction-to-mix.html">read the guide introduction</a> or check out the chapter index in the sidebar.

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -7,6 +7,8 @@ title: Agent
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In this chapter, we will create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way it can be read and modified by other processes.
 
 If you have skipped the Getting Started guide or if you have read it long ago, be sure to re-read the chapter about [Processes](/getting-started/processes.html). We will use it as a starting point.

--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -7,6 +7,8 @@ title: Dependencies and umbrella projects
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In this chapter, we will discuss how to manage dependencies in Mix.
 
 Our `kv` application is complete, so it's time to implement the server that will handle the requests we defined in the first chapter:

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -7,6 +7,8 @@ title: Distributed tasks and configuration
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In this last chapter, we will go back to the `:kv` application and add a routing layer that will allow us to distribute requests between nodes based on the bucket name.
 
 The routing layer will receive a routing table of the following format:

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -8,6 +8,8 @@ redirect_from: /getting-started/mix_otp/docs-tests-and-pipelines.html
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In this chapter, we will implement the code that parses the commands we described in the first chapter:
 
 ```

--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -7,6 +7,8 @@ title: ETS
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 Every time we need to look up a bucket, we need to send a message to the registry. In case our registry is being accessed concurrently by multiple processes, the registry may become a bottleneck!
 
 In this chapter we will learn about ETS (Erlang Term Storage) and how to use it as a cache mechanism.

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -7,6 +7,8 @@ title: GenServer
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In the [previous chapter](/getting-started/mix-otp/agent.html) we used agents to represent our buckets. In the first chapter, we specified we would like to name each bucket so we can do the following:
 
 ```elixir

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -7,6 +7,8 @@ title: Supervisor and Application
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 So far our application has a registry that may monitor dozens, if not hundreds, of buckets. While we think our implementation so far is quite good, no software is bug free, and failures are definitely going to happen.
 
 When things fail, your first reaction may be: "let's rescue those errors". But in Elixir we avoid the defensive programming habit of rescuing exceptions, as commonly seen in other languages. Instead, we say "let it crash". If there is a bug that leads our registry to crash, we have nothing to worry about because we are going to set up a supervisor that will start a fresh copy of the registry.

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -7,6 +7,8 @@ title: Task and gen_tcp
 
 {% include toc.html %}
 
+{% include mix-otp-preface.html %}
+
 In this chapter, we are going to learn how to use [Erlang's `:gen_tcp` module](http://www.erlang.org/doc/man/gen_tcp.html) to serve requests. This provides a great opportunity to explore Elixir's `Task` module. In future chapters we will expand our server so it can actually serve the commands.
 
 ## Echo server


### PR DESCRIPTION
In the beginning of every chapter reference the previous chapter and the first
chapter of the "OTP & Mix" guide.

See #834

I can change the wording if required.