### PR TITLE
Fix a statement about the heaviness of threads in other programming languages

### DIFF
--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -9,7 +9,7 @@ title: Processes
 
 In Elixir, all code runs inside processes. Processes are isolated from each other, run concurrent to one another and communicate via message passing. Processes are not only the basis for concurrency in Elixir, but they also provide the means for building distributed and fault-tolerant programs.
 
-Elixir's processes should not be confused with operating system processes. Processes in Elixir are extremely lightweight in terms of memory and CPU (unlike threads in many other programming languages). Because of this, it is not uncommon to have tens or even hundreds of thousands of processes running simultaneously.
+Elixir's processes should not be confused with operating system processes. Processes in Elixir are extremely lightweight in terms of memory and CPU (like threads in many other programming languages). Because of this, it is not uncommon to have tens or even hundreds of thousands of processes running simultaneously.
 
 In this chapter, we will learn about the basic constructs for spawning new processes, as well as sending and receiving messages between processes.
 

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -9,7 +9,7 @@ title: Processes
 
 In Elixir, all code runs inside processes. Processes are isolated from each other, run concurrent to one another and communicate via message passing. Processes are not only the basis for concurrency in Elixir, but they also provide the means for building distributed and fault-tolerant programs.
 
-Elixir's processes should not be confused with operating system processes. Processes in Elixir are extremely lightweight in terms of memory and CPU (like threads in many other programming languages). Because of this, it is not uncommon to have tens or even hundreds of thousands of processes running simultaneously.
+Elixir's processes should not be confused with operating system processes. Processes in Elixir are extremely lightweight in terms of memory and CPU (even compared to threads as used in many other programming languages). Because of this, it is not uncommon to have tens or even hundreds of thousands of processes running simultaneously.
 
 In this chapter, we will learn about the basic constructs for spawning new processes, as well as sending and receiving messages between processes.
 


### PR DESCRIPTION
I think the initial intent was to write "not unlike", but the "not" got dropped.