### PR TITLE
Fix wrong stable version leading to wrong download links

### DIFF
--- a/_data/elixir-versions.yml
+++ b/_data/elixir-versions.yml
@@ -1,4 +1,4 @@
-stable: v1_6
+stable: v1_7
 
 v1_0:
   name: v1.0


### PR DESCRIPTION
Link pointed to 1.6 as latest stable, but latest stable is 1.7.

**NOTE:** I am unable to test this commit, because I cannot install the development tools. The gems include nokogiri, which cannot be installed because of this problem: https://github.com/sparklemotion/nokogiri/issues/1772

But I think this should work. :P