### PR TITLE
Specify canonical URL in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ kramdown:
   input: GFM
   hard_wrap: false
 repository: elixir-lang/elixir-lang.github.com
+url: https://elixir-lang.org
 plugins:
   - jemoji
   - jekyll-sitemap


### PR DESCRIPTION
I've noticed that when I search for elixir, google points me to  https://elixir-lang.github.io instead of elixir-lang.org Looks like the canonical URL has not been set and it defaulted to GitHub one. This PR fixes it.

Before this canonical link looks like this (after GitHub build):
```
<link rel="canonical" href="http://elixir-lang.github.io/" />
```

After this PR it should be this:
```
<link rel="canonical" href="https://elixir-lang.org/" />
```
