### PR TITLE
Wrong Error exception issue at documentation fixed

### DIFF
--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -179,7 +179,7 @@ Although pattern matching allows us to build powerful constructs, its usage is l
 
 ```iex
 iex> length([1, [2], 3]) = 3
-** (CompileError) iex:1: illegal pattern
+** (CompileError) iex:1: cannot invoke remote function :erlang.length/1 inside match
 ```
 
 This finishes our introduction to pattern matching. As we will see in the next chapter, pattern matching is very common in many language constructs.


### PR DESCRIPTION
What were proposed in this Pull Request ?

    iex> length([1, [2], 3]) = 3
    above syntax won't give below error
    ** (CompileError) iex:1: illegal pattern
    but it gives ** (CompileError) iex:1: cannot invoke remote function :erlang.length/1 inside match

so it has been manually verified at shell and update the documentation.