### PR TITLE
Fixed typo: Extra code fencing near the list of data types.

### DIFF
--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -72,7 +72,6 @@ It's possible to implement protocols for all Elixir data types:
 * `Reference`
 * `Tuple`
 
-```
 
 ## Protocols and structs
 


### PR DESCRIPTION
There appears to be a minor typo in the protocols guide.