### PR TITLE
Use `console` language for command line examples in guides

### DIFF
--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -65,7 +65,7 @@ IO.puts "Hello world from Elixir"
 
 Save it as `simple.exs` and execute it with `elixir`:
 
-```bash
+```console
 $ elixir simple.exs
 Hello world from Elixir
 ```

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -39,7 +39,7 @@ The function receives the arguments and passes them to `if`. However, as we lear
 
 Let's start `iex` with the module above:
 
-```bash
+```console
 $ iex macros.exs
 ```
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -32,7 +32,7 @@ We will explore most of these abstractions in this guide. Keep in mind that they
 
 [Agents](https://hexdocs.pm/elixir/Agent.html) are simple wrappers around state. If all you want from a process is to keep state, agents are a great fit. Let's start an `iex` session inside the project with:
 
-```bash
+```console
 $ iex -S mix
 ```
 

--- a/getting-started/mix-otp/dependencies-and-umbrella-projects.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-projects.markdown
@@ -62,7 +62,7 @@ You will notice that when you add a dependency to your project, Mix generates a 
 
 Mix provides many tasks for working with dependencies, which can be seen in `mix help`:
 
-```bash
+```console
 $ mix help
 mix deps              # Lists dependencies and their status
 mix deps.clean        # Deletes the given dependencies' files
@@ -112,7 +112,7 @@ So let's get started!
 
 Let's start a new project using `mix new`. This new project will be named `kv_umbrella` and we need to pass the `--umbrella` option when creating it. Do not create this new project inside the existing `kv` project!
 
-```bash
+```console
 $ mix new kv_umbrella --umbrella
 * creating README.md
 * creating .formatter.exs
@@ -147,7 +147,7 @@ What makes this project different from the previous one is the `apps_path: "apps
 
 Let's move inside the apps directory and start building `kv_server`. This time, we are going to pass the `--sup` flag, which will tell Mix to generate a supervision tree automatically for us, instead of building one manually as we did in previous chapters:
 
-```bash
+```console
 $ cd kv_umbrella/apps
 $ mix new kv_server --module KVServer --sup
 ```
@@ -244,7 +244,7 @@ Notice that it defines the application callback function, `start/2`, and instead
 
 We can already try out our first umbrella child. We could run tests inside the `apps/kv_server` directory, but that wouldn't be much fun. Instead, go to the root of the umbrella project and run `mix test`:
 
-```bash
+```console
 $ mix test
 ```
 

--- a/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
+++ b/getting-started/mix-otp/distributed-tasks-and-configuration.markdown
@@ -34,7 +34,7 @@ Elixir ships with facilities to connect nodes and exchange information between t
 
 In order to run distributed code, we need to start the <abbr title="Virtual Machine">VM</abbr> with a name. The name can be short (when in the same network) or long (requires the full computer address). Let's start a new IEx session:
 
-```bash
+```console
 $ iex --sname foo
 ```
 
@@ -55,7 +55,7 @@ iex> defmodule Hello do
 
 If you have another computer on the same network with both Erlang and Elixir installed, you can start another shell on it. If you don't, you can start another IEx session in another terminal. In either case, give it the short name of `bar`:
 
-```bash
+```console
 $ iex --sname bar
 ```
 
@@ -129,7 +129,7 @@ Distributed tasks are exactly the same as supervised tasks. The only difference 
 
 Now, let's start two named nodes again, but inside the `:kv` application:
 
-```bash
+```console
 $ iex --sname foo -S mix
 $ iex --sname bar -S mix
 ```
@@ -229,13 +229,13 @@ The second test checks that the code raises for unknown entries.
 
 In order to run the first test, we need to have two nodes running. Move into `apps/kv` and let's restart the node named `bar` which is going to be used by tests.
 
-```bash
+```console
 $ iex --sname bar -S mix
 ```
 
 And now run tests with:
 
-```bash
+```console
 $ elixir --sname foo -S mix test
 ```
 
@@ -267,7 +267,7 @@ ExUnit.start(exclude: exclude)
 
 Now run tests with `mix test`:
 
-```bash
+```console
 $ mix test
 Excluding tags: [distributed: true]
 
@@ -281,7 +281,7 @@ This time all tests passed and ExUnit warned us that distributed tests were bein
 
 The `mix test` command also allows us to dynamically include and exclude tags. For example, we can run `$ mix test --include distributed` to run distributed tests regardless of the value set in `test/test_helper.exs`. We could also pass `--exclude` to exclude a particular tag from the command line. Finally, `--only` can be used to run only tests with a particular tag:
 
-```bash
+```console
 $ elixir --sname foo -S mix test --only distributed
 ```
 
@@ -322,7 +322,7 @@ We use `Application.fetch_env!/2` to read the entry for `:routing_table` in `:kv
 
 Since our routing table is now empty, our distributed test should fail. Restart the apps and re-run tests to see the failure:
 
-```bash
+```console
 $ iex --sname bar -S mix
 $ elixir --sname foo -S mix test --only distributed
 ```

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -250,7 +250,7 @@ end
 
 If we start our server, we can now send commands to it. For now, we will get two different responses: "OK" when the command is known and "UNKNOWN COMMAND" otherwise:
 
-```bash
+```console
 $ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.

--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -205,7 +205,7 @@ We changed the callback from `handle_cast/2` to `handle_call/3` and changed it t
 
 Let's run the tests once again. This time though, we will pass the `--trace` option:
 
-```bash
+```console
 $ mix test --trace
 ```
 

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -57,7 +57,7 @@ When you install Elixir, besides getting the `elixir`, `elixirc` and `iex` execu
 
 Let's create our first project by invoking `mix new` from the command line. We'll pass the project name as the argument (`kv`, in this case), and tell Mix that our main module should be the all-uppercase `KV`, instead of the default, which would have been `Kv`:
 
-```bash
+```console
 $ mix new kv --module KV
 ```
 
@@ -144,7 +144,7 @@ end
 
 This structure is enough to compile our project:
 
-```bash
+```console
 $ cd kv
 $ mix compile
 ```
@@ -158,7 +158,7 @@ The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was ge
 
 Once the project is compiled, you can start an `iex` session inside the project by running:
 
-```bash
+```console
 $ iex -S mix
 ```
 
@@ -232,7 +232,7 @@ For each failure, ExUnit prints a detailed report, containing the test name with
 
 In the second line of the failure, right below the test name, there is the location where the test was defined. If you copy the test location in full, including the file and line number, and append it to `mix test`, Mix will load and run just that particular test:
 
-```bash
+```console
 $ mix test test/kv_test.exs:5
 ```
 
@@ -276,7 +276,7 @@ When true, the `:start_permanent` option starts your application in permanent mo
 
 Mix will default to the `:dev` environment, except for the `test` task that will default to the `:test` environment. The environment can be changed via the `MIX_ENV` environment variable:
 
-```bash
+```console
 $ MIX_ENV=prod mix compile
 ```
 
@@ -294,7 +294,7 @@ There is much more to Mix, and we will continue to explore it as we build our pr
 
 Keep in mind that you can always invoke the help task to list all available tasks:
 
-```bash
+```console
 $ mix help
 ```
 

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -94,7 +94,7 @@ iex> KVServer.accept(4040)
 
 The server is now running, and you will even notice the console is blocked. Let's use [a `telnet` client](https://en.wikipedia.org/wiki/Telnet) to access our server. There are clients available on most operating systems, and their command lines are generally similar:
 
-```bash
+```console
 $ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.
@@ -153,7 +153,7 @@ port = String.to_integer(System.get_env("PORT") || raise "missing $PORT environm
 
 Now that the server is part of the supervision tree, it should start automatically when we run the application. Type `mix run --no-halt` in the terminal, and once again use the `telnet` client to make sure that everything still works:
 
-```bash
+```console
 $ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.
@@ -168,7 +168,7 @@ Yes, it works! However, does it *scale*?
 
 Try to connect two telnet clients at the same time. When you do so, you will notice that the second client doesn't echo:
 
-```bash
+```console
 $ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.

--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -59,7 +59,7 @@ end
 
 Elixir promotes the use of Markdown with heredocs to write readable documentation. Heredocs are multi-line strings, they start and end with triple double-quotes, keeping the formatting of the inner text. We can access the documentation of any compiled module directly from IEx:
 
-```bash
+```console
 $ elixirc math.ex
 $ iex
 ```

--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -44,7 +44,7 @@ end
 
 This file can be compiled using `elixirc`:
 
-```bash
+```console
 $ elixirc math.ex
 ```
 
@@ -81,7 +81,7 @@ IO.puts Math.sum(1, 2)
 
 And execute it as:
 
-```bash
+```console
 $ elixir math.exs
 ```
 
@@ -144,7 +144,7 @@ And it will provide the same behaviour. You may use `do:` for one-liners but alw
 
 Throughout this tutorial, we have been using the notation `name/arity` to refer to functions. It happens that this notation can actually be used to retrieve a named function as a function type. Start `iex`, running the `math.exs` file defined above:
 
-```bash
+```console
 $ iex math.exs
 ```
 
@@ -270,7 +270,7 @@ If we save the code above in a file named "concat.ex" and compile it, Elixir wil
 
 The compiler is telling us that invoking the `join` function with two arguments will always choose the first definition of `join` whereas the second one will only be invoked when three arguments are passed:
 
-```bash
+```console
 $ iex concat.exs
 ```
 

--- a/getting-started/recursion.markdown
+++ b/getting-started/recursion.markdown
@@ -97,7 +97,7 @@ defmodule Math do
 end
 ```
 
-```bash
+```console
 iex math.exs
 ```
 

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -13,7 +13,7 @@ Eager to learn more? Keep reading!
 
 In order to get your first project started, Elixir ships with a build tool called Mix. You can get your new project started by running:
 
-```bash
+```console
 $ mix new path/to/new/project
 ```
 


### PR DESCRIPTION
`bash` denotes a shell script whereas `console` denotes a shell session.

Basic examples don’t look very different (before first, after second):

![Before](https://user-images.githubusercontent.com/652793/41849465-5b439862-7881-11e8-809c-101af23fef52.png)
![After](https://user-images.githubusercontent.com/652793/41849464-5b249836-7881-11e8-8161-dd32aecf8813.png)

One benefit is that Bash keywords are no longer highlighted (`for` in this case):

![Before](https://user-images.githubusercontent.com/652793/41849669-0c799104-7882-11e8-8cb1-3836e7ae0474.png)
![After](https://user-images.githubusercontent.com/652793/41849668-0c5b4fb4-7882-11e8-8c68-d50b8697157f.png)

The only downside I could find is that comments in the output are no longer highlighted:

![Before](https://user-images.githubusercontent.com/652793/41849853-c53b3918-7882-11e8-94b0-e6b8fd75af28.png)
![After](https://user-images.githubusercontent.com/652793/41849854-c5589f30-7882-11e8-93a1-910fe842b746.png)

However, for the sake of consistency, I’ve changed them to `console` as well.