### PR TITLE
change pronoun to match number, of "the community"

### DIFF
--- a/getting-started/debugging.markdown
+++ b/getting-started/debugging.markdown
@@ -154,7 +154,7 @@ We have just scratched the surface of what the Erlang VM has to offer, for examp
   * Mix ships with many tasks under the `profile` namespace, such as `cprof` and `fprof`
   * And more
 
-The community has also created their own tools, often to aid in production, other times in development:
+The community has also created its own tools, often to aid in production, other times in development:
 
   * [wObserver](https://github.com/shinyscorpion/wObserver) observes production nodes through a web interface.
   * [visualixir](https://github.com/koudelka/visualixir) is a development-time process message visualizer.


### PR DESCRIPTION
changed from the possessive pronoun "their", in "their own tools", referring to the tools of "the community", to the possessive pronoun "its", since "the community" is a single entity. 
if "the community" is to be considered as being plural, please consider changing from "has also created" to "have also created".