### PR TITLE
Fix end of fenced code blocks

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -364,7 +364,7 @@ end
 
 Now, if the registry worker crashes, both the registry and the "rest" of `KV.Supervisor`'s children (i.e. `KV.Bucket.Supervisor`) will be restarted. However, if `KV.Bucket.Supervisor` crashes, `KV.Registry` will not be restarted, because it was started prior to `KV.Bucket.Supervisor`.
 
-There are other strategies and other options that could be given to `worker/2`, `supervisor/2` and `supervise/2` functions, so don't forget to check both [`Supervisor`](https://hexdocs.pm/elixir/Supervisor.html) and [`Supervisor.Spec`](https://hexdocs.pm/elixir/Supervisor.Spec.html) modules. 
+There are other strategies and other options that could be given to `worker/2`, `supervisor/2` and `supervise/2` functions, so don't forget to check both [`Supervisor`](https://hexdocs.pm/elixir/Supervisor.html) and [`Supervisor.Spec`](https://hexdocs.pm/elixir/Supervisor.Spec.html) modules.
 
 To help developers remember how to work with Supervisors and its convenience functions, [Benjamin Tan Wei Hao](http://benjamintan.io/) has created a [Supervisor cheat sheet](https://raw.githubusercontent.com/benjamintanweihao/elixir-cheatsheets/master/Supervisor_CheatSheet.pdf).
 
@@ -382,7 +382,7 @@ A GUI should pop-up containing all sorts of information about our system, from g
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:
 
-<img src="/images/contents/kv-observer.png" width="640px">
+<img src="/images/contents/kv-observer.png" width="640px"/>
 
 Not only that, as you create new buckets on the terminal, you should see new processes spawned in the supervision tree shown in Observer:
 

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -154,7 +154,7 @@ iex> is_function(fun)
 true
 iex> fun.(0)
 true
-````
+```
 
 Local or imported functions, like `is_function/1`, can be captured without the module:
 

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -36,7 +36,7 @@ A variable can only be assigned on the left side of `=`:
 ```iex
 iex> 1 = unknown
 ** (CompileError) iex:1: undefined function unknown/0
-````
+```
 
 Since there is no variable `unknown` previously defined, Elixir imagined you were trying to call a function named `unknown/0`, but such a function does not exist.
 


### PR DESCRIPTION
This commit also closes correctly the `img` tag element in the "Supervisor and Application" lesson.