### PR TITLE
Final minor details

### DIFF
--- a/getting-started/erlang-libraries.markdown
+++ b/getting-started/erlang-libraries.markdown
@@ -29,7 +29,7 @@ iex> :binary.bin_to_list "Ø"
 [195, 152]
 ```
 
-The above example shows the difference; the `String` module returns UTF-8
+The above example shows the difference; the `String` module returns Unicode
 codepoints, while `:binary` deals with raw data bytes.
 
 ## Formatted text output
@@ -80,9 +80,6 @@ functions for dealing with directed graphs built of vertices and edges.
 After constructing the graph, the algorithms in there will help finding
 for instance the shortest path between two vertices, or loops in the graph.
 
-Note that the functions in `:digraph` alter the graph structure indirectly
-as a side effect, while returning the added vertices or edges.
-
 Given three vertices, find the shortest path from the first to the last.
 
 ```iex
@@ -94,6 +91,9 @@ iex> :digraph.add_edge(digraph, v1, v2)
 iex> :digraph.get_short_path(digraph, v0, v2)
 [{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}]
 ```
+
+Note that the functions in `:digraph` alter the graph structure in-place, this
+is possible because they are implemented as ETS tables, explained next.
 
 ## Erlang Term Storage
 
@@ -116,15 +116,15 @@ iex> :ets.insert(table, {"China", 1_374_000_000})
 iex> :ets.insert(table, {"India", 1_284_000_000})
 iex> :ets.insert(table, {"USA", 322_000_000})
 iex> :ets.i(table)
-<1   > {"USA", 322000000}
-<2   > {"China", 1_374_000_000}
-<3   > {"India", 1_284_000_000}
+<1   > {<<"India">>,1284000000}
+<2   > {<<"USA">>,322000000}
+<3   > {<<"China">>,1374000000}
 ```
 
 ## The math module
 
 [The `math` module](http://erlang.org/doc/man/math.html) contains common
-mathematical operations covering trigonometry, exponential and logarithmic
+mathematical operations covering trigonometry, exponential, and logarithmic
 functions.
 
 ```iex
@@ -174,10 +174,10 @@ iex> :rand.uniform(6)
 
 ## The zip and zlib modules
 
-[The `zip` module](http://erlang.org/doc/man/zip.html) lets you read and write zip files to and from disk or memory,
-as well as extracting file information.
+[The `zip` module](http://erlang.org/doc/man/zip.html) lets you read and write
+ZIP files to and from disk or memory, as well as extracting file information.
 
-This code counts the number of files in a zip file:
+This code counts the number of files in a ZIP file:
 
 ```iex
 iex> :zip.foldl(fn _, _, _, acc -> acc + 1 end, 0, :binary.bin_to_list("file.zip"))

--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -11,8 +11,9 @@ title: Typespecs and behaviours
 
 Elixir is a dynamically typed language, so all types in Elixir are inferred by the runtime. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
 
-1. declaring custom data types;
-2. declaring typed function signatures (specifications).
+1. declaring typed function signatures (specifications);
+2. declaring custom data types.
+
 
 ### Function specifications
 
@@ -35,7 +36,7 @@ Elixir supports compound types as well. For example, a list of integers has type
 
 While Elixir provides a lot of useful built-in types, it's convenient to define custom types when appropriate. This can be done when defining modules through the `@type` directive.
 
-Say we have a `LousyCalculator` module, which performs the usual arithmetic operations (sum, product and so on) but, instead of returning numbers, it returns tuples with the result of an operation as the first element and a random remark as the second element.
+Say we have a `LousyCalculator` module, which performs the usual arithmetic operations (sum, product, and so on) but, instead of returning numbers, it returns tuples with the result of an operation as the first element and a random remark as the second element.
 
 ```elixir
 defmodule LousyCalculator do

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -17,7 +17,7 @@ In order to get your first project started, Elixir ships with a build tool calle
 $ mix new path/to/new/project
 ```
 
-We have written a guide that covers how to build an Elixir application, with its own supervision tree, configuration, tests and more. The application works as a distributed key-value store where we organize key-value pairs into buckets and distribute those buckets across multiple nodes:
+We have written a guide that covers how to build an Elixir application, with its own supervision tree, configuration, tests, and more. The application works as a distributed key-value store where we organize key-value pairs into buckets and distribute those buckets across multiple nodes:
 
 * [Mix and OTP](/getting-started/mix-otp/introduction-to-mix.html)
 
@@ -29,7 +29,7 @@ Elixir is an extensible and very customizable programming language thanks to its
 
 ## Community and other resources
 
-We have a [Learning](/learning.html) section that suggests books, screencasts and other resources for learning Elixir and exploring the ecosystem. There are also plenty of Elixir resources out there, like conference talks, open source projects, and other learning material produced by the community.
+We have a [Learning](/learning.html) section that suggests books, screencasts, and other resources for learning Elixir and exploring the ecosystem. There are also plenty of Elixir resources out there, like conference talks, open source projects, and other learning material produced by the community.
 
 Don't forget that you can also check the [source code of Elixir itself](https://github.com/elixir-lang/elixir), which is mostly written in Elixir (mainly the `lib` directory), or [explore Elixir's documentation](/docs.html).
 
@@ -41,4 +41,4 @@ Elixir runs on the Erlang Virtual Machine and, sooner or later, an Elixir develo
 
 * Erlang's official website has a short [tutorial](http://www.erlang.org/course/concurrent_programming.html) with pictures that briefly describe Erlang's primitives for concurrent programming.
 
-* [Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/) is an excellent introduction to Erlang, its design principles, standard library, best practices and much more. Once you have read through the crash course mentioned above, you'll be able to safely skip the first couple of chapters in the book that mostly deal with the syntax. When you reach [The Hitchhiker's Guide to Concurrency](http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency) chapter, that's where the real fun starts.
+* [Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/) is an excellent introduction to Erlang, its design principles, standard library, best practices, and much more. Once you have read through the crash course mentioned above, you'll be able to safely skip the first couple of chapters in the book that mostly deal with the syntax. When you reach [The Hitchhiker's Guide to Concurrency](http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency) chapter, that's where the real fun starts.


### PR DESCRIPTION
I have completed the getting started guide, here's a last patch with minor details.

Things that deserve a comment:

* When I read the paragraph that says that the digraph API modifies the graph in-place I wondered what is this vodoo :). Given this API is like nothing you've seen before, I believe a short explanation would leave the reader less puzzled. I have reordered the exposition to come after the shell session, and leveraged that ETS comes next to explain and connect in one shot.

* "ZIP" is the most common spelling I'd say. For example look at its [MIME registration](http://www.iana.org/assignments/media-types/application/zip). [Wikipedia uses ".ZIP"](https://en.wikipedia.org/wiki/Zip_(file_format)), with a leading dot, but in any case you do not write "zip files" normally. Different from zlib, whose [own documentation](http://www.zlib.net/) consistently writes it in lowercase.

* In the typespecs guide the patch reorders the list to match the order of the following sections.