### PR TITLE
ETS page

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -99,7 +99,7 @@ defmodule KV.Registry do
       {:ok, _pid} ->
         {:noreply, {names, refs}}
       :error ->
-        {:ok, pid} = KV.BucketSupervisor.start_bucket()
+        {:ok, pid} = DynamicSupervisor.start_child(KV.BucketSupervisor, KV.Bucket)
         ref = Process.monitor(pid)
         refs = Map.put(refs, ref, name)
         :ets.insert(names, {name, pid})
@@ -192,7 +192,7 @@ def handle_call({:create, name}, _from, {names, refs}) do
     {:ok, pid} ->
       {:reply, pid, {names, refs}}
     :error ->
-      {:ok, pid} = KV.BucketSupervisor.start_bucket()
+      {:ok, pid} = DynamicSupervisor.start_child(KV.BucketSupervisor, KV.Bucket)
       ref = Process.monitor(pid)
       refs = Map.put(refs, ref, name)
       :ets.insert(names, {name, pid})


### PR DESCRIPTION
Changed `KV.BucketSupervisor.start_bucket` with `DynamicSupervisor.star_child`.
As I understand for this documentation with Elixir 1.6.1 `KV.BucketSupervisor` was removed, so it's necessary to update `KV.Registry.handle_call` also.