### PR TITLE
Adding note about headless vs gui-enabled erlang

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,9 +170,9 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-> Note: If you receive an `{:error, ...}` tuple similar to "No driver found" instead of seeing the observer window, here's what's happened: some package managers default to installing a minimized Erlang without WX bindings for GUI support when you install Elixir. If this affects you, you can either replace the headless Erlang with a more complete package (look for packages named `erlang` vs `erlang-nox` on debian/ubuntu/arch), or you can continue using your current version without being able to use GUI tools.
-
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
+
+> Note: If you receive an `{:error, ...}` tuple similar to "No driver found" instead of seeing the Observer window, here is what may have happened: some package managers default to installing a minimized Erlang without WX bindings for GUI support. In some package managers, you may be able to replace the headless Erlang with a more complete package (look for packages named `erlang` vs `erlang-nox` on Debian/Ubuntu/Arch). In others managers, you may need to install a separate `erlang-wx` (or similarly named) package. Alternatively, you can continue using your current version without being able to use GUI tools.
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:
 

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,6 +170,8 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
+> Note: If you receive an `{:error...` tuple that mentions 'No driver found', ensure that you have installed `erlang` and not the headless `erlang-nox` package from your package manager. You can continue using the headless version, but will have no GUI tools.
+
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
 
 In the Applications tab, you will see all applications currently running in your system along side their supervision tree. You can select the `kv` application to explore it further:

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,7 +170,7 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-> Note: Some distributions and package managers do not install Erlang's complete standard library when you install Erlang. Therefore, if you receive an `{:error, ...}` tuple that mentions "No driver found" or similar, make sure that you have installed the complete version of Erlang or at least include its WX bindings (on ubuntu and some other distributions, the package named `erlang-nox` is headless). If you prefer, you can continue using your current version, but you will have no GUI tools.
+> Note: If you receive an `{:error, ...}` tuple similar to "No driver found" instead of seeing the observer window, here's what's happened: some package managers default to installing a minimized Erlang without WX bindings for GUI support when you install Elixir. If this affects you, you can either replace the headless Erlang with a more complete package (look for packages named `erlang` vs `erlang-nox` on debian/ubuntu/arch), or you can continue using your current version without being able to use GUI tools.
 
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
 

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,7 +170,7 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-> Note: Some distributions and package managers do not install Erlang's complete standard library when you install Erlang. Therefore, if you receive an `{:error, ...}` tuple that mentions "No driver found" or similar, make sure that you have installed the complete version of Erlang or at least include its WX bindings. If you prefer, you can continue using your current version, but you will have no GUI tools.
+> Note: Some distributions and package managers do not install Erlang's complete standard library when you install Erlang. Therefore, if you receive an `{:error, ...}` tuple that mentions "No driver found" or similar, make sure that you have installed the complete version of Erlang or at least include its WX bindings (on ubuntu and some other distributions, the package named `erlang-nox` is headless). If you prefer, you can continue using your current version, but you will have no GUI tools.
 
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
 

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,7 +170,7 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-> Note: If you receive an `{:error, ...}` tuple that mentions "No driver found", ensure that you have installed `erlang` and not the headless `erlang-nox` package from your package manager. You can continue using the headless version, but you will have no GUI tools.
+> Note: Some distributions and package managers do not install Erlang's complete standard library when you install Erlang. Therefore, if you receive an `{:error, ...}` tuple that mentions "No driver found" or similar, make sure that you have installed the complete version of Erlang or at least include its WX bindings. If you prefer, you can continue using your current version, but you will have no GUI tools.
 
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
 

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -170,7 +170,7 @@ Now that we have defined our supervision tree, it is a great opportunity to intr
 iex> :observer.start
 ```
 
-> Note: If you receive an `{:error...` tuple that mentions 'No driver found', ensure that you have installed `erlang` and not the headless `erlang-nox` package from your package manager. You can continue using the headless version, but will have no GUI tools.
+> Note: If you receive an `{:error, ...}` tuple that mentions "No driver found", ensure that you have installed `erlang` and not the headless `erlang-nox` package from your package manager. You can continue using the headless version, but you will have no GUI tools.
 
 A GUI should pop-up containing all sorts of information about our system, from general statistics to load charts as well as a list of all running processes and applications.
 


### PR DESCRIPTION
On at least some linux distributions, the headless version of erlang is installed as the default dependency for elixir. This results in an error when trying to start the observer or other gui tools.

```elixir
iex> :observer.start
{:error,
 {{:load_driver, 'No driver found'},
  [...]
}}
```