### PR TITLE
Call ExUnit.Callback function correctly.

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -135,7 +135,7 @@ defmodule KV.RegistryTest do
   use ExUnit.Case, async: true
 
   setup do
-    registry = start_supervised!(KV.Registry)
+    registry = start_supervised(KV.Registry)
     %{registry: registry}
   end
 


### PR DESCRIPTION
I guess the function is now `start_supervised/2` instead of `start_supervised!/2`.

https://hexdocs.pm/ex_unit/ExUnit.Callbacks.html#start_supervised/2