### PR TITLE
Update typespecs-and-behaviours.markdown to remove compilation errors in the Parser definition

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -105,12 +105,12 @@ We can create a `Parser` behaviour:
 
 ```elixir
 defmodule Parser do
-  @callback parse(String.t) :: {:ok, value} | {:error, reason}
+  @callback parse(String.t) :: {:ok, term} | {:error, String.t}
   @callback extensions() :: [String.t]
 end
 ```
 
-Modules adopting the `Parser` behaviour will have to implement all the functions defined with the `@callback` directive. As you can see, `@callback` expects a function name but also a function specification like the ones used with the `@spec` directive we saw above.
+Modules adopting the `Parser` behaviour will have to implement all the functions defined with the `@callback` directive. As you can see, `@callback` expects a function name but also a function specification like the ones used with the `@spec` directive we saw above. Also note that the `term` type is used to represent the parsed value. In Elixir, the `term` type is a shortcut to represent any type.
 
 ### Adopting behaviours
 


### PR DESCRIPTION
The original documentation was throwing an error because reason and value are not defined. Assuming reason is a string and the value is a term, the proposed changes at least compiles. This also matches the definition in line 145. I also added a note explaining what `term` represents.

Error:
```
** (CompileError) iex:2: type reason() undefined
    (stdlib) lists.erl:1338: :lists.foreach/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6 
    (iex) lib/iex/evaluator.ex:219: IEx.Evaluator.handle_eval/5
```