### PR TITLE
Adding examples to structs presentation

### DIFF
--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -135,7 +135,7 @@ iex> defmodule Product do
 ...>   defstruct name: nil, price: 12
 ...> end
 iex> %Product{}
-%Product{name: nil}
+%Product{name: nil, price: 12}
 ```
 
 You can also let one key be assumed to default to `nil`, but the fields must be enclosed in square brackets, and the `nil` keys must be at the beginning of the list:
@@ -145,7 +145,7 @@ iex> defmodule Product do
 ...>   defstruct [:name, price: 12]
 ...> end
 iex> %Product{}
-%Product{name: nil}
+%Product{name: nil, price: 12}
 ```
 
 You can also enforce that certain keys have to be specified when creating the struct:

--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -127,6 +127,27 @@ iex> %Product{}
 %Product{name: nil}
 ```
 
+You can mix keys with an explicit default value and keys defaulting to `nil`.
+You can do it explicitly:
+
+```iex
+iex> defmodule Product do
+...>   defstruct name: nil, price: 12
+...> end
+iex> %Product{}
+%Product{name: nil}
+```
+
+You can also let one key be assumed to default to `nil`, but the fields must be enclosed in square brackets, and the `nil` keys must be at the beginning of the list:
+
+```iex
+iex> defmodule Product do
+...>   defstruct [:name, price: 12]
+...> end
+iex> %Product{}
+%Product{name: nil}
+```
+
 You can also enforce that certain keys have to be specified when creating the struct:
 
 ```iex


### PR DESCRIPTION
I'm proposing to add some explanation and examples about how to mix keys with an explicit default value and keys defaulting to `nil`.
I added two snippets, one showing that one can explicitly make a field default to `nil`, and the other how one can simply use an atom with no value and have it default to `nil`.

This StackOverflow post helped me: https://stackoverflow.com/questions/41222494/correct-struct-definition