### PR TITLE
Minor add to "Adopting behaviours" examples

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -120,7 +120,7 @@ Adopting a behaviour is straightforward:
 defmodule JSONParser do
   @behaviour Parser
 
-  def parse(str), do: # ... parse JSON
+  def parse(str), do: "" # ... parse JSON
   def extensions, do: ["json"]
 end
 ```
@@ -129,7 +129,7 @@ end
 defmodule YAMLParser do
   @behaviour Parser
 
-  def parse(str), do: # ... parse YAML
+  def parse(str), do: "" # ... parse YAML
   def extensions, do: ["yml"]
 end
 ```


### PR DESCRIPTION
The example modules JSONParser and YAMLParser on the "Adopting behaviours" examples would not compile ( "(ArgumentError) cannot invoke def/2 inside function/macro" ) if the parse function does not return anything. By adding a simple empty string we allow a beginner to copy the code and see the expected behaviour. The thing that matters in these example is for the reader to experiment with leaving out a Parser callback and witness the behaviour warning, not having to figure out a compilation error at the time he is learning.