### PR TITLE
Update ETS markdown

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -160,7 +160,7 @@ How can this line fail if we just created the bucket in the previous line?
 The reason those failures are happening is because, for didactic purposes, we have made two mistakes:
 
   1. We are prematurely optimizing (by adding this cache layer)
-  2. We are using `cast/2` (while we should be using `call/2`)
+  2. We are using `cast/2` (while we should be using `call/3`)
 
 ## Race conditions?
 


### PR DESCRIPTION
`GenServer` module doesn't provide `call/2` function. I checked the [documentation]( https://hexdocs.pm/elixir/search.html?q=GenServer.call) and the [source code](https://github.com/elixir-lang/elixir/blob/v1.7.4/lib/elixir/lib/gen_server.ex#L911) and didn't find any `GenServer.call/2` function.