### PR TITLE
I had totally missed the text in the note

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -81,6 +81,24 @@ iex> trunc(3.58)
 
 Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `round/1` identifies the function which is named `round` and takes `1` argument, whereas `round/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
 
+## Getting help
+
+The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h round/1` is going to print the documentation for the `round/1` function. It also works with operators and other constructs (try `h +/2`).
+
+Without parameters, it prints information on how to use the shell. 
+
+Here we invoke `h/1` to get help about the shell help function `h/0`:
+
+```iex
+iex> h h/0
+
+                             def h()
+
+Prints the documentation for IEx.Helpers.
+```
+
+Similarly, there's a `i` function, which you can use to print information about a value or about the result of an expression.
+
 ## Booleans
 
 Elixir supports `true` and `false` as booleans:
@@ -102,8 +120,6 @@ false
 ```
 
 You can also use `is_integer/1`, `is_float/1` or `is_number/1` to check, respectively, if an argument is an integer, a float, or either.
-
-> Note: At any moment you can type `h()` in the shell to print information on how to use the shell. The `h` helper can also be used to access documentation for any function. For example, typing `h is_integer/1` is going to print the documentation for the `is_integer/1` function. It also works with operators and other constructs (try `h ==/2`).
 
 ## Atoms
 

--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -77,27 +77,20 @@ iex> trunc(3.58)
 3
 ```
 
-## Identifying functions
+## Identifying functions and documentation
 
 Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `round/1` identifies the function which is named `round` and takes `1` argument, whereas `round/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
 
-## Getting help
-
-The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h round/1` is going to print the documentation for the `round/1` function. It also works with operators and other constructs (try `h +/2`).
-
-Without parameters, it prints information on how to use the shell. 
-
-Here we invoke `h/1` to get help about the shell help function `h/0`:
+We can also use this syntax to access documentation. The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h round/1` is going to print the documentation for the `round/1` function:
 
 ```iex
-iex> h h/0
-
-                             def h()
-
-Prints the documentation for IEx.Helpers.
+iex> h round/1
+                             def round()
+                             
+Rounds a number to the nearest integer.
 ```
 
-Similarly, there's a `i` function, which you can use to print information about a value or about the result of an expression.
+It also works with operators and other constructs (try `h +/2`). Invoking `h` without arguments displays the documentation for `IEx.Helpers`, which is where `h` and other functionality is defined.
 
 ## Booleans
 


### PR DESCRIPTION
would I have not missed it if it was more prominent, like I'm suggesting here?  I had reached the module attributes page, and finally realized there was a help function, so I said to myself let's put it somewhere in the text, where it should be introduced, and guess what I intended to put it just only one paragraph above the spot I had missed.