### PR TITLE
Link directly to latest version compressed files in Install page

### DIFF
--- a/_data/elixir-versions.yml
+++ b/_data/elixir-versions.yml
@@ -1,0 +1,26 @@
+stable: v1_4
+
+v1_0:
+  name: v1.0
+  version: 1.0.5
+  docs_zip: false
+
+v1_1:
+  name: v1.1
+  version: 1.1.1
+  docs_zip: true
+
+v1_2:
+  name: v1.2
+  version: 1.2.6
+  docs_zip: true
+
+v1_3:
+  name: v1.3
+  version: 1.3.3
+  docs_zip: true
+
+v1_4:
+  name: v1.4
+  version: 1.4.0
+  docs_zip: true

--- a/docs.markdown
+++ b/docs.markdown
@@ -8,7 +8,13 @@ layout: default
 
 Choose which version you want documentation for.
 
-#### Stable
+{% assign stable = site.data.elixir-versions[site.data.elixir-versions.stable] %}
+
+<h4 id="stable">Stable
+  {% if stable.docs_zip == true %}
+    <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/Docs.zip">download</a>)</small>
+  {% endif %}
+</h4>
 
 * [Elixir](https://hexdocs.pm/elixir/) - standard library
 * [EEx](https://hexdocs.pm/eex/) - templating library
@@ -26,38 +32,19 @@ Choose which version you want documentation for.
 * [Logger](https://hexdocs.pm/logger/master/) - built-in Logger
 * [Mix](https://hexdocs.pm/mix/master/) - build tool
 
-<h4 id="v1.4">v1.4 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.4.0/Docs.zip">download</a>)</small></h4>
+{% for version in site.data.elixir-versions reversed %}
+  {% if version[0] == 'stable' %}
+    {% continue %}
+  {% endif %}
 
-* [Elixir](https://hexdocs.pm/elixir/1.4.0/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.4.0/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.4.0/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.4.0/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.4.0/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.4.0/) - build tool
+<h4 id="{{ version[1].name }}">{{ version[1].name }}
+  {% if version[1].docs_zip == true %}<small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v{{ version[1].version }}/Docs.zip">download</a>)</small>{% endif %}
+</h4>
 
-<h4 id="v1.3">v1.3 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.3.3/Docs.zip">download</a>)</small></h4>
-
-* [Elixir](https://hexdocs.pm/elixir/1.3.3/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.3.3/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.3.3/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.3.3/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.3.3/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.3.3/) - build tool
-
-<h4 id="v1.2">v1.2 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.2.6/Docs.zip">download</a>)</small></h4>
-
-* [Elixir](https://hexdocs.pm/elixir/1.2.6/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.2.6/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.2.6/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.2.6/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.2.6/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.2.6/) - build tool
-
-<h4 id="v1.1">v1.1 <small>(<a href="https://github.com/elixir-lang/elixir/releases/download/v1.1.1/Docs.zip">download</a>)</small></h4>
-
-* [Elixir](https://hexdocs.pm/elixir/1.1.1/) - standard library
-* [EEx](https://hexdocs.pm/eex/1.1.1/) - templating library
-* [ExUnit](https://hexdocs.pm/ex_unit/1.1.1/) - unit test library
-* [IEx](https://hexdocs.pm/iex/1.1.1/) - interactive shell
-* [Logger](https://hexdocs.pm/logger/1.1.1/) - built-in Logger
-* [Mix](https://hexdocs.pm/mix/1.1.1/) - build tool
+* [Elixir](https://hexdocs.pm/elixir/{{ version[1].version }}/) - standard library
+* [EEx](https://hexdocs.pm/eex/{{ version[1].version }}/) - templating library
+* [ExUnit](https://hexdocs.pm/ex_unit/{{ version[1].version }}/) - unit test library
+* [IEx](https://hexdocs.pm/iex/{{ version[1].version }}/) - interactive shell
+* [Logger](https://hexdocs.pm/logger/{{ version[1].version }}/) - built-in Logger
+* [Mix](https://hexdocs.pm/mix/{{ version[1].version }}/) - build tool
+{% endfor %}

--- a/install.markdown
+++ b/install.markdown
@@ -3,6 +3,7 @@ title: "Installing Elixir"
 section: install
 layout: default
 ---
+{% assign stable = site.data.elixir-versions[site.data.elixir-versions.stable] %}
 
 # {{ page.title }}
 
@@ -88,7 +89,7 @@ Those distributions will likely install Erlang automatically for you too. In cas
 
 ## Precompiled package
 
-Elixir provides a precompiled package for every release. First [install Erlang](/install.html#installing-erlang) and then download and unzip the [Precompiled.zip file for the latest release](https://github.com/elixir-lang/elixir/releases/).
+Elixir provides a precompiled package for every release. First [install Erlang](/install.html#installing-erlang) and then download and unzip the [Precompiled.zip file for the latest release](https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/Precompiled.zip).
 
 Once the release is unpacked, you are ready to run the `elixir` and `iex` commands from the `bin` directory, but we recommend you to [add Elixir's bin path to your PATH environment variable](#setting-path-environment-variable) to ease development.
 
@@ -107,7 +108,7 @@ If you would prefer to compile from source manually, don't worry, we got your ba
 
 You can download and compile Elixir in few steps. The first one is to [install Erlang](/install.html#installing-erlang).
 
-Next you should download the [latest release](https://github.com/elixir-lang/elixir/releases/), unpack it and then run `make` inside the unpacked directory (note: if you are running on Windows, [read this page on setting up your environment for compiling Elixir](https://github.com/elixir-lang/elixir/wiki/Windows)).
+Next you should download source code ([.zip](https://github.com/elixir-lang/elixir/archive/v{{ stable.version }}.zip), [.tar.gz](https://github.com/elixir-lang/elixir/archive/v{{ stable.version }}.tar.gz)) of the [latest release](https://github.com/elixir-lang/elixir/releases/tag/v{{ stable.version }}), unpack it and then run `make` inside the unpacked directory (note: if you are running on Windows, [read this page on setting up your environment for compiling Elixir](https://github.com/elixir-lang/elixir/wiki/Windows)).
 
 After compiling, you are ready to run the elixir and `iex` commands from the bin directory. It is recommended that you [add Elixir's bin path to your PATH environment variable](#setting-path-environment-variable) to ease development.
 


### PR DESCRIPTION
based on chages proposed in https://github.com/elixir-lang/elixir-lang.github.com/pull/931

Link directly to latest version compressed files in Install page
- stable Precompiled.zip
- stable source code (zip and tar.gz)