### PR TITLE
Fix outdated link to `String.t` typespec note

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -47,7 +47,7 @@ defmodule LousyCalculator do
 end
 ```
 
-As you can see in the example, tuples are a compound type and each tuple is identified by the types inside it. To understand why `String.t` is not written as `string`, have another look at the [notes in the typespecs docs](https://hexdocs.pm/elixir/typespecs.html#notes).
+As you can see in the example, tuples are a compound type and each tuple is identified by the types inside it. To understand why `String.t` is not written as `string`, have another look at the [typespecs docs](https://hexdocs.pm/elixir/typespecs.html#the-string-type).
 
 Defining function specs this way works, but it quickly becomes annoying since we're repeating the type `{number, String.t}` over and over. We can use the `@type` directive in order to declare our own custom type.
 


### PR DESCRIPTION
Change a link to point to the section renamed by https://github.com/elixir-lang/elixir/commit/db017e7f18b35d69a2b4305efc0f002bb3675669.