### PR TITLE
[install.markdown] Update Ubuntu and Debian versions

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -47,7 +47,7 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * From pkg: `pkg install elixir`
   * Solus
     * Run: `eopkg install elixir`
-  * Ubuntu 12.04/14.04/16.04 or Debian 7
+  * Ubuntu 14.04/16.04/16.10/17.04 or Debian 7/8/9
     * Add Erlang Solutions repo: `wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb`
     * Run: `sudo apt-get update`
     * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`


### PR DESCRIPTION
 * Ubuntu Precise (12.04) has reached EOL, removed from list.
 * Added other Ubuntu and Debian versions with packages available on https://packages.erlang-solutions.com/erlang/