### PR TITLE
fix / the titles without the oxford comma in the side menu

### DIFF
--- a/_data/getting-started.yml
+++ b/_data/getting-started.yml
@@ -13,7 +13,7 @@
     - title: Pattern matching
       slug: pattern-matching
 
-    - title: case, cond and if
+    - title: case, cond, and if
       slug: case-cond-and-if
 
     - title: Binaries, strings, and charlists
@@ -37,7 +37,7 @@
     - title: IO and the file system
       slug: io-and-the-file-system
 
-    - title: alias, require and import
+    - title: alias, require, and import
       slug: alias-require-and-import
 
     - title: Module attributes
@@ -55,7 +55,7 @@
     - title: Sigils
       slug: sigils
 
-    - title: try, catch and rescue
+    - title: try, catch, and rescue
       slug: try-catch-and-rescue
 
     - title: Typespecs and behaviours


### PR DESCRIPTION
**Reason:** Put the title with the oxford comma, as in the title of the page.