### PR TITLE
Minor fix - enclose function arity in code block

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -79,7 +79,7 @@ iex> trunc(3.58)
 
 ## Identifying functions
 
-Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `round/1` identifies the function which is named `round` and takes 1 argument, whereas `round/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
+Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `round/1` identifies the function which is named `round` and takes `1` argument, whereas `round/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
 
 ## Booleans
 


### PR DESCRIPTION
A minor fix in `Basic Types` section, which encloses the function arity in code block.