### PR TITLE
Remove unreachable line

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -43,7 +43,6 @@ end
 defp loop_acceptor(socket) do
   {:ok, client} = :gen_tcp.accept(socket)
   serve(client)
-  loop_acceptor(socket)
 end
 
 defp serve(socket) do


### PR DESCRIPTION
Function `serve` is an infinite loop itself, so recursive call to `loop_acceptor` is never reached, and thus unneeded.