### PR TITLE
Update io-and-the-file-system.markdown

### DIFF
--- a/getting-started/io-and-the-file-system.markdown
+++ b/getting-started/io-and-the-file-system.markdown
@@ -9,7 +9,7 @@ title: IO and the file system
 
 This chapter is a quick introduction to input/output mechanisms and file-system-related tasks, as well as to related modules like [`IO`](https://hexdocs.pm/elixir/IO.html), [`File`](https://hexdocs.pm/elixir/File.html) and [`Path`](https://hexdocs.pm/elixir/Path.html).
 
-We had originally sketched this chapter to come much earlier in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the <abbr title="Virtual Machine">VM</abbr>.
+We had originally sketched this chapter to come later in the getting started guide. However, we noticed the IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the <abbr title="Virtual Machine">VM</abbr> so we decided to bring it earlier in the guide.
 
 ## The `IO` module
 


### PR DESCRIPTION
I think there is a logic error in the intro sentence explaining why the chapter is earlier rather than later in the guide.