### PR TITLE
Update mix.exs deps call

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-apps.markdown
@@ -131,7 +131,7 @@ defmodule KvUmbrella.Mixfile do
     [
       apps_path: "apps",
       start_permanent: Mix.env == :prod,
-      deps: deps
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
This change reflects the latest stable elixir version (1.5.1), after running `mix new kv_umbrella --umbrella` (maybe it is different upstream?).  
My first PR here, hope it's fine.
