### PR TITLE
Update description for adding run method

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -345,7 +345,7 @@ And our server functionality is almost complete! Only tests are missing. This ti
 
 `KVServer.Command.run/1`'s implementation is sending commands directly to the server named `KV.Registry`, which is registered by the `:kv` application. This means this server is global and if we have two tests sending messages to it at the same time, our tests will conflict with each other (and likely fail). We need to decide between having unit tests that are isolated and can run asynchronously, or writing integration tests that work on top of the global state, but exercise our application's full stack as it is meant to be exercised in production.
 
-So far we have only written unit tests, typically testing a single module directly. However, in order to make `KVServer.Command.run/1` testable as a unit we would need to change its implementation to not send commands directly to the `KV.Registry` process but instead pass a server as argument. This means we would need to change `run`'s signature to `def run(command, pid)` and the implementation for the `:create` command would look like:
+So far we have only written unit tests, typically testing a single module directly. However, in order to make `KVServer.Command.run/1` testable as a unit we would need to change its implementation to not send commands directly to the `KV.Registry` process but instead pass a server as argument. This means we would need to change `run`'s signature to `def run(command, pid)`. This means adding another `run` method with different arguments. The implementation for the `:create` command would look like:
 
 ```elixir
 def run({:create, bucket}, pid) do


### PR DESCRIPTION
IMO current version of the tutorial does not make clear a new method must be added. I stumbled upon this and replaced 
```
  def run({:create, bucket}) do
    KV.Registry.create(KV.Registry, bucket)
    {:ok, "OK\r\n"}
  end
```

with

```
  def run({:create, bucket}, pid) do
    KV.Registry.create(pid, bucket)
    {:ok, "OK\r\n"}
  end
```
instead adding another "version" of the method. This confusion could come with OOP way of thinking. I am not a native speaker, so the wording could be changed.