### PR TITLE
updated spelling in docker section of distibutions

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -62,23 +62,23 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
 ### Raspberry Pi
 
 If necessary replace "jessie" with the name of your Raspian release.   
-  
+
   * The Erlang Solutions repository has a prebuilt package for armhf.  
     This saves significant time instead of recompiling natively.  
-  
+
   * Get Erlang key   
-  
+
     * `echo "deb http://packages.erlang-solutions.com/debian jessie contrib" | sudo tee /etc/apt/sources.list.d/erlang-solutions.list`    
     * Run: `wget http://packages.erlang-solutions.com/debian/erlang_solutions.asc`  
     * Add to keychain: `sudo apt-key add erlang_solutions.asc`   
-     
+
   * Install Elixir
     * Update apt to latest: `sudo apt update`     
     * Run: `sudo apt install elixir`   
 
 ### Docker
 
-If you are familiar with Docker you can use the offical Docker image to get started quickly with Elixir. 
+If you are familiar with Docker you can use the official Docker image to get started quickly with Elixir. 
 
   * Enter interactive mode
     * Run: `docker run -it --rm elixir`


### PR DESCRIPTION
My change was to the spelling in the Docker section but my linter picked up a few whitespaces/retuns that it cleaned up