### PR TITLE
Providing a non-boolean will raise a BadBooleanError

### DIFF
--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -38,7 +38,7 @@ Providing a non-boolean will raise an exception:
 
 ```iex
 iex> 1 and true
-** (ArgumentError) argument error: 1
+** (BadBooleanError) expected a boolean on left-side of "and", got: 1
 ```
 
 `or` and `and` are short-circuit operators. They only execute the right side if the left side is not enough to determine the result:


### PR DESCRIPTION
Since 1.4 it will raise BadBooleanError instead of ArgumentError. 

See the following links:
- https://github.com/elixir-lang/elixir/releases/tag/v1.4.0
- https://github.com/elixir-lang/elixir/commit/6b8db410b33b3cc77a5bab07c709eed9b4bcc564