### PR TITLE
reviewing getting_started/GenServer

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -71,7 +71,9 @@ iex> Agent.get(agent, fn content -> content end)
 iex>
 ```
 
-It is completely up to us, to use `Agent` in a sensible way, and the proper way to go is by writing modules that enforce a behaviour, by exposing a well defined API. Let's do precisely that, let's implement our `KV.Bucket` using agents and let's start by first writing some tests, to define the API exposed by our module. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
+What does the above mess show? The sensible use of agents is completely in our hands, and the proper way to go is by writing modules that implement a behaviour, by exposing a well defined API. Let's do precisely that, let's implement our `KV.Bucket` using `Agent` and let's start by first writing some tests, to define the API exposed by our module.
+
+Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
 
 ```elixir
 defmodule KV.BucketTest do

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -68,10 +68,10 @@ iex> Agent.update(agent, fn list -> [:nop | list] end)
 :ok
 iex> Agent.get(agent, fn content -> content end)
 [:nop, 12, %{a: 123}]
-iex> 
+iex>
 ```
 
-It is completely up to us, to use `Agent` in a sensible way, and the proper way to go is by writing modules that enforce a behaviour, by exposing a well defined API. Let's do precisely that, let's implement our `KV.Bucket` using agents and let's start start by first writing some tests, to define the API exposed by our module. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
+It is completely up to us, to use `Agent` in a sensible way, and the proper way to go is by writing modules that enforce a behaviour, by exposing a well defined API. Let's do precisely that, let's implement our `KV.Bucket` using agents and let's start by first writing some tests, to define the API exposed by our module. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
 
 ```elixir
 defmodule KV.BucketTest do

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -9,7 +9,9 @@ title: Agent
 
 {% include mix-otp-preface.html %}
 
-In this chapter, we will create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way that allows them to be read and modified by other processes.
+In this chapter, we will learn about variables in the aethernally invariability of the Erlang VM ecosystem.
+
+create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way that allows them to be read and modified by other processes.
 
 If you have skipped the Getting Started guide or read it long ago, be sure to re-read the [Processes](/getting-started/processes.html) chapter. We will use it as a starting point.
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -9,15 +9,13 @@ title: Agent
 
 {% include mix-otp-preface.html %}
 
-In this chapter, we will learn about variables in the aethernally invariability of the Erlang VM ecosystem.
-
-create a module named `KV.Bucket`. This module will be responsible for storing our key-value entries in a way that allows them to be read and modified by other processes.
+In this chapter we will learn how to keep a dynamic status within the Elixir ecosystem of immutable values. If you have previous programming experience outside functional programming, you may think of globally shared variables. The next chapters will generalize the concepts introduced here.
 
 If you have skipped the Getting Started guide or read it long ago, be sure to re-read the [Processes](/getting-started/processes.html) chapter. We will use it as a starting point.
 
 ## The trouble with state
 
-Elixir is an immutable language where nothing is shared by default. If we want to provide buckets, which can be read and modified from multiple places, we have two main options in Elixir:
+Elixir is an immutable language where nothing is shared by default. If we want to provide "variables", which can be read and modified from multiple places, we have two main options in Elixir:
 
 * Processes
 * [ETS (Erlang Term Storage)](http://www.erlang.org/doc/man/ets.html)
@@ -29,6 +27,8 @@ We covered processes in the Getting Started guide. <abbr title="Erlang Term Stor
 * [Task](https://hexdocs.pm/elixir/Task.html) - Asynchronous units of computation that allow spawning a process and potentially retrieving its result at a later time.
 
 We will explore most of these abstractions in this guide. Keep in mind that they are all implemented on top of processes using the basic features provided by the <abbr title="Virtual Machine">VM</abbr>, like `send`, `receive`, `spawn` and `link`.
+
+Here we will use Agents, and create a module named `KV.Bucket`, responsible for storing our key-value entries in a way that allows them to be read and modified by other processes.
 
 ## Agents
 
@@ -53,7 +53,25 @@ iex> Agent.stop(agent)
 
 We started an agent with an initial state of an empty list. We updated the agent's state, adding our new item to the head of the list. The second argument of [`Agent.update/3`](https://hexdocs.pm/elixir/Agent.html#update/3) is a function that takes the agent's current state as input and returns its desired new state. Finally, we retrieved the whole list. The second argument of [`Agent.get/3`](https://hexdocs.pm/elixir/Agent.html#get/3) is a function that takes the state as input and returns the value that [`Agent.get/3`](https://hexdocs.pm/elixir/Agent.html#get/3) itself will return. Once we are done with the agent, we can call [`Agent.stop/3`](https://hexdocs.pm/elixir/Agent.html#stop/3) to terminate the agent process.
 
-Let's implement our `KV.Bucket` using agents. But before starting the implementation, let's first write some tests. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
+The `Agent.update/3` function accepts just any function-value as second argument, as long as it accepts a value and returns a value. Semantic nonsense like the following being perfectly legal:
+
+```iex
+iex> {:ok, agent} = Agent.start_link fn -> [] end
+{:ok, #PID<0.338.0>}
+iex> Agent.update(agent, fn _list -> 123 end)
+:ok
+iex> Agent.update(agent, fn content -> %{a: content} end)
+:ok
+iex> Agent.update(agent, fn content -> [12 | [content]] end)
+:ok
+iex> Agent.update(agent, fn list -> [:nop | list] end)
+:ok
+iex> Agent.get(agent, fn content -> content end)
+[:nop, 12, %{a: 123}]
+iex> 
+```
+
+It is completely up to us, to use `Agent` in a sensible way, and the proper way to go is by writing modules that enforce a behaviour, by exposing a well defined API. Let's do precisely that, let's implement our `KV.Bucket` using agents and let's start start by first writing some tests, to define the API exposed by our module. Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
 
 ```elixir
 defmodule KV.BucketTest do
@@ -68,6 +86,8 @@ defmodule KV.BucketTest do
   end
 end
 ```
+
+The leading `use` line injects several macros in our module. Among these: `test` helps us define test functions.
 
 Our first test starts a new `KV.Bucket` by calling the `start_link/1` and passing an empty list of options. Then we perform some `get/2` and `put/3` operations on it, asserting the result.
 
@@ -140,7 +160,7 @@ defmodule KV.BucketTest do
 end
 ```
 
-We have first defined a setup callback with the help of the `setup/1` macro. The `setup/1` callback runs before every test, in the same process as the test itself.
+We have first defined a setup callback with the help of the `setup/1` macro. The `setup/1` macro defines a callback that is run before every test, in the same process as the test itself.
 
 Note that we need a mechanism to pass the `bucket` pid from the callback to the test. We do so by using the *test context*. When we return `%{bucket: bucket}` from the callback, ExUnit will merge this map into the test context. Since the test context is a map itself, we can pattern match the bucket out of it, providing access to the bucket inside the test:
 

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -40,19 +40,57 @@ However, naming dynamic processes with atoms is a terrible idea! If we use atoms
 
 In practice, it is more likely you will reach the Erlang <abbr title="Virtual Machine">VM</abbr> limit for the maximum number of atoms before you run out of memory, which will bring your system down regardless.
 
-Instead of abusing the built-in name facility, we will create our own *process registry* that associates the bucket name to the bucket process. Is this an other use for `Agent`?
+Instead of abusing the built-in name facility, we will create our own *process registry* that associates the bucket name to the bucket process.
 
-The registry needs to guarantee that it is always up to date. For example, if one of the bucket processes crashes due to a bug, the registry must notice this change and avoid serving stale entries. In Elixir, we say the registry needs to *monitor* each bucket. Not something an `Agent` can do.
+The registry needs to guarantee that it is always up to date. For example, if one of the bucket processes crashes due to a bug, the registry must notice this change and avoid serving stale entries. In Elixir, we say the registry needs to *monitor* each bucket. Because our *registry* needs to be able to receive and handle ad-hoc messages from the system, the `Agent` API is not enough.
 
 We will use a [GenServer](https://hexdocs.pm/elixir/GenServer.html) to create a registry process that can monitor the bucket processes. GenServer provides industrial strength functionality for building servers in both Elixir and  <abbr title="Open Telecom Platform">OTP</abbr>.
 
-Please do follow the [GenServer](https://hexdocs.pm/elixir/GenServer.html) link, we are going to assume you have read the first few sections of the page.
+Please read [the GenServer module documentation](https://hexdocs.pm/elixir/GenServer.html) for an overview if you haven't yet. Once you do so, we are ready to proceed.
 
-## By brute force
+## GenServer callbacks
 
-Right, you did **not** check the above link, you expect this docs to be self-contained. Too bad.
+A GenServer is a process that invokes a limited set of functions under specific conditions. When we used an `Agent`, we would keep both the client code and the server code side by side, like this:
 
-Let's start by writing our bucket registering logic, and show how its usage would be, if we do not write a proper API.
+```elixir
+def put(bucket, key, value) do
+  Agent.update(bucket, &Map.put(&1, key, value))
+end
+```
+
+Let's break that code apart a bit:
+
+```elixir
+def put(bucket, key, value) do
+  # Here is the client code
+  Agent.update(bucket, fn state ->
+    # Here is the server code
+    Map.put(state, key, value)
+  end)
+  # Back to the client code
+end
+```
+
+In the code above, we have a process, which we call "the client" sending a request to an agent, "the server". The request contains an anonymous function, which must be executed by the server.
+
+In a GenServer, the code above would be two separate functions, roughly like this:
+
+```elixir
+def put(bucket, key, value) do
+  # Send the server a :put "instruction"
+  GenServer.call(bucket, {:put, key, value})
+end
+
+# Server callback
+
+def handle_call({:put, key, value}, from, state) do
+  {:noreply, Map.put(state, key, value)}
+end
+```
+
+There is quite a bit more ceremony in the GenServer code but, as we will see, it brings some benefits too.
+
+For now, we will write only the server callbacks for our bucket registering logic, without providing a proper API, which we will do later.
 
 Create a new file at `lib/kv/registry.ex` with the following contents:
 
@@ -62,7 +100,7 @@ defmodule KV.Registry do
 
   ## Missing Client API - will add this later
 
-  ## Overriding GenServer Callbacks
+  ## Defining GenServer Callbacks
 
   @impl true
   def init(:ok) do
@@ -86,63 +124,28 @@ defmodule KV.Registry do
 end
 ```
 
-There are two types of requests you can send to a GenServer: calls and casts. Calls are synchronous and the server **must** send a response back to such requests. Casts are asynchronous and the server won't send a response back. Both requests are messages sent to the server, and will be handled in sequence. In the above implementation, we pattern-match on the `:create` messages, to be handled as cast, and on the `:lookup` messages, to be handled as call.
+There are two types of requests you can send to a GenServer: calls and casts. Calls are synchronous and the server **must** send a response back to such requests. While the server computes the response, the client is **waiting**. Casts are asynchronous: the server won't send a response back and therefore the client won't wait for one. Both requests are messages sent to the server, and will be handled in sequence. In the above implementation, we pattern-match on the `:create` messages, to be handled as cast, and on the `:lookup` messages, to be handled as call.
 
-As long as we don't define a client API, in order to activate our code, we need to go through the corresponding `GenServer` functions; to create our registry, to create a named bucket, and to look one up.
+In order to invoke the callbacks above, we need to go through the corresponding `GenServer` functions. Let's start a registry, create a named bucket, and then look it up:
 
 ```elixir
-iex> {:ok, reg} = GenServer.start(KV.Registry, :ok)
+iex> {:ok, registry} = GenServer.start_link(KV.Registry, :ok)
 {:ok, #PID<0.136.0>}
-iex> GenServer.cast(reg, {:create, "shopping"})
+iex> GenServer.cast(registry, {:create, "shopping"})
 :ok
-iex> {:ok, bk} = GenServer.call(reg, {:lookup, "shopping"})
+iex> {:ok, bk} = GenServer.call(registry, {:lookup, "shopping"})
 {:ok, #PID<0.174.0>}
 ```
 
-Our `KV.Registry` process would receive the two messages `{:create, "shopping"}` and `{:lookup, "shopping"}`, in this sequence. It would handle them in the same order, in the callbacks we defined above. Notice how our call to `GenServer.cast` would immediately return, possibly even before the message was delivered to the `reg` process. The `GenServer.call` on the other hand, is where we would be waiting for an answer, provided by the above `KV.Registry.handle_call` callback.
+Our `KV.Registry` process received a cast with `{:create, "shopping"}` and a call with `{:lookup, "shopping"}`, in this sequence. `GenServer.cast` will immediately return, as soon as the message is sent to the `registry`. The `GenServer.call` on the other hand, is where we would be waiting for an answer, provided by the above `KV.Registry.handle_call` callback.
 
-> Oh, and the role of those fancy `@impl true`? It's a safety net, it informs the compiler that our intention for the subsequent function definition is to override a callback. If by any chance we make a mistake in arity, like we define a `handle_call/2`, the compile would warn us there isn't any `handle_call/2` to override, and would give us the complete list of known callbacks for the `GenServer` module.
+You may also have noticed that we have added `@impl true` before each callback. The `@impl true` informs the compiler that our intention for the subsequent function definition is to define a callback. If by any chance we make a mistake in the function name or in the number of arguments, like we define a `handle_call/2`, the compile would warn us there isn't any `handle_call/2` to define, and would give us the complete list of known callbacks for the `GenServer` module.
 
 This is all good and well, but we still want to offer our users an API that allows us to hide our implementation details.
 
-## First things first
+## The Client API
 
-Let's start by defining tests, describing the API we intend to implement.
-
-Testing a GenServer is not much different from testing an agent. We will spawn the server on a setup callback and use it throughout our tests. Create a file at `test/kv/registry_test.exs` with the following:
-
-```elixir
-defmodule KV.RegistryTest do
-  use ExUnit.Case, async: true
-
-  setup do
-    registry = start_supervised!(KV.Registry)
-    %{registry: registry}
-  end
-
-  test "spawns buckets", %{registry: registry} do
-    assert KV.Registry.lookup(registry, "shopping") == :error
-
-    KV.Registry.create(registry, "shopping")
-    assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
-
-    KV.Bucket.put(bucket, "milk", 1)
-    assert KV.Bucket.get(bucket, "milk") == 1
-  end
-end
-```
-
-Our test case first asserts there's no buckets in our registry, creates a named bucket, looks it up, and asserts it behaves as a bucket.
-
-There is one important difference between the `setup` block we wrote for `KV.Registry` and the one we wrote for `KV.Bucket`. Instead of starting the registry by hand by calling `KV.Registry.start_link/1`, we instead called [the `start_supervised!/2` function](https://hexdocs.pm/ex_unit/ExUnit.Callbacks.html#start_supervised/2), passing the `KV.Registry` module.
-
-The `start_supervised!` function was injected into our test module by `use ExUnit.Case`. It does the job of starting the `KV.Registry` process, by calling its `start_link/1` function. The advantage of using `start_supervised!` is that ExUnit will guarantee that the registry process will be shutdown **before** the next test starts. In other words, it helps guarantee the state of one test is not going to interfere with the next one in case they depend on shared resources.
-
-When starting processes during your tests, we should always prefer to use `start_supervised!`. We recommend you to change the `setup` block in `bucket_test.exs` to use `start_supervised!` too.
-
-## Implementing it
-
-A GenServer is implemented in two parts: the client API and the server callbacks. You can either combine both parts into a single module or you can separate them into a client module and a server module. The client and server run in separate processes, with the client passing messages back and forth to the server as its functions are called. Here we'll use a single module for both the server callbacks and the client API.
+A GenServer is implemented in two parts: the client API and the server callbacks. You can either combine both parts into a single module or you can separate them into a client module and a server module. The client is any process that invokes the client function. The server is always the process identifier or process name that we will explicitly pass as argument to the client API. Here we'll use a single module for both the server callbacks and the client API.
 
 Edit the file at `lib/kv/registry.ex`, filling in the blanks for the client API:
 
@@ -183,7 +186,7 @@ The first function is `start_link/1`, which starts a new GenServer passing a lis
 
 The next two functions, `lookup/2` and `create/2` are responsible for sending these requests to the server.  In this case, we have used `{:lookup, name}` and `{:create, name}` respectively.  Requests are often specified as tuples, like this, in order to provide more than one "argument" in that first argument slot. It's common to specify the action being requested as the first element of a tuple, and arguments for that action in the remaining elements. Note that the requests must match the first argument to `handle_call/3` or `handle_cast/2`.
 
-That's it for the client API. On the server side, we can implement a variety of callbacks to guarantee the server initialization, termination, and handling of requests. Those callbacks are optional and for now, we have only implemented the ones we care about.
+That's it for the client API. On the server side, we can implement a variety of callbacks to guarantee the server initialization, termination, and handling of requests. Those callbacks are optional and for now, we have only implemented the ones we care about. Let's recap.
 
 The first is the `init/1` callback, that receives the second argument given to `GenServer.start_link/3` and returns `{:ok, state}`, where state is a new map. We can already notice how the `GenServer` API makes the client/server segregation more apparent. `start_link/3` happens in the client, while `init/1` is the respective callback that runs on the server.
 
@@ -193,28 +196,48 @@ For `cast/2` requests, we implement a `handle_cast/2` callback that receives the
 
 There are other tuple formats both `handle_call/3` and `handle_cast/2` callbacks may return. There are also other callbacks like `terminate/2` and `code_change/3` that we could implement. You are welcome to explore the [full GenServer documentation](https://hexdocs.pm/elixir/GenServer.html) to learn more about those.
 
-The API we just added should satisfy the tests we defined before.
+For now, let's write some tests to guarantee our GenServer works as expected.
 
-In addition, if there is a need to stop a `GenServer` as part of the application logic, one can use the `GenServer.stop/1` function:
+## Testing a GenServer
+
+Testing a GenServer is not much different from testing an agent. We will spawn the server on a setup callback and use it throughout our tests. Create a file at `test/kv/registry_test.exs` with the following:
 
 ```elixir
-## Client API
+defmodule KV.RegistryTest do
+  use ExUnit.Case, async: true
 
-@doc """
-Stops the registry.
-"""
-def stop(server) do
-  GenServer.stop(server)
+  setup do
+    registry = start_supervised!(KV.Registry)
+    %{registry: registry}
+  end
+
+  test "spawns buckets", %{registry: registry} do
+    assert KV.Registry.lookup(registry, "shopping") == :error
+
+    KV.Registry.create(registry, "shopping")
+    assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
+
+    KV.Bucket.put(bucket, "milk", 1)
+    assert KV.Bucket.get(bucket, "milk") == 1
+  end
 end
 ```
 
-You can write the tests for this functionality as well.
+Our test case first asserts there's no buckets in our registry, creates a named bucket, looks it up, and asserts it behaves as a bucket.
+
+There is one important difference between the `setup` block we wrote for `KV.Registry` and the one we wrote for `KV.Bucket`. Instead of starting the registry by hand by calling `KV.Registry.start_link/1`, we instead called [the `start_supervised!/2` function](https://hexdocs.pm/ex_unit/ExUnit.Callbacks.html#start_supervised/2), passing the `KV.Registry` module.
+
+The `start_supervised!` function was injected into our test module by `use ExUnit.Case`. It does the job of starting the `KV.Registry` process, by calling its `start_link/1` function. The advantage of using `start_supervised!` is that ExUnit will guarantee that the registry process will be shutdown **before** the next test starts. In other words, it helps guarantee the state of one test is not going to interfere with the next one in case they depend on shared resources.
+
+When starting processes during your tests, we should always prefer to use `start_supervised!`. We recommend you to change the `setup` block in `bucket_test.exs` to use `start_supervised!` too.
+
+Run the tests and they should all pass!
 
 ## The need for monitoring
 
-We could have written the above code, based on `Agent`. Here we show the extra power offered by `GenServer`, as compared to a plain `Agent`.
+Everything we have done so far could have been implemented with an `Agent`. In this section, we will see one of many things that we can achieve with a GenServer that is not possible with an Agent.
 
-Let's program a test, describing the desired behaviour of our registry, if a bucket stops or crashes:
+Let's start with a test that describes how we want the registry to behave if a bucket stops or crashes:
 
 ```elixir
 test "removes buckets on exit", %{registry: registry} do

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -52,7 +52,7 @@ Please do follow the [GenServer](https://hexdocs.pm/elixir/GenServer.html) link,
 
 Right, you did **not** check the above link, you expect this docs to be self-contained. Too bad.
 
-Let's start by writing our bucket registering logit, and show how its usage would be, if we do not write a proper API.
+Let's start by writing our bucket registering logic, and show how its usage would be, if we do not write a proper API.
 
 ```elixir
 defmodule KV.Registry do
@@ -80,7 +80,7 @@ defmodule KV.Registry do
 end
 ```
 
-Without an API, in order to create a registry, we need to go through a `GenServer` function, with the right parameters, to create a bucket, again we need a `GenServer` function, as well as for retrieving one. All obviously quite error-prone:
+Without an API, in order to create a registry, we need to go through a `GenServer` function, with the right parameters; to create a bucket, again we need a `GenServer` function; again the same for retrieving one, like this:
 
 ```
 {:ok, reg} = GenServer.start(KV.Registry, :ok)
@@ -88,14 +88,11 @@ GenServer.cast(reg, {:create, "shopping"})
 {:ok, bk} = GenServer.call(reg, {:lookup, "shopping"})
 ```
 
-We all do agree that the following would be more readable, don't we?
+Our `KV.Registry` process would receive the two messages `{:create, "shopping"}` and `{:lookup, "shopping"}`, in this sequence. It would handle them in the same order, in the callbacks we defined above. Notice how our call to `GenServer.cast` would immediately return, possibly even before the message was delivered to the `reg` process. The `GenServer.call` on the other hand, is where we would be waiting for an answer, provided by the `KV.Registry.handle_call` callback.
 
-```
-KV.Registry.create(reg, "shopping")
-{:ok, bk} = KV.Registry.lookup(reg, "shopping")
-```
+> Oh, and the role of those fancy `@impl true`? It's a safety net, it informs the compiler that our intention for the subsequent function definition is to override a callback. If by any chance we make a mistake in arity, like we define a `handle_call/2`, the compile would warn us there isn't any `handle_call/2` to override, and would give us the complete list of known callbacks for the `GenServer` module.
 
-The initialization, and connection of our `KV.Registry` to a supervisor, we do that further in the text.
+This is all good and well, but we still want to offer our users an API that allows us to hide our implementation details.
 
 ## First things first
 


### PR DESCRIPTION
I was a bit overwhelmed when the `getting started` guide reached the use of `Agent` and even more so when it was the time for `GenServer`.  I added an example of plain straight use of Agent, which helped me make sense of writing and testing the KV.Bucket API.  I later saw this is precisely the approach taken in the https://hexdocs.pm/elixir/GenServer.html linked page.  I can follow it better that way.

but now what, I mean, do we want the reader to jump to the other docs, read and understand, but with the chance they get lost in far deeper details?  or do we want to copy/adapt part of that text into this getting-started guide?  I still didn't reach the place where it handles supervisors.