### PR TITLE
Add explanation for functions without body

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -331,7 +331,7 @@ end
 
 Every function clause dispatches the appropriate command to the `KV.Registry` server that we registered during the `:kv` application startup. Since our `:kv_server` depends on the `:kv` application, it is completely fine to depend on the services it provides.
 
-You might have noticed we have a function head (`def run(command)`) without a body. In the [Modules and Functions](/getting-started/modules-and-functions#default-arguments) chapter, we learned that a bodiless function can be used to declare default arguments for a multi-clause function. Here is another use case. Here, all clauses of `run/1` are pattern matching on `command`. In such cases, defining a function without a body helps to document what the arguments really are.
+You might have noticed we have a function head, `def run(command)`, without a body. In the [Modules and Functions](/getting-started/modules-and-functions#default-arguments) chapter, we learned that a bodiless function can be used to declare default arguments for a multi-clause function. Here is another use case where we use a function without a body to document what the arguments are.
 
 Note that we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
 

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -331,7 +331,7 @@ end
 
 Every function clause dispatches the appropriate command to the `KV.Registry` server that we registered during the `:kv` application startup. Since our `:kv_server` depends on the `:kv` application, it is completely fine to depend on the services it provides.
 
-You might have noticed we have a function head `def run(command)` without a body. In the [Modules and Functions](/getting-started/modules-and-functions#default-arguments) chapter, we learned that a function without a body is used to declare default arguments for a multi-clause function. Here is another use case. Here, all clauses of `run/1` are pattern matching on `command`. In such cases, defining a function without a body, helps to document what the arguments really are.
+You might have noticed we have a function head (`def run(command)`) without a body. In the [Modules and Functions](/getting-started/modules-and-functions#default-arguments) chapter, we learned that a bodiless function can be used to declare default arguments for a multi-clause function. Here is another use case. Here, all clauses of `run/1` are pattern matching on `command`. In such cases, defining a function without a body helps to document what the arguments really are.
 
 Note that we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
 

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -331,6 +331,8 @@ end
 
 Every function clause dispatches the appropriate command to the `KV.Registry` server that we registered during the `:kv` application startup. Since our `:kv_server` depends on the `:kv` application, it is completely fine to depend on the services it provides.
 
+You might have noticed we have a function head `def run(command)` without a body. In the [Modules and Functions](/getting-started/modules-and-functions#default-arguments) chapter, we learned that a function without a body is used to declare default arguments for a multi-clause function. Here is another use case. Here, all clauses of `run/1` are pattern matching on `command`. In such cases, defining a function without a body, helps to document what the arguments really are.
+
 Note that we have also defined a private function named `lookup/2` to help with the common functionality of looking up a bucket and returning its `pid` if it exists, `{:error, :not_found}` otherwise.
 
 By the way, since we are now returning `{:error, :not_found}`, we should amend the `write_line/2` function in `KVServer` to print such error as well:


### PR DESCRIPTION
Add explanation for functions without body when used as a way to document the arguments.