### PR TITLE
Updated the output of `:ets.new/2` in ETS documentation

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -21,7 +21,7 @@ ETS allows us to store any Elixir term in an in-memory table. Working with ETS t
 
 ```iex
 iex> table = :ets.new(:buckets_registry, [:set, :protected])
-8207
+#Reference<0.1885502827.460455937.234656>
 iex> :ets.insert(table, {"foo", self()})
 true
 iex> :ets.lookup(table, "foo")


### PR DESCRIPTION
The type of table identifiers changed from integer to reference in OTP20, according to the changelog : http://erlang.org/download/otp_src_20.0.readme
I edited the first snippet where `:ets.new/2` was returning an integer, so as to have it return a reference.
I was pointed toward the document thanks to this answer on StackOverflow: https://stackoverflow.com/a/49633326/7051394