### PR TITLE
Define minimum OTP version and erl command output in data file

### DIFF
--- a/_data/elixir-versions.yml
+++ b/_data/elixir-versions.yml
@@ -1,4 +1,6 @@
 stable: v1_6
+minimum_otp_version: 19.0
+erl_output: "Erlang/OTP 19 [erts-8.0] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]"
 
 v1_0:
   name: v1.0

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -3,6 +3,7 @@ layout: getting-started
 title: Introduction
 redirect_from: /getting_started/1.html
 ---
+{% assign stable = site.data.elixir-versions[site.data.elixir-versions.stable] %}
 
 # {{ page.title }}
 
@@ -40,9 +41,9 @@ For now, let's start by running `iex` (or `iex.bat` if you are on Windows) which
 Open up `iex` and type the following expressions:
 
 ```iex
-Erlang/OTP 19 [erts-8.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+{{ site.data.elixir-versions.erl_output }}
 
-Interactive Elixir (1.4.0) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ stable }}) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)> 40 + 2
 42
 iex(2)> "hello" <> " world"

--- a/install.markdown
+++ b/install.markdown
@@ -11,7 +11,7 @@ layout: default
 
 The quickest way to install Elixir is through a distribution or using one of the available installers. If not available, then we recommend the precompiled packages or compiling it.
 
-Note that Elixir requires Erlang 18.0 or later. Many of the instructions below will automatically install Erlang for you. In case they do not, read the "Installing Erlang" section below.
+Note that Elixir requires Erlang {{ site.data.elixir-versions.minimum_otp_version }} or later. Many of the instructions below will automatically install Erlang for you. In case they do not, read the "Installing Erlang" section below.
 
 ## Distributions
 
@@ -131,13 +131,13 @@ If the tests pass, you are ready to go. Otherwise, feel free to open an issue [i
 
 ## Installing Erlang
 
-The only prerequisite for Elixir is Erlang, version 18.0 or later, which can be easily installed with [Precompiled packages](https://www.erlang-solutions.com/resources/download.html). In case you want to install it directly from source, it can be found on [the Erlang website](http://www.erlang.org/download.html) or by following the excellent tutorial available in the [Riak documentation](https://docs.basho.com/riak/latest/ops/building/installing/erlang/).
+The only prerequisite for Elixir is Erlang, version {{ site.data.elixir-versions.minimum_otp_version }} or later, which can be easily installed with [Precompiled packages](https://www.erlang-solutions.com/resources/download.html). In case you want to install it directly from source, it can be found on [the Erlang website](http://www.erlang.org/download.html) or by following the excellent tutorial available in the [Riak documentation](https://docs.basho.com/riak/latest/ops/building/installing/erlang/).
 
 For Windows developers, we recommend the precompiled packages. Those on a Unix platform can probably get Erlang installed via one of the many package distribution tools.
 
 After Erlang is installed, you should be able to open up the command line (or command prompt) and check the Erlang version by typing `erl`. You will see some information as follows:
 
-    Erlang/OTP 18 (erts-7) [64-bit] [smp:2:2] [async-threads:0] [hipe] [kernel-poll:false]
+    {{ site.data.elixir-versions.erl_output }}
 
 Notice that depending on how you installed Erlang, Erlang binaries might not be available in your PATH. Be sure to have Erlang binaries in your [PATH](https://en.wikipedia.org/wiki/Environment_variable), otherwise Elixir won't work!
 


### PR DESCRIPTION
Unify the minimum required OTP version and the output of the `erl`.
As you can see it was outdated in some places.