### PR TITLE
Update Pathogrean Triples example (missing triples)

### DIFF
--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -103,7 +103,7 @@ defmodule Triple do
     for a <- 1..n-2,
         b <- a+1..n-1,
         c <- b+1..n,
-        a + b + c <= n,
+        a + b + >= c,
         a*a + b*b == c*c,
         do: {a, b, c}
   end


### PR DESCRIPTION
The last Pythagorean triples is missing numerous Pythagorean triples.  The filter "a + b + c <= n" looks like an accident in the application the triangle inequality.  The theorem actually states "a + b >= c."  Adjusting this will result in the inclusion of missing triples without duplication.