### PR TITLE
Add subreddit links.

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -23,6 +23,7 @@
   <h3 class="widget-title">Join the Community</h3>
   <ul>
     <li><a class="spec" href="http://elixirforum.com">Elixir Forum</a></li>
+    <li><a class="spec" href="https://www.reddit.com/r/elixir">Elixir on Reddit</a></li>
     <li><a class="spec" href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a></li>
     <li><a class="spec" href="https://discord.gg/elixir">Elixir on Discord</a></li>
     <li><a class="spec" href="http://elixir.meetup.com">Meetups around the world</a></li>

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -81,6 +81,7 @@ When going through this getting started guide, it is common to have questions; a
 
   * [Official #elixir-lang on freenode IRC](irc://irc.freenode.net/elixir-lang)
   * [Elixir Forum](http://elixirforum.com)
+  * [Elixir on Reddit](https://www.reddit.com/r/elixir)
   * [Elixir on Slack](https://elixir-slackin.herokuapp.com/)
   * [Elixir on Discord](https://discord.gg/elixir)
   * [elixir tag on StackOverflow](https://stackoverflow.com/questions/tagged/elixir)


### PR DESCRIPTION
Now that I've actually found the time to get the subreddit back in [working order](https://www.reddit.com/r/elixir/comments/bvqzc8/an_update_on_the_state_of_this_subreddit/), I thought it would make sense to add it to the list of community links.

I'm not sure how the list of links is supposed to be sorted. I went with the logic that since a subreddit is essentially a forum, the link would go after the official Elixir Forum. I have no particular preference though.