### PR TITLE
Update Mix and OTP guide for Elixir 1.4

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -170,7 +170,7 @@ defmodule KVServer.Mixfile do
 
   def application do
     [extra_applications: [:logger],
-     mod: {KVServer, []}]
+     mod: {KVServer.Application, []}]
   end
 
   defp deps do
@@ -196,25 +196,33 @@ The second change is in the `application` function inside `mix.exs`:
 ```elixir
 def application do
   [extra_applications: [:logger],
-   mod: {KVServer, []}]
+   mod: {KVServer.Application, []}]
 end
 ```
 
-Because we passed the `--sup` flag, Mix automatically added `mod: {KVServer, []}`, specifying that `KVServer` is our application callback module. `KVServer` will start our application supervision tree.
+Because we passed the `--sup` flag, Mix automatically added `mod: {KVServer.Application, []}`, specifying that `KVServer.Application` is our application callback module. `KVServer.Application` will start our application supervision tree.
 
-In fact, let's open up `lib/kv_server.ex`:
+In fact, let's open up `lib/kv_server/application.ex`:
 
 ```elixir
-defmodule KVServer do
+defmodule KVServer.Application do
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
   use Application
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    # Define workers and child supervisors to be supervised
     children = [
-      # worker(KVServer.Worker, [arg1, arg2, arg3])
+      # Starts a worker by calling: KVServer.Worker.start_link(arg1, arg2, arg3)
+      # worker(KVServer.Worker, [arg1, arg2, arg3]),
     ]
 
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: KVServer.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -84,9 +84,9 @@ iex> pid = Node.spawn_link :"foo@computer-name", fn ->
 ...>   end
 ...> end
 #PID<9014.59.0>
-iex> send pid, {:ping, self}
+iex> send pid, {:ping, self()}
 {:ping, #PID<0.73.0>}
-iex> flush
+iex> flush()
 :pong
 :ok
 ```
@@ -138,7 +138,7 @@ From inside `bar@computer-name`, we can now spawn a task directly on the other n
 iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, fn ->
 ...>   {:ok, node()}
 ...> end
-%Task{pid: #PID<12467.88.0>, ref: #Reference<0.0.0.400>}
+%Task{owner: #PID<0.122.0>, pid: #PID<12467.88.0>, ref: #Reference<0.0.0.400>}
 iex> Task.await(task)
 {:ok, :"foo@computer-name"}
 ```
@@ -147,7 +147,7 @@ Our first distributed task retrieves the name of the node the task is running on
 
 ```iex
 iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, Kernel, :node, []
-%Task{pid: #PID<12467.88.0>, ref: #Reference<0.0.0.400>}
+%Task{owner: #PID<0.122.0>, pid: #PID<12467.89.0>, ref: #Reference<0.0.0.404>}
 iex> Task.await(task)
 :"foo@computer-name"
 ```
@@ -170,9 +170,9 @@ defmodule KV.Router do
     # Get the first byte of the binary
     first = :binary.first(bucket)
 
-    # Try to find an entry in the table or raise
+    # Try to find an entry in the table() or raise
     entry =
-      Enum.find(table, fn {enum, _node} ->
+      Enum.find(table(), fn {enum, _node} ->
         first in enum
       end) || no_entry_error(bucket)
 
@@ -187,7 +187,7 @@ defmodule KV.Router do
   end
 
   defp no_entry_error(bucket) do
-    raise "could not find entry for #{inspect bucket} in table #{inspect table}"
+    raise "could not find entry for #{inspect bucket} in table() #{inspect table()}"
   end
 
   @doc """

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -181,7 +181,7 @@ defmodule KVServer.Command do
 end
 ```
 
-Before we implement this function, let's change our server to start using our new `parse/1` and `run/1` functions. Remember, our `read_line/1` function was also crashing when the client closed the socket, so let's take the opportunity to fix it, too. Open up `lib/kv_server.ex` and replace the existing server definition:
+Before we implement this function, let's change our server to start using our new `parse/1` and `run/1` functions. Remember, our `read_line/1` function was also crashing when the client closed the socket, so let's take the opportunity to fix it, too. Open up `lib/kv_server/application.ex` and replace the existing server definition:
 
 ```elixir
 defp serve(socket) do
@@ -333,7 +333,7 @@ Every function clause dispatches the appropriate command to the `KV.Registry` se
 
 Note that we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
 
-By the way, since we are now returning `{:error, :not_found}`, we should amend the `write_line/2` function in `KVServer` to print such error as well:
+By the way, since we are now returning `{:error, :not_found}`, we should amend the `write_line/2` function in `KVServer.Application` to print such error as well:
 
 ```elixir
 defp write_line(socket, {:error, :not_found}) do
@@ -422,7 +422,7 @@ This time, since our test relies on global data, we have not given `async: true`
 
 To avoid printing log messages during tests, ExUnit provides a neat feature called `:capture_log`. By setting `@tag :capture_log` before each test or `@moduletag :capture_log` for the whole test case, ExUnit will automatically capture anything that is logged while the test runs. In case our test fails, the captured logs will be printed alongside the ExUnit report.
 
-Before setup, add the following call:
+Between `use ExUnit.Case` and setup, add the following call:
 
 ```elixir
 @moduletag :capture_log

--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -22,7 +22,7 @@ ETS allows us to store any Elixir term in an in-memory table. Working with ETS t
 ```iex
 iex> table = :ets.new(:buckets_registry, [:set, :protected])
 8207
-iex> :ets.insert(table, {"foo", self})
+iex> :ets.insert(table, {"foo", self()})
 true
 iex> :ets.lookup(table, "foo")
 [{"foo", #PID<0.41.0>}]
@@ -35,7 +35,7 @@ ETS tables can also be named, allowing us to access them by a given name:
 ```iex
 iex> :ets.new(:buckets_registry, [:named_table])
 :buckets_registry
-iex> :ets.insert(:buckets_registry, {"foo", self})
+iex> :ets.insert(:buckets_registry, {"foo", self()})
 true
 iex> :ets.lookup(:buckets_registry, "foo")
 [{"foo", #PID<0.41.0>}]

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -190,7 +190,7 @@ iex> Process.monitor(pid)
 #Reference<0.0.0.551>
 iex> Agent.stop(pid)
 :ok
-iex> flush
+iex> flush()
 {:DOWN, #Reference<0.0.0.551>, :process, #PID<0.66.0>, :normal}
 ```
 


### PR DESCRIPTION
Reflect new application directory structure from `mix new MyApp --sup`
in Mix 1.4.

Add parentheses to function calls used like variable, like `self()`,
`table()`, `flush()`.

Change a few wordings for better clarity.

Other minor changes like the result of `Task.async`.

Signed-off-by: Bonghyun Kim <bonghyun.d.kim@gmail.com>