### PR TITLE
Update task-and-gen-tcp.markdown to have KVServer module

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -26,41 +26,43 @@ Let's implement those steps. Move to the `apps/kv_server` application, open up `
 ```elixir
 require Logger
 
-def accept(port) do
-  # The options below mean:
-  #
-  # 1. `:binary` - receives data as binaries (instead of lists)
-  # 2. `packet: :line` - receives data line by line
-  # 3. `active: false` - blocks on `:gen_tcp.recv/2` until data is available
-  # 4. `reuseaddr: true` - allows us to reuse the address if the listener crashes
-  #
-  {:ok, socket} = :gen_tcp.listen(port,
-                    [:binary, packet: :line, active: false, reuseaddr: true])
-  Logger.info "Accepting connections on port #{port}"
-  loop_acceptor(socket)
-end
+defmodule KVServer do
+  def accept(port) do
+    # The options below mean:
+    #
+    # 1. `:binary` - receives data as binaries (instead of lists)
+    # 2. `packet: :line` - receives data line by line
+    # 3. `active: false` - blocks on `:gen_tcp.recv/2` until data is available
+    # 4. `reuseaddr: true` - allows us to reuse the address if the listener crashes
+    #
+    {:ok, socket} = :gen_tcp.listen(port,
+                      [:binary, packet: :line, active: false, reuseaddr: true])
+    Logger.info "Accepting connections on port #{port}"
+    loop_acceptor(socket)
+  end
 
-defp loop_acceptor(socket) do
-  {:ok, client} = :gen_tcp.accept(socket)
-  serve(client)
-  loop_acceptor(socket)
-end
+  defp loop_acceptor(socket) do
+    {:ok, client} = :gen_tcp.accept(socket)
+    serve(client)
+    loop_acceptor(socket)
+  end
 
-defp serve(socket) do
-  socket
-  |> read_line()
-  |> write_line(socket)
+  defp serve(socket) do
+    socket
+    |> read_line()
+    |> write_line(socket)
 
-  serve(socket)
-end
+    serve(socket)
+  end
 
-defp read_line(socket) do
-  {:ok, data} = :gen_tcp.recv(socket, 0)
-  data
-end
+  defp read_line(socket) do
+    {:ok, data} = :gen_tcp.recv(socket, 0)
+    data
+  end
 
-defp write_line(line, socket) do
-  :gen_tcp.send(socket, line)
+  defp write_line(line, socket) do
+    :gen_tcp.send(socket, line)
+  end
 end
 ```
 


### PR DESCRIPTION
Added a KVServer module definition to the file. Received this error without it:
`** (ArgumentError) cannot invoke def/2 outside module`