### PR TITLE
Fix section title "Keyword lists and maps"

### DIFF
--- a/_data/getting-started.yml
+++ b/_data/getting-started.yml
@@ -19,7 +19,7 @@
     - title: Binaries, strings, and charlists
       slug: binaries-strings-and-char-lists
 
-    - title: Keywords lists and maps
+    - title: Keyword lists and maps
       slug: keywords-and-maps
 
     - title: Modules and Functions


### PR DESCRIPTION
The title appeared in the table of contents as "Keywords lists and
maps" (note the "s" at the end of "Keyword"), but on the page it
appeared as "Keyword lists and maps". The table of contents version
was incorrect and has been changed.