### PR TITLE
Bring back outline styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,8 +52,6 @@ a:hover {
   text-decoration: none;
   color: #000;
 }
-a:focus { outline: none; }
-a:hover, a:active { outline: 0; }
 abbr { cursor: help }
 abbr[title] { border-bottom: 1px dotted; }
 acronym {
@@ -392,7 +390,6 @@ form label {
 input[type="text"], input[type="password"], input[type="email"], .input-text, textarea, select {
   border: 1px solid #ddd;
   padding: 5px;
-  outline: none;
   font-size: 0.8125em;
   color: #888;
   margin: 0;


### PR DESCRIPTION
This PR brings back styling for outline when an element is focused. This is tremendously important for accessibility: http://www.outlinenone.com/