### PR TITLE
Update example in Enumerables and Streams docs

### DIFF
--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -113,7 +113,12 @@ Another interesting function is `Stream.resource/3` which can be used to wrap ar
 
 ```iex
 iex> stream = File.stream!("path/to/file")
-#Function<18.16982430/2 in Stream.resource/3>
+%File.Stream{
+  line_or_bytes: :line,
+  modes: [:raw, :read_ahead, :binary],
+  path: "path/to/file",
+  raw: true
+}
 iex> Enum.take(stream, 10)
 ```
 


### PR DESCRIPTION
When going through the tutorial I noticed that when executing `stream = File.stream!("path/to/file")` it does not return a function like in the docs `#Function<18.16982430/2 in Stream.resource/3>`.
In the proposed change I have added what was returned by `iex`.

I am not sure if tha was a mistake. Please close the PR if the docs are correct.