### PR TITLE
Add Slackware install instructions

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -53,6 +53,10 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Run: `sudo apt-get update`
     * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`
     * Install Elixir: `sudo apt-get install elixir`
+  * Slackware
+    * Using [`sbopkg`](https://sbopkg.org/): `sbopkg -ki "erlang-otp elixir"`  
+      **Or**  
+      Manually download/build/install from SlackBuilds.org: [`erlang-otp`](https://slackbuilds.org/repository/14.2/development/erlang-otp/), [`elixir`](https://slackbuilds.org/repository/14.2/development/elixir)
 
 ### Windows
 


### PR DESCRIPTION
I've only been maintaining these SlackBuilds for 3 years now; might as well advertise 'em :)

Note that at the moment SlackBuilds.org does not have the latest versions of Erlang/Elixir (my bad), but I submitted those today, so they'll hopefully be approved and included in the next SBo update cycle.  The updated versions of the SlackBuild scripts can be found in [the GitHub repo I use for maintaining my SlackBuilds](https://github.com/YellowApple/slackbuilds).