### PR TITLE
Make comments more consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ layout: default
 {% highlight elixir %}
 current_process = self()
 
-# Spawns an Elixir process (not an operating system one!)
+# Spawn an Elixir process (not an operating system one!)
 spawn_link(fn ->
   send current_process, {:msg, "hello world"}
 end)


### PR DESCRIPTION
The first comments said "spawns an Elixir process...", the second said "Block until..."

I feel it should be "spawn" and "block" or "spawns" and "blocks"