### PR TITLE
Edits in the "alias, require, and import" chapter

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -1,6 +1,6 @@
 ---
 layout: getting-started
-title: alias, require and import
+title: alias, require, and import
 ---
 
 # {{ page.title }}
@@ -27,23 +27,20 @@ We are going to explore them in detail now. Keep in mind the first three are cal
 
 ## alias
 
-`alias` allows you to set up aliases for any given module name. Imagine our `Math` module uses a special list implementation for doing math specific operations:
+`alias` allows you to set up aliases for any given module name.
+
+Imagine a module uses a specialized list implemented in `Math.List`. The `alias` directive allows referring to `Math.List` just as `List` within the module definition:
 
 ```elixir
-defmodule Math do
+defmodule Stats do
   alias Math.List, as: List
+  # In the remaining module definition List expands to Math.List.
 end
 ```
 
-From now on, any reference to `List` will automatically expand to `Math.List`. In case one wants to access the original `List`, it can be done by prefixing the module name with `Elixir.`:
+The original `List` can still be accessed within `Stats` by the fully-qualified name `Elixir.List`.
 
-```elixir
-List.flatten             #=> uses Math.List.flatten
-Elixir.List.flatten      #=> uses List.flatten
-Elixir.Math.List.flatten #=> uses Math.List.flatten
-```
-
-> Note: All modules defined in Elixir are defined inside a main Elixir namespace. However, for convenience, you can omit "Elixir." when referencing them.
+> Note: All modules defined in Elixir are defined inside a main `Elixir` namespace. However, for convenience, you can omit "Elixir." when referencing them.
 
 Aliases are frequently used to define shortcuts. In fact, calling `alias` without an `:as` option sets the alias automatically to the last part of the module name, for example:
 
@@ -82,7 +79,7 @@ Macros are chunks of code that are executed and expanded at compilation time. Th
 
 ```iex
 iex> Integer.is_odd(3)
-** (CompileError) iex:1: you must require Integer before invoking the macro Integer.is_odd/1
+** (UndefinedFunctionError) function Integer.is_odd/1 is undefined or private. However there is a macro with the same name and arity. Be sure to require Integer if you intend to invoke this macro
 iex> require Integer
 Integer
 iex> Integer.is_odd(3)
@@ -166,8 +163,6 @@ defmodule Example do
 end
 ```
 
-With this we have almost finished our tour of Elixir modules. The last topic to cover is module attributes.
-
 ## Understanding Aliases
 
 At this point, you may be wondering: what exactly is an Elixir alias and how is it represented?
@@ -226,3 +221,5 @@ From Elixir v1.2, it is possible to alias, import or require multiple modules at
 ```elixir
 alias MyApp.{Foo, Bar, Baz}
 ```
+
+With this we have finished our tour of Elixir modules. The last topic to cover is module attributes.


### PR DESCRIPTION
Besides the details like the Oxford comma and such, the main edit in this patch rewords a bit the introduction of `alias`.

The original example has a complete module definition

```elixir
defmodule Math do
  alias Math.List, as: List
end
```

and the text starts saying

> From now on, any reference to `List` will automatically expand to `Math.List`.

If you look at the two, you'll see "From now on" is not as clear as it could be, because there is not even a place in which the alias is effective. The text introduces `alias` with an example in which the directive has no effect. Moreover, at this point the reader does not know `alias` has lexical scope, so they could wrongly believe that maybe "From now on" has a wider scope.

In addition to that, if `Math.List` was implemented within `Math`, then the aliasing is automatic. Thus, the description kind of takes for granted `Math.List` is implemented elsewhere. But since the scope does not match, why should nesting match (the reader may wonder).

The proposal addresses these two points with two minimal changes:

* Adds a comment in the example that indicates the scope of the aliasing, and explicitly says this alias is effective "within the module definition" (from that point on).
* Renames the main module to `Stats`, which is a lateral kick to the second issue.
