### PR TITLE
introduce supervisors at the top of the supervisors chapter

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -337,4 +337,4 @@ Returning to our `handle_cast/2` implementation, you can see the registry is bot
 ref = Process.monitor(pid)
 ```
 
-This is a bad idea, as we don't want the registry to crash when a bucket crashes! We typically avoid creating new processes directly, instead, we delegate this responsibility to supervisors. As we'll see in the next chapter, supervisors rely on links and that explains why link-based APIs (`spawn_link`, `start_link`, etc) are so prevalent in Elixir and <abbr title="Open Telecom Platform">OTP</abbr>.
+This is a bad idea, as we don't want the registry to crash when a bucket crashes. A reasonable fix here, once we have settled for our `KV.Registry` to monitor its buckets via references, is replace `KV.Bucket.start_link` for a plain `start`. A more radical solution is explored in the next chapter, where we introduce "supervisors".

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -9,9 +9,11 @@ title: Supervisor and Application
 
 {% include mix-otp-preface.html %}
 
-So far our application has a registry that may monitor dozens, if not hundreds, of buckets. While we think our implementation so far is quite good, no software is bug-free, and failures are definitely going to happen.
+In this chapter, we are going to learn about supervisors. We are going to create not one, but two supervisors, and use them to supervise our processes. (TODO: the impatient reader (forcing themselves to read the docs this time) sees 'first supervisor' and I can assure you their first urge is to search for the word 'second', and there's none here.)
 
-When things fail, your first reaction may be: "let's rescue those errors". But in Elixir we avoid the defensive programming habit of rescuing errors. Instead, we say "let it crash". If there is a bug that leads our registry to crash, we have nothing to worry about. We are going to learn how to use a special type of process, called Supervisor, which will start a fresh copy of the registry whenever there is a failure.
+We closed the previous chapter about GenServer, with our `KV.Registry` managing buckets, and able to take action whenever a monitored `KV.Bucket` crashed. Not a particularly pro-active reaction, just removing the reference, why not restart the crashed process? In our buckets case it's probably not worth the effort, but there's a more compelling reason: Elixir offers a module designed precisely to do this, supervise that every vital element of our application is up and running at any given moment.
+
+When things fail, your first reaction may be: "let's rescue those errors". In Elixir we avoid the defensive programming habit of rescuing exceptions. Instead, we say "let it crash". If there is a bug that leads our registry to crash, we have nothing to worry about because we are going to set up a supervisor that will start a fresh copy of the registry.
 
 At the end of the chapter, we will also talk about Applications. As we will see, Mix has been packaging all of our code into an application, and we will learn how to customize it to control exactly what happens when our system starts.
 

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -58,13 +58,15 @@ We will learn those details as we move forward on this guide. If you would rathe
 
 After the supervisor retrieves all child specifications, it proceeds to start its children one by one, in the order they were defined, using the information in the `:start` key in the child specification. For our current specification, it will call `KV.Registry.start_link([])`.
 
-In the previous chapter, we have used `start_supervised!` to start the registry during our tests. Internally, the `start_supervised!` function starts the registry under a supervisor defined by the ExUnit framework. By defining our own supervisor, we provide more structure on how we initialize, shutdown and supervise registries in your applications, aligning our production code and tests best practices.
+TODO: at this point we have a supervisor, on top of our registry, on top of our buckets. I miss some summarizing this. Like, in the previous chapter we `stop` a bucket and we saw the bucket disappears from the list. Here I would like to stop the registry (how do I do that?) and see that a new registry was started by the supervisor.
 
-So far `start_link/1` has always received an empty list of options. It is time we change that.
+In the previous chapter, we have used `start_supervised!` to start the registry during our tests. Internally, the `start_supervised!` function starts the registry under a supervisor defined by the ExUnit framework. By defining our own supervisor, we provide more structure on how we initialize, shutdown and supervise registries in your applications, aligning our production code and tests best practices.
 
 ## Naming processes
 
-While our application will have many buckets, it will only have a single registry. So instead of always passing the registry PID around, we can give the registry a name, and always reference it by its name.
+TODO: split the amount of goals we are stating. Is it naming our Registry? Also, What's the point in giving it a name, if it's only one process? After talking of naming the only Registry in the play, we move back to the goal stated above, which makes a lot more sense: make sure we `start_supervised` our registry. Can we focus on this one first, and then talk about naming processes?
+
+While our application will have many buckets, it will only have a single registry. So instead of always passing the registry PID around, we can give the registry a name, and always reference it by its name. We do this by changing the `KV.Registry.start_link/1`.
 
 Also, remember buckets were started dynamically based on user input, and that meant we should not use atom names for managing our buckets. But the registry is in the opposite situation, we want to start a single registry, preferably under a supervisor, when our application boots.
 

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -9,11 +9,11 @@ title: Supervisor and Application
 
 {% include mix-otp-preface.html %}
 
-In this chapter, we are going to learn about supervisors. We are going to create not one, but two supervisors, and use them to supervise our processes. (TODO: the impatient reader (forcing themselves to read the docs this time) sees 'first supervisor' and I can assure you their first urge is to search for the word 'second', and there's none here.)
+We closed the previous chapter about `GenServer`, with our `KV.Registry` managing buckets, and being notified and able to take action whenever a monitored `KV.Bucket` crashed. We did not program a particularly pro-active reaction, just removing the reference, why not restart the crashed process? In our buckets case it's probably not worth the effort, but there's a more compelling reason: Elixir offers a module designed precisely to do this, supervise that every vital element of our application is up and running at any given moment.
 
-We closed the previous chapter about GenServer, with our `KV.Registry` managing buckets, and able to take action whenever a monitored `KV.Bucket` crashed. Not a particularly pro-active reaction, just removing the reference, why not restart the crashed process? In our buckets case it's probably not worth the effort, but there's a more compelling reason: Elixir offers a module designed precisely to do this, supervise that every vital element of our application is up and running at any given moment.
+Let's back up a few steps: when things fail, your first reaction may be: "let's rescue those errors". In Elixir most modules run as separate processes, and this lets us avoid the defensive programming habit of rescuing exceptions. Instead, we say "let it crash" and, for vital elements of our application, "let's start it afresh". 
 
-When things fail, your first reaction may be: "let's rescue those errors". In Elixir we avoid the defensive programming habit of rescuing exceptions. Instead, we say "let it crash". If there is a bug that leads our registry to crash, we have nothing to worry about because we are going to set up a supervisor that will start a fresh copy of the registry.
+In this chapter, we will consider our registry as the "vital" element of our application, and we will define a `KV.Supervisor` module that guarantees that our `KV.Registry` is up and running at any given moment.
 
 At the end of the chapter, we will also talk about Applications. As we will see, Mix has been packaging all of our code into an application, and we will learn how to customize it to control exactly what happens when our system starts.
 


### PR DESCRIPTION
I was reorganizing the text at the end of the chapter, answering (proposing an answer) the the open question "if this is a bad idea, what would be the proper solution?".  and I realized I was not only closing the chapter, but also introducing supervisors, which I think is precisely the introduction I had missed to that chapter.

this is part of what I was writing, mixed with stuff I intend to remove.

This however has a major drawback: when our registry is notified about any unexpected crash, we have to program the whole reaction to the new situation, a more prevalent practice in We typically avoid creating new processes directly, instead, we delegate this responsibility to supervisors. 

As we'll see in the next chapter, supervisors rely on links and that explains why link-based APIs (`spawn_link`, `start_link`, etc) are so prevalent in Elixir and <abbr title="Open Telecom Platform">OTP</abbr>.