### PR TITLE
Add a note about being in a defmodule to refer to a struct

### DIFF
--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -35,7 +35,7 @@ The keyword list used with `defstruct` defines what fields the struct will have 
 
 Structs take the name of the module they're defined in. In the example above, we defined a struct named `User`.
 
-We can now create `User` structs by using a syntax similar to the one used to create maps (although do note that you must be within a `defmodule` in a `.ex` or `.exs` file to refer to a struct, otherwise you will get an error saying `the struct was not yet defined`):
+We can now create `User` structs by using a syntax similar to the one used to create maps (if you have defined the struct in a separate file, you can compile the file inside IEx before proceeding by running `c "file.exs"`; be aware you may get an error saying `the struct was not yet defined` if you try the below example in a file directly due to when definitions are resolved):
 
 ```iex
 iex> %User{}

--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -35,7 +35,7 @@ The keyword list used with `defstruct` defines what fields the struct will have 
 
 Structs take the name of the module they're defined in. In the example above, we defined a struct named `User`.
 
-We can now create `User` structs by using a syntax similar to the one used to create maps:
+We can now create `User` structs by using a syntax similar to the one used to create maps (although do note that you must be within a `defmodule` in a `.ex` or `.exs` file to refer to a struct, otherwise you will get an error saying `the struct was not yet defined`):
 
 ```iex
 iex> %User{}


### PR DESCRIPTION
If you follow the tutorial in a `.ex` or `.exs` file, then referring to a struct leads to an unexpected error about it not being defined. (This has already come up on Stack Overflow: https://stackoverflow.com/questions/39576209/elixir-cannot-access-struct.)