### PR TITLE
Add ubuntu 19.04 to the list of supported distros

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -48,7 +48,7 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * From pkg: `pkg install elixir`
   * Solus
     * Run: `eopkg install elixir`
-  * Ubuntu 14.04/16.04/17.04/18.04 or Debian 7/8/9
+  * Ubuntu 14.04/16.04/17.04/18.04/19.04 or Debian 7/8/9
     * Add Erlang Solutions repo: `wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb`
     * Run: `sudo apt-get update`
     * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`


### PR DESCRIPTION
As it was commented here (https://github.com/elixir-lang/elixir/issues/8990). Add Ubuntu 19.04 at the list of supported distros.