### PR TITLE
removing link to proprietary cheat sheet

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -322,8 +322,6 @@ So far we have used three callbacks: `handle_call/3`, `handle_cast/2` and `handl
 
 Since any message, including the ones sent via `send/2`, go to `handle_info/2`, there is a chance unexpected messages will arrive to the server. Therefore, if we don't define the catch-all clause, those messages could cause our registry to crash, because no clause would match. We don't need to worry about such cases for `handle_call/3` and `handle_cast/2` though. Calls and casts are only done via the `GenServer` API, so an unknown message is quite likely a developer mistake.
 
-To help developers remember the differences between call, cast and info, the supported return values and more, [Benjamin Tan Wei Hao](http://benjamintan.io) has created an excellent [GenServer cheat sheet](https://raw.githubusercontent.com/benjamintanweihao/elixir-cheatsheets/master/GenServer_CheatSheet.pdf).
-
 ## Monitors or links?
 
 We have previously learned about links in the [Process chapter](/getting-started/processes.html). Now, with the registry complete, you may be wondering: when should we use monitors and when should we use links?


### PR DESCRIPTION
I don't think this cheat sheet makes things so much clearer:
- it has hardly any structure (like it would be if all client->return-value-from-client->callback->return-value-from-callback would all be organized as in the clearly structured initialization block), 
- graphic elements drawn on top of the text make it less readable, 
- I think it has flaws (not mentioning the return value from `handle_call`, explaining `*`, why return value tuples have different sizes) 

**and**
- it has one major problem: the license does not allow correcting it.