### PR TITLE
Rename to_char_list to to_charlist

### DIFF
--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -169,10 +169,10 @@ iex> 'hello'
 
 You can see that, instead of containing bytes, a char list contains the code points of the characters between single-quotes (note that IEx will only output code points if any of the chars is outside the ASCII range). So while double-quotes represent a string (i.e. a binary), single-quotes represents a char list (i.e. a list).
 
-In practice, char lists are used mostly when interfacing with Erlang, in particular old libraries that do not accept binaries as arguments. You can convert a char list to a string and back by using the `to_string/1` and `to_char_list/1` functions:
+In practice, char lists are used mostly when interfacing with Erlang, in particular old libraries that do not accept binaries as arguments. You can convert a char list to a string and back by using the `to_string/1` and `to_charlist/1` functions:
 
 ```iex
-iex> to_char_list "hełło"
+iex> to_charlist "hełło"
 [104, 101, 322, 322, 111]
 iex> to_string 'hełło'
 "hełło"

--- a/getting-started/erlang-libraries.markdown
+++ b/getting-started/erlang-libraries.markdown
@@ -23,7 +23,7 @@ The built-in Elixir String module handles binaries that are UTF-8 encoded.
 you are dealing with binary data that is not necessarily UTF-8 encoded.
 
 ```iex
-iex> String.to_char_list "Ø"
+iex> String.to_charlist "Ø"
 [216]
 iex> :binary.bin_to_list "Ø"
 [195, 152]


### PR DESCRIPTION
Hi!
As far as I understand `to_char_list` is deprecated. I am renaming it to `to_charlist`