### PR TITLE
Fix call to loop_acceptor

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -43,6 +43,7 @@ end
 defp loop_acceptor(socket) do
   {:ok, client} = :gen_tcp.accept(socket)
   serve(client)
+  loop_acceptor(socket)
 end
 
 defp serve(socket) do
@@ -51,7 +52,6 @@ defp serve(socket) do
   |> write_line(socket)
 
   serve(socket)
-  loop_acceptor(socket)
 end
 
 defp read_line(socket) do


### PR DESCRIPTION
Amends changes made in PR https://github.com/elixir-lang/elixir-lang.github.com/pull/851. The tail call to `loop_acceptor/1` should go at the end of `loop_acceptor/1`.