### PR TITLE
The name of the file was mentioned that way before

### DIFF
--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -276,7 +276,7 @@ If we save the code above in a file named "concat.ex" and compile it, Elixir wil
 The compiler is telling us that invoking the `join` function with two arguments will always choose the first definition of `join` whereas the second one will only be invoked when three arguments are passed:
 
 ```console
-$ iex concat.exs
+$ iex concat.ex
 ```
 
 ```iex


### PR DESCRIPTION
It's not a script, so it makes sense to use it that way too.