### PR TITLE
Fix message after Stream.cycle call on lists

### DIFF
--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -95,7 +95,7 @@ Many functions in the `Stream` module accept any enumerable as an argument and r
 
 ```iex
 iex> stream = Stream.cycle([1, 2, 3])
-#Function<15.16982430/2 in Stream.cycle/1>
+#Function<15.16982430/2 in Stream.unfold/2>
 iex> Enum.take(stream, 10)
 [1, 2, 3, 1, 2, 3, 1, 2, 3, 1]
 ```


### PR DESCRIPTION
Since `Stream.cycle/1` calls `Stream.unfold/2` for a `list`, the message should be `Stream.unfold/2`.