### PR TITLE
Behaviours do not return compile time warnings

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -134,5 +134,3 @@ defmodule YAMLParser do
   def extensions, do: ["yml"]
 end
 ```
-
-If a module adopting a given behaviour doesn't implement one of the callbacks required by that behaviour, a compile-time warning will be generated.


### PR DESCRIPTION
I tried reproducing what this page says to do, but I don't see any compile time warnings: https://gist.github.com/radar/baf6251ea0891fc043828cb32a65ba5d. What JSONParser returns is a String, while YAMLParser returns a List. 

Maybe I am just misunderstanding this bit of documentation and so it should be improved to help that misunderstanding?

I have the above code in a sample project and running `mix compile` does not show me any warnings at all.

How do I make it do the compile time warning if that is what should be happening?