### PR TITLE
Correct `KV.Supervisor` call to `init`

### DIFF
--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -116,7 +116,7 @@ We can also configure the generated `.app` file by customizing the values return
 
 ### Starting applications
 
-When we define a `.app` file, which is the application specification, we are able to start and stop the application as a whole. We haven't worried about this so far for two reasons:
+When we define an `.app` file, which is the application specification, we are able to start and stop the application as a whole. We haven't worried about this so far for two reasons:
 
 1. Mix automatically starts our current application for us
 
@@ -189,7 +189,7 @@ defmodule KV do
   use Application
 
   def start(_type, _args) do
-    KV.Supervisor.start_link
+    KV.Supervisor.init
   end
 end
 ```


### PR DESCRIPTION
- Change `KV.Supervisor` call from `start_link` to `init`
- Correct an "a" to an "an"