### PR TITLE
add installation instructions for OpenBSD

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -57,6 +57,8 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Using [`sbopkg`](https://sbopkg.org/): `sbopkg -ki "erlang-otp elixir"`  
       **Or**  
       Manually download/build/install from SlackBuilds.org: [`erlang-otp`](https://slackbuilds.org/repository/14.2/development/erlang-otp/), [`elixir`](https://slackbuilds.org/repository/14.2/development/elixir)
+  * OpenBSD
+    * Run: `pkg_add elixir`
 
 ### Windows
 


### PR DESCRIPTION
OpenBSD has been providing elixir packages since 0.5.0 so we might as well list it here.