### PR TITLE
Make Dynamic Dispatch example executable.

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -120,7 +120,7 @@ Adopting a behaviour is straightforward:
 defmodule JSONParser do
   @behaviour Parser
 
-  def parse(str), do: "" # ... parse JSON
+  def parse(str), do: {:ok, "some json " <> str} # ... parse JSON
   def extensions, do: ["json"]
 end
 ```
@@ -129,7 +129,7 @@ end
 defmodule YAMLParser do
   @behaviour Parser
 
-  def parse(str), do: "" # ... parse YAML
+  def parse(str), do: {:ok, "some yaml " <> str} # ... parse YAML
   def extensions, do: ["yml"]
 end
 ```


### PR DESCRIPTION
To conform to the typespec in the Parser behaviour, the two parse functions in the implementations in JSONParser and YAMLParser should return a tuple. This makes the example executable as is.