### PR TITLE
fix: Remove the README page for jekyll-table-of-contents

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ exclude:
   - CNAME
   - .gitignore
   - README.md
+  - js/toc/README.md
 plugins:
   - jemoji
   - jekyll-sitemap


### PR DESCRIPTION
If you navigate to [https://elixir-lang.org/js/toc/](https://elixir-lang.org/js/toc/), you can see that the
README for the jekyll-table-of-contents javascript library is displayed.
This probably does not belong on the Elixir language site.

Add the toc README to the list of files ignored during site build.