### PR TITLE
Added a link to the Code Elixir LDN conference to important links

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -1,4 +1,8 @@
 <div class="widget">
+  <a class="spec" href="https://codesync.global/conferences/code-elixir-ldn-2019/" target="_blank"><img src="https://storage.pardot.com/23452/194513/elixir_conference.jpg" title="Code Elixir LDN logo" style="width: 100%; margin-left: -4px; border: 0" alt="Code Elixir LDN 2019">Code Elixir LDN</a> is an Elixir conference in London, taking place on 18 July. Early bird conference and training tickets on sale.
+</div>
+
+<div class="widget">
   <a class="spec" href="https://elixirconf.com/" target="_blank">
     <img src="https://elixirconf.com/2018/images/resources/elixirconf-logo-brand-dk.png" width="190" title="ElixirConf logo" style="border:0; margin-left:-4px">
   </a>


### PR DESCRIPTION
I placed it above the link to ElixirConf US as the Code Elixir LDN conference will take place sooner than ElixirConf.

Also, the image graphic is included in the anchor tag such that the link is only present once, which should be good for both people navigating the site using keyboard and screen readers.