### PR TITLE
Replace the term 'dictionary' with 'keyword list'

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -131,7 +131,7 @@ end
 
 We have first defined a setup callback with the help of the `setup/1` macro. The `setup/1` callback runs before every test, in the same process as the test itself.
 
-Note that we need a mechanism to pass the `bucket` pid from the callback to the test. We do so by using the *test context*. When we return `{:ok, bucket: bucket}` from the callback, ExUnit will merge the second element of the tuple (a dictionary) into the test context. The test context is a map which we can then match in the test definition, providing access to these values inside the block:
+Note that we need a mechanism to pass the `bucket` pid from the callback to the test. We do so by using the *test context*. When we return `{:ok, bucket: bucket}` from the callback, ExUnit will merge the second element of the tuple (a keyword list) into the test context. The test context is a map which we can then match in the test definition, providing access to these values inside the block:
 
 ```elixir
 test "stores values by key", %{bucket: bucket} do


### PR DESCRIPTION
I might be mistaken, but the term 'dictionary' seems more appropriate when discussing the relevant Python data structure, while 'keyword list' was returned when performing the following in Iex:

```elixir
{a, b} = {:ok, bucket: "bucket"}
{:ok, [bucket: "bucket"]}

i b
Term
  [bucket: "bucket"]
Data type
  List
Description
  This is what is referred to as a "keyword list". A keyword list is a list
  of two-element tuples where the first element of each tuple is an atom.
Reference modules
  Keyword, List
Implemented protocols
  Collectable, Enumerable, IEx.Info, Inspect, List.Chars, String.Chars
```