### PR TITLE
Keep latest Elixir versions in a data file

### DIFF
--- a/_data/elixir_version.yml
+++ b/_data/elixir_version.yml
@@ -1,0 +1,23 @@
+v1_0:
+  name: "v1.0"
+  version: "1.0.5"
+
+v1_1:
+  name: "v1.1"
+  version: "1.1.1"
+
+v1_2:
+  name: "v1.2"
+  version: "1.2.6"
+
+v1_3:
+  name: "v1.3"
+  version: "1.3.3"
+
+v1_4:
+  name: "v1.4"
+  version: "1.4.0"
+
+stable:
+  name: "v1.4"
+  version: "1.4.0"

--- a/docs.markdown
+++ b/docs.markdown
@@ -61,3 +61,12 @@ Choose which version you want documentation for.
 * [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_1.version }}/) - interactive shell
 * [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_1.version }}/) - built-in Logger
 * [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_1.version }}/) - build tool
+
+<h4 id="v1.0">v1.0</h4>
+
+* [Elixir](https://hexdocs.pm/elixir/{{ site.data.elixir_version.v1_0.version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ site.data.elixir_version.v1_0.version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ site.data.elixir_version.v1_0.version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_0.version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_0.version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_0.version }}/) - build tool

--- a/docs.markdown
+++ b/docs.markdown
@@ -26,38 +26,38 @@ Choose which version you want documentation for.
 * [Logger](https://hexdocs.pm/logger/master/) - built-in Logger
 * [Mix](https://hexdocs.pm/mix/master/) - build tool
 
-<h4 id="v1.4">v1.4 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.4.0/Docs.zip">download</a>)</small></h4>
+<h4 id="v1.4">v1.4 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ site.data.elixir_version.v1_4.version }}/Docs.zip">download</a>)</small></h4>
 
-* [Elixir](https://hexdocs.pm/elixir/1.4.0/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.4.0/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.4.0/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.4.0/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.4.0/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.4.0/) - build tool
+* [Elixir](https://hexdocs.pm/elixir/{{ site.data.elixir_version.v1_4.version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ site.data.elixir_version.v1_4.version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ site.data.elixir_version.v1_4.version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_4.version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_4.version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_4.version }}/) - build tool
 
-<h4 id="v1.3">v1.3 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.3.3/Docs.zip">download</a>)</small></h4>
+<h4 id="v1.3">v1.3 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ site.data.elixir_version.v1_3.version }}/Docs.zip">download</a>)</small></h4>
 
-* [Elixir](https://hexdocs.pm/elixir/1.3.3/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.3.3/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.3.3/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.3.3/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.3.3/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.3.3/) - build tool
+* [Elixir](https://hexdocs.pm/elixir/{{ site.data.elixir_version.v1_3.version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ site.data.elixir_version.v1_3.version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ site.data.elixir_version.v1_3.version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_3.version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_3.version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_3.version }}/) - build tool
 
-<h4 id="v1.2">v1.2 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.2.6/Docs.zip">download</a>)</small></h4>
+<h4 id="v1.2">v1.2 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ site.data.elixir_version.v1_2.version }}/Docs.zip">download</a>)</small></h4>
 
-* [Elixir](https://hexdocs.pm/elixir/1.2.6/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.2.6/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.2.6/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.2.6/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.2.6/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.2.6/) - build tool
+* [Elixir](https://hexdocs.pm/elixir/{{ site.data.elixir_version.v1_2.version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ site.data.elixir_version.v1_2.version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ site.data.elixir_version.v1_2.version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_2.version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_2.version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_2.version }}/) - build tool
 
-<h4 id="v1.1">v1.1 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.1.1/Docs.zip">download</a>)</small></h4>
+<h4 id="v1.1">v1.1 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ site.data.elixir_version.v1_1.version }}/Docs.zip">download</a>)</small></h4>
 
-* [Elixir](https://hexdocs.pm/elixir/1.1.1/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.1.1/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.1.1/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.1.1/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.1.1/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.1.1/) - build tool
+* [Elixir](https://hexdocs.pm/elixir/{{ site.data.elixir_version.v1_1.version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ site.data.elixir_version.v1_1.version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ site.data.elixir_version.v1_1.version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ site.data.elixir_version.v1_1.version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ site.data.elixir_version.v1_1.version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ site.data.elixir_version.v1_1.version }}/) - build tool


### PR DESCRIPTION
We keep all the latest versions in one file, so we don't need to update them many places.
Additionally it adds links to the Elixir v1.0 docs