### PR TITLE
add keyboard navigation into getting started guide

### DIFF
--- a/_includes/bottom.html
+++ b/_includes/bottom.html
@@ -12,6 +12,28 @@
   <script src="/js/toc/toc.js" type="text/javascript" charset="utf-8"></script>
   <script type="text/javascript">
     $(document).ready(function() {
+      $(document).on('keyup', function(e) {
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+
+        switch(e.which) {
+          case 37: // left arrow
+            goToPage('previous');
+          break;
+          case 39: // right arrow
+            goToPage('next');
+          break;
+        }
+      });
+
+      function goToPage(target) {
+        var href = $('.pagination .' + target).attr('href');
+
+        if (href) document.location = href;
+      }
+    });
+  </script>
+  <script type="text/javascript">
+    $(document).ready(function() {
       $('.toc').toc({
         title: '',
         listType: 'ol',

--- a/_layouts/getting-started.html
+++ b/_layouts/getting-started.html
@@ -54,7 +54,7 @@ section: getting-started
               <a class="page-numbers spec" href="#container">Top</a>
             {% unless forloop.last %}
               {% assign next = guide.pages[forloop.index] %}
-              <a href="{{guide.dir}}{{next.slug}}.html" class="previous page-numbers spec" title="{{next.title | escape}}">Next &rarr;</a>
+              <a href="{{guide.dir}}{{next.slug}}.html" class="next page-numbers spec" title="{{next.title | escape}}">Next &rarr;</a>
             {% endunless %}
           </div>
         {% endif %}


### PR DESCRIPTION
This PR tries to add left/right keyboard shortcut to the getting started section, which will activate `previous` and `next` navigation respectively, since I find it easier to navigate with keyboard shortcut than having to reach for the mouse..

Hopefully it will help.. :tada: 