### PR TITLE
Adding explanation about the naming conventions

### DIFF
--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -125,6 +125,8 @@ IO.puts Math.zero?([1, 2, 3]) #=> ** (FunctionClauseError)
 IO.puts Math.zero?(0.0)       #=> ** (FunctionClauseError)
 ```
 
+*The trailing question mark in `zero?` means that this function returns a boolean; see [Naming Conventions](https://hexdocs.pm/elixir/master/naming-conventions.html#trailing-question-mark-foo).*
+
 Giving an argument that does not match any of the clauses raises an error.
 
 Similar to constructs like `if`, named functions support both `do:` and `do`/`end` block syntax, as [we learned `do`/`end` is a convenient syntax for the keyword list format](/getting-started/case-cond-and-if.html#doend-blocks). For example, we can edit `math.exs` to look like this:

--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -244,6 +244,8 @@ IO.puts Concat.join("Hello", "world", "_") #=> Hello_world
 IO.puts Concat.join("Hello")               #=> Hello
 ```
 
+*The leading underscore in `_sep` means that the variable will be ignored in this function; see [Naming Conventions](https://hexdocs.pm/elixir/master/naming-conventions.html#underscore-_foo).*
+
 When using default values, one must be careful to avoid overlapping function definitions. Consider the following example:
 
 ```elixir


### PR DESCRIPTION
I propose to add short explanation about naming conventions in the "Modules and functions" chapter.
I feel introducing these (namely, trailing question mark and leading underscore) is a bit confusing, and telling the reader that it's just naming conventions should reassure them.