### PR TITLE
Update install.markdown for ubuntu and raspbian

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -49,7 +49,7 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
   * Solus
     * Run: `eopkg install elixir`
   * Ubuntu 14.04/16.04/17.04/18.04/19.04 or Debian 7/8/9
-    * Add Erlang Solutions repo: `wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb`
+    * Add Erlang Solutions repo: `wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && sudo dpkg -i erlang-solutions_2.0_all.deb`
     * Run: `sudo apt-get update`
     * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`
     * Install Elixir: `sudo apt-get install elixir`
@@ -70,11 +70,11 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
 
 ### Raspberry Pi
 
-If necessary, replace "stretch" with the name of your Raspbian release.
+If necessary, replace "buster" with the name of your Raspbian release.
 
   * The Erlang Solutions repository has a prebuilt package for armhf. This saves a significant amount of time in comparison to recompiling natively
   * Get Erlang key
-    * `echo "deb https://packages.erlang-solutions.com/debian stretch contrib" | sudo tee /etc/apt/sources.list.d/erlang-solutions.list`
+    * `echo "deb https://packages.erlang-solutions.com/debian buster contrib" | sudo tee /etc/apt/sources.list.d/erlang-solutions.list`
     * Run: `wget https://packages.erlang-solutions.com/debian/erlang_solutions.asc`
     * Add to keychain: `sudo apt-key add erlang_solutions.asc`
   * Install Elixir


### PR DESCRIPTION
* Update `ubuntu` and `Debian` instructions to use `erlang-solutions_2.0_all.deb` as recommended on Erlang Solutions website
* Update `Raspbian` to reference `buster` since that is now the latest OS