### PR TITLE
Changes focus in the require explanation

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -13,7 +13,7 @@ In order to facilitate software reuse, Elixir provides three directives (`alias`
 # Alias the module so it can be called as Bar instead of Foo.Bar
 alias Foo.Bar, as: Bar
 
-# Ensure the module is compiled and available (usually for macros)
+# Require the module in order to use its macros
 require Foo
 
 # Import functions from Foo so they can be called without the `Foo.` prefix
@@ -73,9 +73,9 @@ In the example above, since we are invoking `alias` inside the function `plus/2`
 
 ## require
 
-Elixir provides macros as a mechanism for meta-programming (writing code that generates code).
+Elixir provides macros as a mechanism for meta-programming (writing code that generates code). Macros are expanded at compile time.
 
-Macros are chunks of code that are executed and expanded at compilation time. This means, in order to use a macro, we need to guarantee its module and implementation are available during compilation. This is done with the `require` directive:
+Public functions in modules are globally available, but in order to use macros, you need to opt-in by requiring the module they are defined in.
 
 ```iex
 iex> Integer.is_odd(3)
@@ -88,7 +88,7 @@ true
 
 In Elixir, `Integer.is_odd/1` is defined as a macro so that it can be used as a guard. This means that, in order to invoke `Integer.is_odd/1`, we need to first require the `Integer` module.
 
-In general a module does not need to be required before usage, except if we want to use the macros available in that module. An attempt to call a macro that was not loaded will raise an error. Note that like the `alias` directive, `require` is also lexically scoped. We will talk more about macros in a later chapter.
+Note that like the `alias` directive, `require` is also lexically scoped. We will talk more about macros in a later chapter.
 
 ## import
 
@@ -132,7 +132,7 @@ Note that `import`ing a module automatically `require`s it.
 
 ## use
 
-Although not a directive, `use` is a macro tightly related to `require` that allows you to use a module in the current context. The `use` macro is frequently used by developers to bring external functionality into the current lexical scope, often modules.
+The `use` macro is frequently used by developers to bring external functionality into the current lexical scope, often modules.
 
 For example, in order to write tests using the ExUnit framework, a developer should use the `ExUnit.Case` module:
 


### PR DESCRIPTION
### Purpose

This edit syncs the Getting Started guide with https://github.com/elixir-lang/elixir/pull/6041.

### Rationale

To summarize the rationale here: If module `M` wants to use macros from `N`, it needs to require `N` **regardless** of whether `N` is loaded in the VM (see example in the PR linked above). Therefore, ensuring the module is loaded is not really the purpose of `require`, you may have the module loaded and still not be able to access its macros.

That is because `require N` actually adds `N` to a list of modules required by `M`, and being in that list is what controls their visibility. Additionally, the compiler needs to load `N` in order to expand its macros if used, but that is more of an implementation detail.

### Questions

By removing emphasis on the compilation and loading of the required module, the documentation of `use` gets shorter. Indeed, if the reader sees the macro expands to

```elixir
require Foo
Foo.__using__(...)
```

in the current docs they may still wonder what is the point of `require`? With the parallel compiler any function call works at that level and Elixir does whatever necessary to be able to execute it.

So it seems this would be reduced to: `use` enables access to macros and invokes `__using__`. Which made me think if the reader may perceive both things as arbitrary, why couple two apparently unrelated things in one macro?

What do you think?