### PR TITLE
Assorted edits

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -46,7 +46,7 @@ iex> rem 10, 3
 
 Notice that parentheses are not required in order to invoke a function.
 
-Elixir also supports shortcut notations for entering binary, octal and hexadecimal numbers:
+Elixir also supports shortcut notations for entering binary, octal, and hexadecimal numbers:
 
 ```iex
 iex> 0b1010
@@ -99,7 +99,7 @@ iex> is_boolean(1)
 false
 ```
 
-You can also use `is_integer/1`, `is_float/1` or `is_number/1` to check, respectively, if an argument is an integer, a float or either.
+You can also use `is_integer/1`, `is_float/1` or `is_number/1` to check, respectively, if an argument is an integer, a float, or either.
 
 > Note: At any moment you can type `h` in the shell to print information on how to use the shell. The `h` helper can also be used to access documentation for any function. For example, typing `h is_integer/1` is going to print the documentation for the `is_integer/1` function. It also works with operators and other constructs (try `h ==/2`).
 
@@ -381,8 +381,8 @@ iex> elem(tuple, 1)
 "hello"
 ```
 
-When "counting" the number of elements in a data structure, Elixir also abides by a simple rule: the function is named `size` if the operation is in constant time (i.e. the value is pre-calculated) or `length` if the operation is linear (i.e. calculating the length gets slower as the input grows).
+When "counting" the number of elements in a data structure, Elixir also abides by a simple rule: the function is named `size` if the operation is in constant time (i.e. the value is pre-calculated) or `length` if the operation is linear (i.e. calculating the length gets slower as the input grows). As a mnemonic, both "length" and "linear" start with "l".
 
 For example, we have used 4 counting functions so far: `byte_size/1` (for the number of bytes in a string), `tuple_size/1` (for the tuple size), `length/1` (for the list length) and `String.length/1` (for the number of graphemes in a string). That said, we use `byte_size` to get the number of bytes in a string, which is cheap, but retrieving the number of unicode characters uses `String.length`, which may be expensive since the whole string needs to be traversed.
 
-Elixir also provides `Port`, `Reference` and `PID` as data types (usually used in process communication), and we will take a quick look at them when talking about processes. For now, let's take a look at some of the basic operators that go with our basic types.
+Elixir also provides `Port`, `Reference`, and `PID` as data types (usually used in process communication), and we will take a quick look at them when talking about processes. For now, let's take a look at some of the basic operators that go with our basic types.

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -10,7 +10,7 @@ redirect_from: /getting_started/1.html
 
 Welcome!
 
-In this tutorial we are going to teach you the Elixir foundation, the language syntax, how to define modules, how to manipulate the characteristics of common data structures and more. This chapter will focus on ensuring Elixir is installed and that you can successfully run Elixir's Interactive Shell, called IEx.
+In this tutorial we are going to teach you the Elixir foundation, the language syntax, how to define modules, how to manipulate the characteristics of common data structures, and more. This chapter will focus on ensuring Elixir is installed and that you can successfully run Elixir's Interactive Shell, called IEx.
 
 Our requirements are:
 
@@ -34,13 +34,16 @@ For now, let's start by running `iex` (or `iex.bat` if you are on Windows) which
 Open up `iex` and type the following expressions:
 
 ```iex
-Interactive Elixir - press Ctrl+C to exit (type h() ENTER for help)
+Erlang/OTP 19 [erts-8.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-iex> 40 + 2
+Interactive Elixir (1.3.4) - press Ctrl+C to exit (type h() ENTER for help)
+iex(1)> 40 + 2
 42
-iex> "hello" <> " world"
+iex(2)> "hello" <> " world"
 "hello world"
 ```
+
+Please note that some details like version numbers may differ a bit in your session, that's not important. From now on `iex` sessions will be stripped down to focus on the code. To exit `iex` press `Ctrl+C` twice.
 
 It seems we are ready to go! We will use the interactive shell quite a lot in the next chapters to get a bit more familiar with the language constructs and basic types, starting in the next chapter.
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ end
     <h4>Fault-tolerance</h4>
 
     <div class="entry-summary">
-      <p>The unavoidable truth about software running in production is that <i>things will go wrong</i>. Even more when we take network, file systems and other third-party resources into account.</p>
+      <p>The unavoidable truth about software running in production is that <i>things will go wrong</i>. Even more when we take network, file systems, and other third-party resources into account.</p>
 
       <p>To cope with failures, Elixir provides supervisors which describe how to restart parts of your system when things go awry, going back to a known initial state that is guaranteed to work:</p>
 
@@ -164,7 +164,7 @@ iex> i "Hello, World"      # Prints information about the given data type
     <h4>Erlang compatible</h4>
 
     <div class="entry-summary">
-      <p>Elixir runs on the Erlang VM giving developers complete access to Erlang&rsquo;s ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="http://www.whatsapp.com">WhatsApp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
+      <p>Elixir runs on the Erlang VM giving developers complete access to Erlang&rsquo;s ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="https://www.whatsapp.com">WhatsApp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
 
 {% highlight iex %}
 iex> :crypto.md5("Using crypto from Erlang OTP")


### PR DESCRIPTION
This patch has assorted edits.

**Oxford comma:** We commented a few days ago with @josevalim that the docs do not use the Oxford comma consistently. It is one of those style details that are worth having uniform across the docs and you need to pick one option and stick to it. Going with the Oxford comma seems to be the safest choice because [a majority of style guides](https://en.wikipedia.org/wiki/Serial_comma) of American English mandate its use.

**Error message of `hd []`:** Completes the output to match the real one.

**`size` vs `length`:** There is a mnemonic to easily remember which of `size` or `length` mean "linear".

**First `iex` session:** The first `iex` session the reader finds has one partial banner. Since this is the first time a session like this is shown I believe readers get more confidence if what they see in the console matches as closely as possible. So I have added the Erlang banner and shell prompts counter. I guess readers will understand the version numbers and minor details may differ.

From then on, it is understandable that `iex` sessions are shown stripped down.

Also, since this is the first session, the patch stresses how to get out of the shell, since the usual `Ctrl-D` and friends do not work, and the reader may have overlooked the message in the banner.

**WhatsApp link:** The HTTP link of WhatsApp redirects to HTTPS, easier to point to that one.
