### PR TITLE
Fix Secure font loading

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="/js/icons/ie7/ie7.css">
   <!--<![endif]-->
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <link rel="stylesheet" id="font-bitter-css" href="http://fonts.googleapis.com/css?family=Bitter:400,700" type="text/css" media="screen" />
+  <link rel="stylesheet" id="font-bitter-css" href="//fonts.googleapis.com/css?family=Bitter:400,700" type="text/css" media="screen" />
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="search" type="application/opensearchdescription+xml" title="elixir-lang.org" href="/opensearch.xml" />
   <script>


### PR DESCRIPTION
Currently the Google fonts link uses `http:`, even when on a secure URL, this causes the font to not be loaded when on a secure URL.  Currently the primary site 'works around' this by having Cloudflare perform URL rewriting, which hides it, however this does not fix mirrors that use direct hosting.  This commit fixes this by allowing the browser to use http or https as necessary as was done with the analytics javascript link earlier, this should complete the work.