### PR TITLE
Grammer fix in "Static code analysis" section

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -85,7 +85,7 @@ If you want to keep a custom type private, you can use the `@typep` directive in
 
 ### Static code analysis
 
-Typespecs are not only useful to developers as additional documentation. The Erlang tool [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html), for example, uses typespecs in order to perform static analysis of code. That's why, in the `QuietCalculator` example, we wrote a spec for the `make_quiet/1` function even if it was defined as a private function.
+Typespecs are not only useful to developers as additional documentation. The Erlang tool [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html), for example, uses typespecs in order to perform static analysis of code. That's why, in the `QuietCalculator` example, we wrote a spec for the `make_quiet/1` function even though it was defined as a private function.
 
 ## Behaviours
 


### PR DESCRIPTION
An alternative way to fix the grammar would be to change the word "wrote" to "write", instead of changing the word "if" to "though".