### PR TITLE
Update structs.markdown

### DIFF
--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -126,6 +126,7 @@ iex> defmodule Product do
 iex> %Product{}
 %Product{name: nil}
 ```
+Providing any default values means that default values have to be given for all keys, since `nil` is assumed only when no defaults are given.
 
 You can also enforce that certain keys have to be specified when creating the struct:
 


### PR DESCRIPTION
I haven't seen it written in any book, but the 'nil' assumption stops after the first field's default value is given. I thought this was something that should be added to the official documentation (since its a bit terse on the subject).