### PR TITLE
remove Try Elixir learning resource links

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -22,8 +22,6 @@
   </ul>
 </div>
 
-{% include try-elixir.html %}
-
 <div class="widget">
   <h3 class="widget-title">Important links</h3>
   <ul>

--- a/_includes/try-elixir.html
+++ b/_includes/try-elixir.html
@@ -1,7 +1,0 @@
-<div id="try-elixir" class="widget">
-  <a href="https://www.codeschool.com/courses/try-elixir?utm_source=elixir_home&utm_medium=referral">
-      <div class="try-elixir-cta">
-        <div class="try-elixir-copy">Learn Elixir in your browser for free!</div>
-      </div>
-  </a>
-</div>

--- a/_layouts/getting-started.html
+++ b/_layouts/getting-started.html
@@ -6,7 +6,6 @@ section: getting-started
 
 <div id="sidebar-primary" class="sidebar">
   {% include search.html %}
-  {% include try-elixir.html %}
 
   {% assign guides = site.data.getting-started  %}
   {% for guide in site.data.getting-started %}

--- a/css/style.css
+++ b/css/style.css
@@ -940,33 +940,6 @@ ol.jekyll-toc li a {
   user-select: none;
 }
 
-/* try elixir */
-#try-elixir a {
-  display: block;
-  margin-bottom: 12px;
-  text-decoration: none;
-}
-
-.try-elixir-cta {
-  background-image: url('/images/learning/try-elixir-logo.png');
-  background-repeat: no-repeat;
-  border: 2px solid #eee;
-  border-radius: 40px;
-  min-width: 208px;
-  padding: 7px;
-}
-
-.try-elixir-copy {
-  color: #4e2a8e;
-  font-family: 'Bitter';
-  height: 48px;
-  margin-left: 66px;
-}
-
-.try-elixir-copy:hover {
-  color: black;
-}
-
 /* elixir radar */
 .elixir-radar-cta {
   padding: 10px 0;

--- a/learning.markdown
+++ b/learning.markdown
@@ -85,14 +85,6 @@ This book will teach you the core concepts of the Elixir programming language in
 
 ## Video/Interactive Resources
 
-<h4 class="resource">Try Elixir with Code School</h4>
-
-<a class="cover" href="https://www.codeschool.com/courses/try-elixir?utm_source=elixir_learning&utm_medium=referral" title="Try Elixir – by Code School"><img src="/images/learning/try-elixir.png" alt="Try Elixir badge" width="190" /></a>
-
-Start learning and programming Elixir in your browser with Code School's interactive Try Elixir course. Learn the basics of functional programming with instructor-led videos before taking on challenges where you’ll code directly in the browser, receiving immediate feedback and code validation.
-
-<div class="clear"></div>
-
 <h4 class="resource">Take Off With Elixir</h4>
 
 <a class="cover" href="https://goo.gl/9w33lp" title="Take Off With Elixir"><img src="/images/learning/take-off-with-elixir.jpg" alt="Red:4" width="190" /></a>


### PR DESCRIPTION
This commit removes links to Code School's Try Elixir course in advance of codeschool.com shutting down on June 1, 2018.