### PR TITLE
Comprehension example a bit clearer by providing ``dirs``

### DIFF
--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -48,6 +48,7 @@ Comprehensions discard all elements for which the filter expression returns `fal
 Comprehensions generally provide a much more concise representation than using the equivalent functions from the `Enum` and `Stream` modules. Furthermore, comprehensions also allow multiple generators and filters to be given. Here is an example that receives a list of directories and gets the size of each file in those directories:
 
 ```elixir
+dirs = ['/home/mikey', '/home/james']
 for dir  <- dirs,
     file <- File.ls!(dir),
     path = Path.join(dir, file),


### PR DESCRIPTION
It's a small thing, but because this is the first example with multiple generators in comprehension for some reason it confused me a bit more than it should have, and I think it makes it easier to read the first time around if ``dirs`` are explicitly set.