### PR TITLE
Specify elixir version in appropriate places

### DIFF
--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -23,7 +23,7 @@ Let's get started!
 
 ## Installation
 
-If you still haven't installed Elixir, run to our [installation page](/install.html). Once you are done, you can run `elixir -v` to get the current Elixir version.
+If you still haven't installed Elixir, run to our [installation page](/install.html). Once you are done, you can run `elixir --version` to get the current Elixir version.
 
 ## Interactive mode
 

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -39,7 +39,7 @@ In order to build our key-value application, we are going to use three main tool
 
 In this chapter, we will create our first project using Mix and explore different features in  <abbr title="Open Telecom Platform">OTP</abbr>, Mix and ExUnit as we go.
 
-> Note: this guide requires Elixir v1.2.0 or later. You can check your Elixir version with `elixir -v` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting-started/introduction.html).
+> Note: this guide requires Elixir v1.2.0 or later. You can check your Elixir version with `elixir --version` and install a more recent version if required by following the steps described in [the first chapter of the Getting Started guide](/getting-started/introduction.html).
 >
 > If you have any questions or improvements to the guide, please reach discussion channels such as the [Elixir Forum](https://elixirforum.com) or the [issues tracker](https://github.com/elixir-lang/elixir-lang.github.com/issues). Your input is really important to help us guarantee the guides are accessible and up to date!
 >

--- a/install.markdown
+++ b/install.markdown
@@ -74,7 +74,6 @@ If necessary replace "jessie" with the name of your Raspian release.
   * Install Elixir
     * Update apt to latest: `sudo apt update`     
     * Run: `sudo apt install elixir`   
-    * Check: `elixir -v`   
 
 ### Docker
 
@@ -145,3 +144,7 @@ On **Unix systems**, you need to [find your shell profile file](https://unix.sta
 ```bash
 export PATH="$PATH:/path/to/elixir/bin"
 ```
+
+## Checking the installed version of Elixir
+
+Once you have Elixir installed, you can check its version by running `elixir --version`.


### PR DESCRIPTION
Based on the discussion [here](https://github.com/elixir-lang/elixir-lang.github.com/issues/924) we're also renaming the preferred way to find one's currently installed Elixir version. 