### PR TITLE
Updated about macOS Mojave Dark mode problem

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,7 +170,7 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
+A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications. *Note that if you are on macOS Mojave and above, and have enabled _dark mode_, the GUI looks inconsistent and certain parts become unreadable. Please disable dark mode on macOS.*
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:
 


### PR DESCRIPTION
Erlang observer GUI is inconsistent (tab bar becomes white over white and sometimes the graph under Applications tab is not shown) with the macOS Mojave Dark Mode. I think better language could be used though. 

Screenshot : 

<img width="847" alt="screenshot 2019-02-28 at 8 41 54 am" src="https://user-images.githubusercontent.com/2824682/53538712-d76b9180-3b34-11e9-83e3-39d47099b9d1.png">
