### PR TITLE
Update install section about Fedora and dnf

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -39,6 +39,8 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Run: `guix package -i elixir`
   * Fedora 21 (and older)
     * Run: `yum install elixir`
+  * Fedora 22 (and newer)
+    * Run `dnf install elixir`
   * FreeBSD
     * From ports: `cd /usr/ports/lang/elixir && make install clean`
     * From pkg: `pkg install elixir`


### PR DESCRIPTION
Since Fedora 22 they switched from yum to dnf tool.

More: https://fedoraproject.org/wiki/F22_release_announcement#Faster_and_better_dependency_management_with_DNF