### PR TITLE
Implemented readability of code at crash course at Elixir-lang

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -634,13 +634,18 @@ Anonymous functions are first-class values, so they can be passed as arguments t
 **Erlang**
 
 ```erlang
+% math.erl
 -module(math).
 -export([square/1]).
 
 square(X) -> X * X.
+```
 
-lists:map(fun math:square/1, [1, 2, 3]).
-%=> [1, 4, 9]
+```erl
+Eshell V5.9  (abort with ^G)
+
+1> lists:map(fun math:square/1, [1, 2, 3]).
+[1, 4, 9]
 ```
 
 **Elixir**

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -643,9 +643,10 @@ square(X) -> X * X.
 
 ```erl
 Eshell V5.9  (abort with ^G)
-
-1> lists:map(fun math:square/1, [1, 2, 3]).
-[1, 4, 9]
+1> c(math).
+{ok,math}
+2> lists:map(fun math:square/1,[1,2,3]).
+[1,4,9]
 ```
 
 **Elixir**

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -645,7 +645,7 @@ square(X) -> X * X.
 Eshell V5.9  (abort with ^G)
 1> c(math).
 {ok,math}
-2> lists:map(fun math:square/1,[1,2,3]).
+2> lists:map(fun math:square/1, [1,2,3]).
 [1,4,9]
 ```
 

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -645,7 +645,7 @@ square(X) -> X * X.
 Eshell V5.9  (abort with ^G)
 1> c(math).
 {ok,math}
-2> lists:map(fun math:square/1, [1,2,3]).
+2> lists:map(fun math:square/1, [1, 2, 3]).
 [1,4,9]
 ```
 


### PR DESCRIPTION
What were proposed in this Pull Request ?
* Given example were confused to readers that 'lists:map(fun math:square/1, [1, 2, 3]).' could be part of .erl file or it could be executed separately or entirely code block executed at erlang shell.
* I believe to make simplification is better in the community so i made code more readable and simple.


Requesting reviewers to review and if looks good merge it. 