### PR TITLE
Fix code typo introduced on ed4fb99

### DIFF
--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -103,7 +103,7 @@ defmodule Triple do
     for a <- 1..n-2,
         b <- a+1..n-1,
         c <- b+1..n,
-        a + b + >= c,
+        a + b >= c,
         a*a + b*b == c*c,
         do: {a, b, c}
   end


### PR DESCRIPTION
Nothing major, just removed a spurious `+` to make it work.