### PR TITLE
Re-word discussion of list prepend / append performance

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -349,16 +349,12 @@ What is the difference between lists and tuples?
 
 Lists are stored in memory as linked lists, meaning that each element in a list holds its value and points to the following element until the end of the list is reached. This means accessing the length of a list is a linear operation: we need to traverse the whole list in order to figure out its size.
 
-The performance of list concatenation depends on the length of the left-hand list, while prepending to a list is always a constant-time operation.
+Similarly, the performance of list concatenation depends on the length of the left-hand list:
 
 ```iex
 iex> list = [1, 2, 3]
 
-# This is fast as prepending an item to a list is a constant-time operation
-iex> [0 | list]
-[0, 1, 2, 3]
-
-# This is still fast as we only need to traverse `[0]` before executing the concatenation
+# This is fast as we only need to traverse `[0]` to prepend to `list`
 iex> [0] ++ list
 [0, 1, 2, 3]
 

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -349,12 +349,16 @@ What is the difference between lists and tuples?
 
 Lists are stored in memory as linked lists, meaning that each element in a list holds its value and points to the following element until the end of the list is reached. This means accessing the length of a list is a linear operation: we need to traverse the whole list in order to figure out its size.
 
-Updating a list is fast as long as we are prepending elements:
+The performance of list concatenation depends on the length of the left-hand list, while prepending to a list is always a constant-time operation.
 
 ```iex
 iex> list = [1, 2, 3]
 
-# This is fast as we don't need to traverse `list` to prepend 0
+# This is fast as prepending an item to a list is a constant-time operation
+iex> [0 | list]
+[0, 1, 2, 3]
+
+# This is still fast as we only need to traverse `[0]` before executing the concatenation
 iex> [0] ++ list
 [0, 1, 2, 3]
 


### PR DESCRIPTION
 * The text mentioned prepending, while the code was concatenating two lists. The distinction between whether "prepending" or "appending" is fast depends on the size of the left-hand list.
 * There exists explicit prepending to a list as well, which is constant time

This is pretty much migrating some content from https://hexdocs.pm/elixir/List.html.