### PR TITLE
fixes, warning: variable "a" is unused.

### DIFF
--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -126,7 +126,6 @@ defmodule HygieneTest do
   def go do
     require Hygiene
     a = 13
-    a
     Hygiene.no_interference
     a
   end
@@ -149,7 +148,6 @@ defmodule HygieneTest do
   def go do
     require Hygiene
     a = 13
-    a
     Hygiene.interference
     a
   end
@@ -158,6 +156,8 @@ end
 HygieneTest.go
 # => 1
 ```
+
+Notice this code will work but issue a warning: `variable "a" is unused`. The macro is overriding the original value and the original value is never used.
 
 Variable hygiene only works because Elixir annotates variables with their context. For example, a variable `x` defined on line 3 of a module would be represented as:
 

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -126,6 +126,7 @@ defmodule HygieneTest do
   def go do
     require Hygiene
     a = 13
+    a
     Hygiene.no_interference
     a
   end
@@ -148,6 +149,7 @@ defmodule HygieneTest do
   def go do
     require Hygiene
     a = 13
+    a
     Hygiene.interference
     a
   end

--- a/getting-started/meta/macros.markdown
+++ b/getting-started/meta/macros.markdown
@@ -157,7 +157,7 @@ HygieneTest.go
 # => 1
 ```
 
-Notice this code will work but issue a warning: `variable "a" is unused`. The macro is overriding the original value and the original value is never used.
+The code above will work but issue a warning: `variable "a" is unused`. The macro is overriding the original value and the original value is never used.
 
 Variable hygiene only works because Elixir annotates variables with their context. For example, a variable `x` defined on line 3 of a module would be represented as:
 


### PR DESCRIPTION
Additionally, because the variable is called before and after the macro.

Tracing how the value changes is easier to implement. 
```elixir
  def go do
    require Hygiene
    a = 13
    a
    Hygiene.interference
    a
  end
```
Can easily be modified to log the values:
```elixir
  def go do
    require Hygiene
    a = 13
    a |> IO.inspect 
    Hygiene.interference
    a |> IO.inspect 
  end
```
Without changing the end result.

This page helped a lot with my macro learning 👍 
The warning was the semi confusing part because it brings uncertainty to whether the original value is unused or the overriding value is unused. If this warning was intentional including the reasoning for the warning could be an alternative solution for the problem.