### PR TITLE
agent.markdown

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -164,7 +164,7 @@ Before we move on to the next chapter, let's discuss the client/server dichotomy
 
 ```elixir
 def delete(bucket, key) do
-  Agent.get_and_update(bucket, fn dict->
+  Agent.get_and_update(bucket, fn dict ->
     Map.pop(dict, key)
   end)
 end


### PR DESCRIPTION
Added a space to a function in a code example. The formatting was inconsistent compared to the other examples on this page. I believe this to be a typo.