### PR TITLE
Refine DynamicSupervisor instructions in Mix/OTP Guide

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -52,7 +52,7 @@ We are going to solve this issue by defining a new supervisor that will spawn an
 
 ## The bucket supervisor
 
-Let's define a DynamicSupervisor and give it a name of `KV.BucketSupervisor` in `lib/kv/supervisor.ex` as follows:
+Let's define a DynamicSupervisor and give it a name of `KV.BucketSupervisor`. Replace the `init` function in `lib/kv/supervisor.ex` as follows:
 
 
 ```elixir


### PR DESCRIPTION
The previous instructions tripped me up a little: First, I created a new module `KV.BucketSupervisor` with the `init` function from the guide. My mind kept auto-correcting "in `lib/kv/supervisor.ex`" to "in `lib/kv/bucketsupervisor.ex`" ;)

After I found #1084, I replaced the whole content of the `KV.Supervisor` module, due to the instructions saying
> Note this time we didn’t have to define a separate module that invokes use DynamicSupervisor

this results in `(UndefinedFunctionError) function KV.Supervisor.start_link/1 is undefined or private`.

Then I finally got it right ;)