### PR TITLE
change Elixir in Action link to 2nd edition

### DIFF
--- a/learning.markdown
+++ b/learning.markdown
@@ -27,7 +27,7 @@ Elixir’s pragmatic syntax and built-in support for metaprogramming will make y
 
 <h4 class="resource">Elixir in Action</h4>
 
-<a class="cover" href="http://manning.com/juric/" title="Elixir in Action
+<a class="cover" href="https://www.manning.com/books/elixir-in-action-second-edition" title="Elixir in Action
 – by Saša Jurić"><img src="/images/learning/elixir-in-action.jpg" alt="Elixir in Action cover" width="190" /></a>
 
 Elixir in Action is a tutorial book that aims to bring developers new to Elixir and Erlang to the point where they can develop complex systems on their own. No knowledge about Elixir, Erlang, or functional programming is required, but it is assumed that a reader has a few years of production experience using mainstream OO languages, for example C#, Java, Python, or Ruby.


### PR DESCRIPTION
This PR changes the URL to the 2nd edition of Elixir in Action. The book is admittedly still in MEAP, but I think that at this point it's already better to point to the 2nd edition for the following reasons:

- the 2nd edition page contains the link to the 1st edition
- the buyers of the 2nd edition get the ebook version of the 1st edition included
- I wouldn't recommend buying the 1st edition anymore, since unfortunately Manning doesn't offer a free upgrade
