### PR TITLE
Added how to get whitespace's code point

### DIFF
--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -50,6 +50,13 @@ iex> ?ł
 322
 ```
 
+Note that the code point of an ASCII whitespace can be accessed by `?\s`:
+
+```iex
+iex> ?\s
+32
+```
+
 You can also use the functions in [the `String` module](https://hexdocs.pm/elixir/String.html) to split a string in its individual characters, each one as a string of length 1:
 
 ```iex


### PR DESCRIPTION
I was searching how to access the code point of an ASCII whitespace, when I came across [this post](https://stackoverflow.com/a/27004332/7051394) on StackOverflow explaining the `?` code point accessor.
I found the info in a comment by @josevalim, saying that "we should probably add such examples to the documentation", so here you go :)

I added a line about the `?\s` syntax, and a short console demonstrating it.