### PR TITLE
rephrasing to avoid mis-matched pronouns.

### DIFF
--- a/getting-started/debugging.markdown
+++ b/getting-started/debugging.markdown
@@ -7,7 +7,7 @@ title: Debugging
 
 {% include toc.html %}
 
-There are a number of ways one can debug their code in Elixir. In this chapter we will cover some of the more common ways of doing so.
+There are a number of ways to debug code in Elixir. In this chapter we will cover some of the more common ways of doing so.
 
 ## IO.inspect/2
 


### PR DESCRIPTION
changed from a phrase using the mis-matched pronouns "one" and "their" to a rephrasing without any such pronouns.