### PR TITLE
Update mix.exs of guide to use :extra_applications

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -169,7 +169,7 @@ defmodule KVServer.Mixfile do
   end
 
   def application do
-    [applications: [:logger],
+    [extra_applications: [:logger],
      mod: {KVServer, []}]
   end
 
@@ -195,7 +195,7 @@ The second change is in the `application` function inside `mix.exs`:
 
 ```elixir
 def application do
-  [applications: [:logger],
+  [extra_applications: [:logger],
    mod: {KVServer, []}]
 end
 ```
@@ -247,7 +247,7 @@ The line above makes `:kv` available as a dependency inside `:kv_server`. We can
 
 ```elixir
 def application do
-  [applications: [:logger, :kv],
+  [extra_applications: [:logger, :kv],
    mod: {KVServer, []}]
 end
 ```

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -296,7 +296,7 @@ Open up `apps/kv/mix.exs` and change the `application/0` function to return the 
 
 ```elixir
 def application do
-  [applications: [],
+  [extra_applications: [:logger],
    env: [routing_table: []],
    mod: {KV, []}]
 end

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -102,7 +102,7 @@ defmodule KV.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -175,7 +175,7 @@ We can configure the application callback in two steps. First, open up the `mix.
 
 ```elixir
 def application do
-  [applications: [:logger],
+  [extra_applications: [:logger],
    mod: {KV, []}]
 end
 ```


### PR DESCRIPTION
Mix 1.4 introduced automatic inference of required applications from
dependencies list. Now Mix creates `:extra_applications` instead of
`:applications` by default in application configuration in `mix.exs`.
This commit updates the example `mix.exs` configurations in the guide to
reflect that change.

Signed-off-by: Bonghyun Kim <bonghyun.d.kim@gmail.com>