### PR TITLE
rename "Modules" page to "Modules and Functions"

### DIFF
--- a/_data/getting-started.yml
+++ b/_data/getting-started.yml
@@ -22,7 +22,7 @@
     - title: Keywords and maps
       slug: keywords-and-maps
 
-    - title: Modules
+    - title: Modules and Functions
       slug: modules
 
     - title: Recursion

--- a/_data/getting-started.yml
+++ b/_data/getting-started.yml
@@ -23,7 +23,7 @@
       slug: keywords-and-maps
 
     - title: Modules and Functions
-      slug: modules
+      slug: modules-and-functions
 
     - title: Recursion
       slug: recursion

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -213,7 +213,7 @@ false
 
 Functions are "first class citizens" in Elixir meaning they can be passed as arguments to other functions in the same way as integers and strings. In the example, we have passed the function in the variable `add` to the `is_function/1` function which correctly returned `true`. We can also check the arity of the function by calling `is_function/2`.
 
-Note a dot (`.`) between the variable and parentheses is required to invoke an anonymous function. The dot ensures there is no ambiguity between calling an anonymous function named `add` and a named function `add/2`. In this sense, Elixir makes a clear distinction between anonymous functions and named functions. We will explore those differences in [Chapter 8](/getting-started/modules.html).
+Note a dot (`.`) between the variable and parentheses is required to invoke an anonymous function. The dot ensures there is no ambiguity between calling an anonymous function named `add` and a named function `add/2`. In this sense, Elixir makes a clear distinction between anonymous functions and named functions. We will explore those differences in [Chapter 8](/getting-started/modules-and-functions.html).
 
 Anonymous functions are closures and as such they can access variables that are in scope when the function is defined. Let's define a new anonymous function that uses the `add` anonymous function we have previously defined:
 

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -64,7 +64,7 @@ $ elixir simple.exs
 Hello world from Elixir
 ```
 
-Later on we will learn how to compile Elixir code (in [Chapter 8](/getting-started/modules.html)) and how to use the Mix build tool (in the [Mix & OTP guide](/getting-started/mix-otp/introduction-to-mix.html)). For now, let's move on to [Chapter 2](/getting-started/basic-types.html).
+Later on we will learn how to compile Elixir code (in [Chapter 8](/getting-started/modules-and-functions.html)) and how to use the Mix build tool (in the [Mix & OTP guide](/getting-started/mix-otp/introduction-to-mix.html)). For now, let's move on to [Chapter 2](/getting-started/basic-types.html).
 
 ## Asking questions
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -101,7 +101,7 @@ defmodule KV.Bucket do
 end
 ```
 
-We are using a map to store our keys and values. The capture operator, `&`, is introduced in [the Getting Started guide](/getting-started/modules.html#function-capturing).
+We are using a map to store our keys and values. The capture operator, `&`, is introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing).
 
 Now that the `KV.Bucket` module has been defined, our test should pass! You can try it yourself by running: `mix test`.
 

--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -1,6 +1,7 @@
 ---
 layout: getting-started
 title: Modules and Functions
+redirect_from: /getting-started/modules.html
 ---
 
 # {{ page.title }}

--- a/getting-started/modules.markdown
+++ b/getting-started/modules.markdown
@@ -1,6 +1,6 @@
 ---
 layout: getting-started
-title: Modules
+title: Modules and Functions
 ---
 
 # {{ page.title }}


### PR DESCRIPTION
Some users were finding it difficult to know where functions page of the
getting started guide was at a glance. Renaming it to "Modules and
Functions" helps to clarify this.

Only the title of the page has been changed so that the URL remains
unchanged.