### PR TITLE
Use `Plug.Builder.send_resp/3` in a code example in Getting Started

### DIFF
--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -137,7 +137,7 @@ defmodule MyPlug do
   end
 
   def send_ok(conn, _opts) do
-    send(conn, 200, "ok")
+    send_resp(conn, 200, "ok")
   end
 end
 


### PR DESCRIPTION
Thank you for providing a great Getting Started documentation!

I found that a code example in ["As temporary storage" section](https://elixir-lang.org/getting-started/module-attributes.html#as-temporary-storage) of "Module attributes" chapter calls `send(conn, 200, "ok")`. But, `plug` does not have `send/3`; `send_resp/3` should be used for this purpose.

https://hexdocs.pm/plug/1.8.2/search.html?q=send