### PR TITLE
Replace deprecated :crypto.md5 call with :crypto.hash(:md5, str)

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@ iex> i "Hello, World"      # Prints information about the given data type
       <p>Elixir runs on the Erlang VM giving developers complete access to Erlang&rsquo;s ecosystem, used by companies like <a href="https://www.heroku.com">Heroku</a>, <a href="https://www.whatsapp.com">WhatsApp</a>, <a href="https://klarna.com">Klarna</a>, <a href="http://basho.com">Basho</a> and many more to build distributed, fault-tolerant applications. An Elixir programmer can invoke any Erlang function with no runtime cost:</p>
 
 {% highlight iex %}
-iex> :crypto.md5("Using crypto from Erlang OTP")
+iex> :crypto.hash(:md5, "Using crypto from Erlang OTP")
 <<192, 223, 75, 115, ...>>
 {% endhighlight %}
 


### PR DESCRIPTION
I kept getting this warning in iex:

`warning: crypto:md5/1 is deprecated and will be removed in a future release; use crypto:hash/2`

The documentation on the front page uses `crypto.md5`. I changed this in favour of `crypto.hash`. 