### PR TITLE
Fix typo in the code sample for DynamicSupervisors

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -66,7 +66,7 @@ defmodule KV.BucketSupervisor do
   end
 
   def start_bucket do
-    Supervisor.start_child(@name, KV.Bucket)
+    DynamicSupervisor.start_child(@name, KV.Bucket)
   end
 
   def init(:ok) do


### PR DESCRIPTION
The code in `KV.BucketSupervisor.start_bucket` is calling the `Supervisor.start_child` function when it should (probably) be calling the `DynamicSupervisor.start_child` function. I tried the code sample on my machine, and it fails with a function match error with the former call, but it runs ok with the latter.