### PR TITLE
Create task-and-gen-tcp.markdown

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -221,7 +221,7 @@ end
 The port is still hardcoded when the `KVServer` is started. This could be changed in a few ways, for example, by reading the port out of the system environment when starting the application:
 
 ```elixir
-port = System.get_env("PORT") || raise "missing $PORT environment variable"
+port = String.to_integer(System.get_env("PORT") || raise "missing $PORT environment variable")
 
 # ...
 worker(Task, [KVServer, :accept, [port]])


### PR DESCRIPTION
The KVServer.accept/1 function needs to have an integer port number and System.get_env/1 returns the environment variable value as a string.  The reason you need an integer port number is because :gen_tcp.listen/2 calls :inet_tcp.getserv/1 and :inet_tcp.getserv/1 is expecting the port to be either an integer or an atom.  In the case that the port is an atom, it is used to look up the port number.  For this example code, since we are already assuming an integer port number, just expecting a string version of the integer port number is sufficient.

Also, by passing the entire expression into String.to_integer/1, if the environment variable is missing, you get the missing $PORT message.  If the environment variable is present but not a string representation of an integer, you get an ArgumentError that shows the problem being associated with :erlang.binary_to_integer/1, which is a clear indication of the problem.