### PR TITLE
Don't use assignment pattern matching in function parameters

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -202,7 +202,7 @@ iex> flush()
 {:DOWN, #Reference<0.0.0.551>, :process, #PID<0.66.0>, :normal}
 ```
 
-Note `Process.monitor(pid)` returns a unique reference that allows us to match upcoming messages to that monitoring reference. After we stop the agent, we can `flush/0` all messages and notice a `:DOWN` message arrived, with the exact reference returned by monitor, notifying that the bucket process exited with reason `:normal`.
+Note `Process.monitor(pid)` returns a unique reference that allows us to match upcoming messages to that monitoring reference. After we stop the agent, we can `flush/0` all messages and notice a `:DOWN` message arrived, with the exact reference returned by `monitor`, notifying that the bucket process exited with reason `:normal`.
 
 Let's reimplement the server callbacks to fix the bug and make the test pass. First, we will modify the GenServer state to two dictionaries: one that contains `name -> pid` and another that holds `ref -> name`. Then we need to monitor the buckets on `handle_cast/2` as well as implement a `handle_info/2` callback to handle the monitoring messages. The full server callbacks implementation is shown below:
 
@@ -215,7 +215,8 @@ def init(:ok) do
   {:ok, {names, refs}}
 end
 
-def handle_call({:lookup, name}, _from, {names, _} = state) do
+def handle_call({:lookup, name}, _from, state) do
+  {names, _} = state
   {:reply, Map.fetch(names, name), state}
 end
 


### PR DESCRIPTION
It doesn't seem to be covered or used anywhere in the entire Getting Started guide, so its sudden use is a bit jarring.

Also add some code literal markup in one place.