### PR TITLE
Implement protocol for BitString to make it work for strings

### DIFF
--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -25,8 +25,8 @@ end
 The `Size` protocol expects a function called `size` that receives one argument (the data structure we want to know the size of) to be implemented. We can now implement this protocol for the data structures that would have a compliant implementation:
 
 ```elixir
-defimpl Size, for: Binary do
-  def size(binary), do: byte_size(binary)
+defimpl Size, for: BitString do
+  def size(string), do: byte_size(string)
 end
 
 defimpl Size, for: Map do


### PR DESCRIPTION
Implementing the protocol for `Binary` does not work with strings. Instead we need to implement it for `BitString` in 1.3.4.

I guess this should be fixed (hopefully soon) as it is related to the code, not just the documentation or error messages. Please correct me, if i got it wrong.