### PR TITLE
Fix dead links in Getting Started guide

### DIFF
--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -111,6 +111,6 @@ The reason we can compare different data types is pragmatism. Sorting algorithms
 
 You don't actually need to memorize this ordering, it's enough to know that this ordering exists.
 
-For reference information about operators (and ordering), check the [reference page on operators](/docs/master/elixir/operators.html).
+For reference information about operators (and ordering), check the [reference page on operators](https://hexdocs.pm/elixir/operators.html).
 
 In the next chapter, we are going to discuss pattern matching through the use of `=`, the match operator.

--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -72,7 +72,7 @@ iex> case :ok do
 ** (CaseClauseError) no case clause matching: :ok
 ```
 
-Consult [the full documentation for guards](/docs/master/elixir/guards.html) for more information about guards, how they are used, and what expressions are allowed in them.
+Consult [the full documentation for guards](https://hexdocs.pm/elixir/guards.html) for more information about guards, how they are used, and what expressions are allowed in them.
 
 Note anonymous functions can also have multiple clauses and guards:
 

--- a/getting-started/io-and-the-file-system.markdown
+++ b/getting-started/io-and-the-file-system.markdown
@@ -13,7 +13,7 @@ We had originally sketched this chapter to come much earlier in the getting star
 
 ## The `IO` module
 
-The [`IO`](http://elixir-lang.org/docs/v1.0/elixir/IO.html) module is the main mechanism in Elixir for reading and writing to standard input/output (`:stdio`), standard error (`:stderr`), files, and other IO devices. Usage of the module is pretty straightforward:
+The [`IO`](https://hexdocs.pm/elixir/IO.html) module is the main mechanism in Elixir for reading and writing to standard input/output (`:stdio`), standard error (`:stderr`), files, and other IO devices. Usage of the module is pretty straightforward:
 
 ```iex
 iex> IO.puts "hello world"


### PR DESCRIPTION
Following links in corresponding pages were fixed:
* Basic operators page; operators documentation link
* case, cond and if page; guards documentation link
* IO and the file system page; IO documentation link