### PR TITLE
Update macros.markdown with more discussion of private macros. 

### DIFF
--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -251,7 +251,7 @@ iex> defmodule Sample do
 ** (CompileError) iex:2: function two/0 undefined
 ```
 
-Private macros are only available at compilation time. That means you can't execute a macro outside of a definition:
+Private macros are only available at compilation time. That means you can't execute a private macro outside of a definition:
 
 ```iex
 iex> defmodule Sample do
@@ -261,7 +261,7 @@ iex> defmodule Sample do
 ** (CompileError) iex:32: undefined function two/0
 ```
 
-It also means you can't both create and use a function-defining macro in a module, even with `defmacrop`. As an example, suppose I want to define a function that's only used for its side effects. To prevent the value of the last calculation from "leaking" to its caller, it will always return an innocuous symbol. Like this:
+It also means you can't both create and use a function-defining macro in the same module, even with `defmacrop`. As an example, suppose I want to define a number of functions that are only used for side effects. To prevent the value of the last calculation from "leaking" to the caller, such functions should always return an innocuous symbol. Like this:
 
 ```iex
 iex> Sample.add_and_print(1, 3)
@@ -269,7 +269,8 @@ iex> Sample.add_and_print(1, 3)
 :"add_and_print does not have a useful return value"
 ```
 
-This is what happens if you try to both define and use the macro in the same module:
+Because I want many of these functions, I decide to create a `def_without_return_value` macro that's just like `def` but returns that special symbol. 
+This is what happens if you try to both define and use that macro in the same module:
 
 ```iex
 iex> defmodule Sample do
@@ -288,6 +289,7 @@ iex> defmodule Sample do
 ** (CompileError): undefined function def_without_return_value/2
 ```
 
+`def_without_return` value will have to be defined in a different module, then `required` in the one that uses it.
 
 ## Write macros responsibly
 


### PR DESCRIPTION
Coming from Clojure, it took me some time to understand where and when macros could be used. One thing I consistently wanted to do was define a macro like `defchecker` and then immediately use it. That doesn't work, even with `defmacrop`. The pull request contains the information I'd have wanted.

There is a perhaps-overly-long example of creating a def-creating macro. I put that in because - for me - it was initially puzzling how the head of a `def` form would passed to the macro (since it doesn't have commas). 
