### PR TITLE
Rocket validator

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -7,9 +7,9 @@
 <div class="widget search">
   <form method="get" id="search-form" class="search-form" action="https://www.google.com/search">
 		<div>
-			<input class="search-text" type="text" name="q" placeholder="Search..." id="searchfield">
+			<input class="search-text" type="text" name="q" placeholder="Search..." id="searchfield" aria-label="Search box">
 			<input type="hidden" name="sitesearch" value="elixir-lang.org">
-			<input class="search-submit button" name="submit" type="submit" value="Search">
+			<input class="search-submit button" name="submit" type="submit" value="Search" aria-label="Search button">
 		</div>
 	</form>
 </div>

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>{% if page.title %}{{ page.title }} - {% endif %}Elixir</title>
   <link href="http://feeds.feedburner.com/ElixirLang" rel="alternate" title="Elixir's Blog" type="application/atom+xml" />
   <link rel="stylesheet" type="text/css" href="/css/style.css" />

--- a/_posts/2016-07-14-announcing-genstage.markdown
+++ b/_posts/2016-07-14-announcing-genstage.markdown
@@ -200,7 +200,7 @@ One of the use cases for GenStage is to consume data from third-party systems. T
 
 During the Elixir London Meetup, I have live-coded a short example that shows how to use `GenStage` to concurrently process data stored in a PostgreSQL database as a queue:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aZuY5-2lwW4" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/aZuY5-2lwW4" frameborder="0" allowfullscreen title="Elixir London June 2016 w/ José Valim"></iframe>
 
 ### GenStage for event dispatching
 

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -382,7 +382,7 @@ A GUI should pop-up containing all sorts of information about our system, from g
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:
 
-<img src="/images/contents/kv-observer.png" width="640px"/>
+<img src="/images/contents/kv-observer.png" width="640" alt="Observer GUI screenshot" />
 
 Not only that, as you create new buckets on the terminal, you should see new processes spawned in the supervision tree shown in Observer:
 


### PR DESCRIPTION
I saw the Tweet referencing some errors in the report from Rocket Validator.

Tweet: https://twitter.com/rocketvalidator/status/842073375514210312
Report: https://rocketvalidator.com/s/a1508cd6-02d1-4129-b8e8-4e0a7df109b5/p

It looks like the majority of those are repeats from include files. I think this should clean up most of them. I'll point out that the `lang` attribute on the `html` element may not be a good idea if you guys have or plan to roll out translations into other languages while reusing the same `top.html` include. 