### PR TITLE
Add instruction to run command with additional arg

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -242,7 +242,7 @@ end
 
 You might notice that we added a line, `:ok = :gen_tcp.controlling_process(client, pid)`. This makes the child process the "controlling process" of the `client` socket. If we didn't do this, the acceptor would bring down all the clients if it crashed because sockets would be tied to the process that accepted them (which is the default behaviour).
 
-Start a new server with `mix run --no-halt` and we can now open up many concurrent telnet clients. You will also notice that quitting a client does not bring the acceptor down. Excellent!
+Start a new server with `PORT=4040 mix run --no-halt` and we can now open up many concurrent telnet clients. You will also notice that quitting a client does not bring the acceptor down. Excellent!
 
 Here is the full echo server implementation:
 


### PR DESCRIPTION
On line `221` it is proposed how to start the application with a default port. However, on line `245`when the application is run again, it does not include how to configure the port when calling `mix run --no-halt`.  I suggest updating the command to `PORT=4040 mix run --no-halt`, if that is an adequate solution.