### PR TITLE
Update test in gen server registry to be correct out of the box

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -141,12 +141,12 @@ defmodule KV.RegistryTest do
 
   test "spawns buckets", %{registry: registry} do
     assert KV.Registry.lookup(registry, "shopping") == :error
-
+    
     KV.Registry.create(registry, "shopping")
     assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
 
-    KV.Bucket.put(bucket, "milk", 1)
-    assert KV.Bucket.get(bucket, "milk") == 1
+    KV.Registry.create(registry, "shopping")
+    assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
   end
 end
 ```


### PR DESCRIPTION
the test for `GenServer` from the getting started guide using mix otp was incorrect. half of it was from the `Agent` test, so i update the test to reflect the bare minimum to make it pass based on what it looked like from the `Agent` test