### PR TITLE
Correction to case-cond-and-if Getting Started

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -102,7 +102,7 @@ module defines guards as functions and operators: `bnot`, `~~~`, `band`,
 `&&&`, `bor`, `|||`, `bxor`, `^^^`, `bsl`, `<<<`, `bsr`, `>>>`.
 
 Note that while boolean operators such as `and`, `or`, `not` are allowed in guards,
-the more general and short-circuiting operators `&&`, `||` and `!` are not.
+the more general operators `&&`, `||` and `!` are not.
 
 Keep in mind errors in guards do not leak but instead make the guard fail:
 


### PR DESCRIPTION
Statement appears to be in conflict with Getting Started Guide, [Basic Operators](https://github.com/elixir-lang/elixir-lang.github.com/edit/master/getting-started/basic-operators.markdown) where on line 44 it says.

````
`or` and `and` are short-circuit operators.
````

I removed `short-circuit` when describing `&&`, `||` and `!` usage in guard clauses.