### PR TITLE
Link to Mix.env/0 instead of Mix.env/1

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -249,7 +249,7 @@ Mix supports the concept of "environments". They allow a developer to customize 
 
 The environment applies only to the current project. As we will see later on, any dependency you add to your project will by default run in the `:prod` environment.
 
-Customization per environment can be done by accessing [the `Mix.env` function](https://hexdocs.pm/mix/Mix.html#env/1) in your `mix.exs` file, which returns the current environment as an atom. That's what we have used in the `:start_permanent` options:
+Customization per environment can be done by accessing [the `Mix.env` function](https://hexdocs.pm/mix/Mix.html#env/0) in your `mix.exs` file, which returns the current environment as an atom. That's what we have used in the `:start_permanent` options:
 
 ```elixir
 def project do


### PR DESCRIPTION
Since the code example uses [`Mix.env/0`](https://hexdocs.pm/mix/Mix.html#env/0) (instead of [`Mix.env/1`](https://hexdocs.pm/mix/Mix.html#env/1)), I think it makes more sense to link to `Mix.env/0`.