### PR TITLE
Removes extra space in case statement

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -32,7 +32,7 @@ iex> x = 1
 1
 iex> case 10 do
 ...>   ^x -> "Won't match"
-...>   _  -> "Will match"
+...>   _ -> "Will match"
 ...> end
 "Will match"
 ```


### PR DESCRIPTION
The case statement contained an extra space that is not present in any of the other examples.