### PR TITLE
Fix guide reintroducing `Task.start_link/1`

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -192,7 +192,7 @@ defp loop_acceptor(socket) do
 end
 ```
 
-to use `Task.start_link/1`, which is similar to `Task.start_link/3`, but it receives an anonymous function instead of module, function and arguments:
+to also use `Task.start_link/1`:
 
 ```elixir
 defp loop_acceptor(socket) do


### PR DESCRIPTION
`start_link/3` was changed to `start_link/1` in https://github.com/elixir-lang/elixir-lang.github.com/commit/cb0987997be2b463399510c6b690f7ed52913168. Therefore, it doesn’t really make sense to refer to `start_link/3` and to re-explain that `start_link/1` receives an anonymous function.