### PR TITLE
Fix link text for vscode-elixir

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -40,7 +40,7 @@
     <li><a class="spec" href="https://github.com/SteffenBauer/elixir-gtksourceview">GtkSourceView (gedit)</a></li>
     <li><a class="spec" href="https://github.com/lucasmazza/language-elixir">Atom Package</a></li>
     <li><a class="spec" href="https://github.com/KronicDeth/intellij-elixir">IntelliJ Elixir</a></li>
-    <li><a class="spec" href="https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir">Visual Studio Elixir</a></li>
+    <li><a class="spec" href="https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir">Visual Studio Code Elixir</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
The extension is for VS Code, which is not the same as Visual Studio.