### PR TITLE
Invalid string (byte sequence) is no longer false.

### DIFF
--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -75,7 +75,7 @@ iex> byte_size(<<0, 1, 2, 3>>)
 A binary is a sequence of bytes. Those bytes can be organized in any way, even in a sequence that does not make them a valid string:
 
 ```iex
-iex> String.valid?(<<239, 191, 191>>)
+iex> String.valid?(<<239, 191, 19>>)
 false
 ```
 


### PR DESCRIPTION
I'm learning Elixir at the moment, so I apologize if I've overlooked something, but this is what I've found:

Elixir 1.5.0
iex> String.valid?(<<239, 191, 191>>
true

Elixir 1.4.0
iex> String.valid?(<<239, 191, 191>>
false

I'm not sure if the documentation should be updated to reflect the new behaviour of String.valid? or if the function is not working the way it was intended to. At this point, I've assumed the documentation needs to be updated to the new behaviour so I just tweaked the byte sequence to be an invalid string.

Any thoughts?