### PR TITLE
Update basic-operators.markdown

### DIFF
--- a/getting-started/basic-operators.markdown
+++ b/getting-started/basic-operators.markdown
@@ -25,7 +25,7 @@ iex> "foo" <> "bar"
 "foobar"
 ```
 
-Elixir also provides three boolean operators: `or`, `and` and `not`. These operators are strict in the sense that they expect a boolean (`true` or `false`) as their first argument:
+Elixir also provides three boolean operators: `or`, `and` and `not`. The operators `or` and `and` are strict in the sense that they expect a boolean (`true` or `false`) as their first argument:
 
 ```iex
 iex> true and true


### PR DESCRIPTION
The boolean operator `not` accepts a non-boolean arguement:
```iex
iex> not is_atom(:hello)
false
```