### PR TITLE
Bug at Documentation: Wrong Error mentioned

### DIFF
--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -634,13 +634,18 @@ Anonymous functions are first-class values, so they can be passed as arguments t
 **Erlang**
 
 ```erlang
+% math.erl
 -module(math).
 -export([square/1]).
 
 square(X) -> X * X.
+```
 
-lists:map(fun math:square/1, [1, 2, 3]).
-%=> [1, 4, 9]
+```erl
+Eshell V5.9  (abort with ^G)
+
+1> lists:map(fun math:square/1, [1, 2, 3]).
+[1, 4, 9]
 ```
 
 **Elixir**

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -643,9 +643,10 @@ square(X) -> X * X.
 
 ```erl
 Eshell V5.9  (abort with ^G)
-
-1> lists:map(fun math:square/1, [1, 2, 3]).
-[1, 4, 9]
+1> c(math).
+{ok,math}
+2> lists:map(fun math:square/1,[1,2,3]).
+[1,4,9]
 ```
 
 **Elixir**

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -645,7 +645,7 @@ square(X) -> X * X.
 Eshell V5.9  (abort with ^G)
 1> c(math).
 {ok,math}
-2> lists:map(fun math:square/1,[1,2,3]).
+2> lists:map(fun math:square/1, [1,2,3]).
 [1,4,9]
 ```
 

--- a/crash-course.markdown
+++ b/crash-course.markdown
@@ -645,7 +645,7 @@ square(X) -> X * X.
 Eshell V5.9  (abort with ^G)
 1> c(math).
 {ok,math}
-2> lists:map(fun math:square/1, [1,2,3]).
+2> lists:map(fun math:square/1, [1, 2, 3]).
 [1,4,9]
 ```
 

--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -179,7 +179,7 @@ Although pattern matching allows us to build powerful constructs, its usage is l
 
 ```iex
 iex> length([1, [2], 3]) = 3
-** (CompileError) iex:1: illegal pattern
+** (CompileError) iex:1: cannot invoke remote function :erlang.length/1 inside match
 ```
 
 This finishes our introduction to pattern matching. As we will see in the next chapter, pattern matching is very common in many language constructs.


### PR DESCRIPTION
What were proposed in this Pull Request ?
* iex> length([1, [2], 3]) = 3
above syntax won't give below error 
** (CompileError) iex:1: illegal pattern
but it gives ** (CompileError) iex:1: cannot invoke remote function :erlang.length/1 inside match

so it has been manually verified at shell and update the documentation