### PR TITLE
x=1 declaration not clear in pattern-match readme

### DIFF
--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -23,6 +23,8 @@ iex> x
 In Elixir, the `=` operator is actually called *the match operator*. Let's see why:
 
 ```iex
+iex> x = 1
+1
 iex> 1 = x
 1
 iex> 2 = x


### PR DESCRIPTION
The code is assuming that x = 1 is declared and then match is checked.
For a new user it's not very clear. I read it for the first time (completely new to Elixir) and thought that 1 = x is the declaration.