### PR TITLE
Update ets.markdown with accessibility example

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -28,13 +28,13 @@ iex> :ets.lookup(table, "foo")
 [{"foo", #PID<0.41.0>}]
 ```
 
-When creating an ETS table, two arguments are required: the table name and a set of options. From the available options, we passed the table type and its access rules. We have chosen the `:set` type, which means that keys cannot be duplicated. We've also set the table's access to `:protected`, meaning only the process that created the table can write to it, but all processes can read from it. Those are actually the default values, so we will skip them from now on, but just take a look at the possible access controls:
+When creating an ETS table, two arguments are required: the table name and a set of options. From the available options, we passed the table type and its access rules. We have chosen the `:set` type, which means that keys cannot be duplicated. We've also set the table's access to `:protected`, meaning only the process that created the table can write to it, but all processes can read from it. The possible access controls:
 
-`:public` — Read/Write available to all processes.
-`:protected` — Read available to all processes. Only writable by owner process. This is the default.
-`:private` — Read/Write limited to owner process.
+  `:public` — Read/Write available to all processes.
+  `:protected` — Read available to all processes. Only writable by owner process. This is the default.
+  `:private` — Read/Write limited to owner process.
 
-Be aware that if your Read/Write call is against the mentioned access controls, the calling process will raise an `ArgumentError` which is generic and does not indicate the accessibility issue.
+Be aware that if your Read/Write call violates the access control, the operation will raise `ArgumentError`. Finally, since `:set` and `:protected` are the default values, we will skip them from now on.
 
 ETS tables can also be named, allowing us to access them by a given name:
 


### PR DESCRIPTION
While playing with ETS I was getting a generic ArgumentError. I thought I'm passing the arguments to the `:ets.insert` incorrectly, while the real cause was the access setting of the ETS table. I did not this information anywhere on `elixing-lang.org` and I believe it should be here.