### PR TITLE
Update exenv URL

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -98,7 +98,7 @@ Once the release is unpacked, you are ready to run the `elixir` and `iex` comman
 There are many tools that allow developers to install and manage multiple Erlang and Elixir versions. They are useful if you can't install Erlang or Elixir as mentioned above or if your package manager is simply outdated. Here are some of those tools:
 
   * [asdf](https://github.com/asdf-vm/asdf) - install and manage different Elixir and Erlang versions
-  * [exenv](https://github.com/mururu/exenv) - install and manage different Elixir versions
+  * [exenv](https://github.com/exenv/exenv) - install and manage different Elixir versions
   * [kiex](https://github.com/taylor/kiex) - install and manage different Elixir versions
   * [kerl](https://github.com/yrashk/kerl) - install and manage different Erlang versions
 


### PR DESCRIPTION
The current URL for exenv on the installation page (https://github.com/mururu/exenv/) points to a project the appears to be dead. There are open pull requests dating back to 2014. A [discussion thread](https://github.com/mururu/exenv/issues/15) started in 2016 points to [this](https://github.com/exenv/exenv) repository as an actively-maintained alternative.

This pull request modifies the URL to point to the active project.