### PR TITLE
Consistently use periods at the end of comments for doc tests page

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -394,14 +394,14 @@ defmodule KVServerTest do
     assert send_and_recv(socket, "PUT shopping eggs 3\r\n") ==
            "OK\r\n"
 
-    # GET returns two lines
+    # GET returns two lines.
     assert send_and_recv(socket, "GET shopping eggs\r\n") == "3\r\n"
     assert send_and_recv(socket, "") == "OK\r\n"
 
     assert send_and_recv(socket, "DELETE shopping eggs\r\n") ==
            "OK\r\n"
 
-    # GET returns two lines
+    # GET returns two lines.
     assert send_and_recv(socket, "GET shopping eggs\r\n") == "\r\n"
     assert send_and_recv(socket, "") == "OK\r\n"
   end


### PR DESCRIPTION
Previously the file _mostly_ used periods, but not everywhere.