### PR TITLE
fix wrong url for opensuse distro obs://devel:languages:erlang/ url

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -32,8 +32,9 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
   * Arch Linux (Community repo)
     * Run: `pacman -S elixir`
   * openSUSE (and SLES)
-    * Add Erlang devel repo: `zypper ar -f obs://devel:languages:erlang/ erlang`
+    * add Elixir/Erlang repo: `zypper ar -f obs://devel:languages:erlang/ Elixir-Factory`
     * Run: `zypper in elixir`
+    * optional: if you want to use the latest Erlang, you can use this repo: `zypper ar -f  obs://devel:languages:erlang:Factory Erlang-Factory`
   * Gentoo
     * Run: `emerge --ask dev-lang/elixir`
   * GNU Guix

--- a/install.markdown
+++ b/install.markdown
@@ -31,8 +31,8 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
 
   * Arch Linux (Community repo)
     * Run: `pacman -S elixir`
-  * openSUSE (and SLES 11 SP3+)
-    * Add Erlang devel repo: `zypper ar -f http://download.opensuse.org/repositories/devel:/languages:/erlang/openSUSE_Factory/ erlang`
+  * openSUSE (and SLES)
+    * Add Erlang devel repo: `zypper ar -f obs://devel:languages:erlang/ erlang`
     * Run: `zypper in elixir`
   * Gentoo
     * Run: `emerge --ask dev-lang/elixir`


### PR DESCRIPTION
# previous behaviour:
repo was picked-up in wrong way because the Url logic.

So an user could endup to install wrong pkgs from elixir/erlang, which can led to bugs of incompatibility vs elixir and erlang version

# new behaviour
when specified obs://devel:languages:erlang/ url, then zypper does look for current right distro version.
In this way each openSUSE distro has the right erlang/elixir pkgs.