### PR TITLE
Rename "Mac OS X" to "macOS" in the installation doc

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -19,7 +19,7 @@ The preferred option for installing Elixir. Choose your operating system and too
 
 If your distribution contains an old Elixir/Erlang version, see the sections below for installing Elixir/Erlang from version managers or from source.
 
-### Mac OS X
+### macOS
 
   * Homebrew
     * Update your homebrew to latest: `brew update`


### PR DESCRIPTION
> In 2016, with the release of macOS 10.12 Sierra, the name was changed from OS X to macOS. ([source](https://en.wikipedia.org/wiki/MacOS#macOS))