### PR TITLE
Rename variable in `unless` example

### DIFF
--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -23,11 +23,11 @@ In order to better understand how macros work, let's create a new module where w
 
 ```elixir
 defmodule Unless do
-  def fun_unless(clause, expression) do
+  def fun_unless(clause, do: expression) do
     if(!clause, do: expression)
   end
 
-  defmacro macro_unless(clause, expression) do
+  defmacro macro_unless(clause, do: expression) do
     quote do
       if(!unquote(clause), do: unquote(expression))
     end
@@ -47,9 +47,9 @@ And play with those definitions:
 
 ```iex
 iex> require Unless
-iex> Unless.macro_unless true, IO.puts "this should never be printed"
+iex> Unless.macro_unless true, do: IO.puts "this should never be printed"
 nil
-iex> Unless.fun_unless true, IO.puts "this should never be printed"
+iex> Unless.fun_unless true, do: IO.puts "this should never be printed"
 "this should never be printed"
 nil
 ```
@@ -59,14 +59,14 @@ Note that in our macro implementation, the sentence was not printed, although it
 In other words, when invoked as:
 
 ```elixir
-Unless.macro_unless true, IO.puts "this should never be printed"
+Unless.macro_unless true, do: IO.puts "this should never be printed"
 ```
 
 Our `macro_unless` macro received the following:
 
 {% raw %}
 ```elixir
-macro_unless(true, {{:., [], [{:aliases, [], [:IO]}, :puts]}, [], ["this should never be printed"]})
+macro_unless(true, [do: {{:., [], [{:__aliases__, [alias: false], [:IO]}, :puts]}, [], ["this should never be printed"]}])
 ```
 {% endraw %}
 
@@ -86,7 +86,7 @@ And it then returned a quoted expression as follows:
 We can actually verify that this is the case by using `Macro.expand_once/2`:
 
 ```iex
-iex> expr = quote do: Unless.macro_unless(true, IO.puts "this should never be printed")
+iex> expr = quote do: Unless.macro_unless(true, do: IO.puts "this should never be printed")
 iex> res  = Macro.expand_once(expr, __ENV__)
 iex> IO.puts Macro.to_string(res)
 if(!true) do
@@ -100,7 +100,7 @@ end
 That's what macros are all about. They are about receiving quoted expressions and transforming them into something else. In fact, `unless/2` in Elixir is implemented as a macro:
 
 ```elixir
-defmacro unless(clause, expression) do
+defmacro unless(clause, do: expression) do
   quote do
     if(!unquote(clause), do: unquote(expression))
   end

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -100,9 +100,9 @@ end
 That's what macros are all about. They are about receiving quoted expressions and transforming them into something else. In fact, `unless/2` in Elixir is implemented as a macro:
 
 ```elixir
-defmacro unless(clause, options) do
+defmacro unless(clause, expression) do
   quote do
-    if(!unquote(clause), do: unquote(options))
+    if(!unquote(clause), do: unquote(expression))
   end
 end
 ```


### PR DESCRIPTION
The name `options` for the second argument didn't seem to make much sense given that the implementation is `unless`. What do you think about renaming the variable to `expression`?