### PR TITLE
Fix HTML issues

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -32,11 +32,9 @@
     <div class="wrap">
     <div id="header">
       <div id="branding">
-        <h1 id="site-title">
-          <a href="/" title="Elixir" rel="Home">
-            <img class="logo" src="/images/logo/logo.png" alt="Elixir Logo" />
-          </a>
-        </h1>
+        <a id="site-title" href="/" title="Elixir" rel="Home">
+          <img class="logo" src="/images/logo/logo.png" alt="Elixir Logo" />
+        </a>
       </div>
 
       <div id="menu-primary" class="menu-container">

--- a/_posts/2016-07-14-announcing-genstage.markdown
+++ b/_posts/2016-07-14-announcing-genstage.markdown
@@ -200,7 +200,7 @@ One of the use cases for GenStage is to consume data from third-party systems. T
 
 During the Elixir London Meetup, I have live-coded a short example that shows how to use `GenStage` to concurrently process data stored in a PostgreSQL database as a queue:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aZuY5-2lwW4" frameborder="0" allowfullscreen title="Elixir London June 2016 w/ José Valim"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/aZuY5-2lwW4" class="video" allowfullscreen title="Elixir London June 2016 w/ José Valim"></iframe>
 
 ### GenStage for event dispatching
 

--- a/css/style.css
+++ b/css/style.css
@@ -515,6 +515,7 @@ body.learning         div.menu li.learning        a {
   width: 25%;
   overflow: hidden;
   margin-top: 20px;
+  margin-bottom: 20px;
 }
 #site-title {
   font-size: 2.307692307692308em;  /* 30 / 13 = 2.307692307692308 */


### PR DESCRIPTION
This PR fixes some HTML issues catched in [this report](https://rocketvalidator.com/s/6a76528d-23a1-48b0-b8f8-9f692bc7a626/i):

* H1 should be used for top-level headings (not for the logo).
* frameborder attribute is obsolete, use CSS instead.