### PR TITLE
Add upcoming conferences section and add CodeBeam SF & ElixirConf EU

### DIFF
--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -1,0 +1,33 @@
+<div class="widget" style="margin-bottom: 0">
+  <h3 class="widget-title">Upcoming conferences</h3>
+  <ul>
+    <!--
+         Please add conferences sorted by their dates, so the
+         conference starting the earliest will be at the top!
+
+         Template:
+         ```
+         <li class="widget">
+           <a href="#link" style="text-decoration: none">
+             <img src="url-to-logo" alt="Conference name" border="0" style="max-width:240px; height:auto; />
+             <span style="text-decoration: none"><strong>City, Country/State</strong> | Date, and a tiny bit of info</span>
+           </a>
+         </li>
+         ```
+      -->
+
+    <li class="widget">
+      <a href="http://bit.ly/2OH94JA" style="text-decoration: none">
+        <img src="https://i.imgur.com/97boNMf.png" alt="CodeBeam SF" border="0" style="max-width:240px; height:auto;" />
+        <span style="text-decoration: none"><strong>San Francisco, California</strong> | Conference 5–6 March | Training 2–4 March</span>
+      </a>
+    </li>
+
+    <li class="widget">
+      <a href="https://www2.elixirconf.eu/l/23452/2019-11-25/6t44sx" style="text-decoration: none">
+        <img src="https://s3.amazonaws.com/esl-conf-stg/media/files/000/000/935/original/elixirconfeu2020-elixirlang.jpg?1574953960" alt="ElixirConf EU 2020" border="0" style="max-width:240px; height:auto;" />
+        <span style="text-decoration: none"><strong>Warsaw, Poland</strong> | Conference 29–30 April | Training 28 April</span>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -1,21 +1,6 @@
 <div class="widget" style="margin-bottom: 0">
   <h3 class="widget-title">Upcoming conferences</h3>
   <ul>
-    <!--
-         Please add conferences sorted by their dates, so the
-         conference starting the earliest will be at the top!
-
-         Template:
-         ```
-         <li class="widget">
-           <a href="#link" style="text-decoration: none">
-             <img src="url-to-logo" alt="Conference name" border="0" style="max-width:240px; height:auto; />
-             <span style="text-decoration: none"><strong>City, Country/State</strong> | Date, and a tiny bit of info</span>
-           </a>
-         </li>
-         ```
-      -->
-
     <li class="widget">
       <a href="http://bit.ly/2OH94JA" style="text-decoration: none">
         <img src="https://i.imgur.com/97boNMf.png" alt="CodeBeam SF" border="0" style="max-width:240px; height:auto;" />

--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -8,6 +8,8 @@
 
 {% include mini-docu.html %}
 
+{% include conferences.html %}
+
 <div class="widget">
   <h3 class="widget-title">Join the Community</h3>
   <ul>


### PR DESCRIPTION
Added in important links; over the community section.

I have made it such that it is easy to add and remove conferences from a list; I thought it would be best to order the conferences such that the most recent is at the top, and the template includes room for a logo, the location (city, country/state), and a little space to write some information about dates. Hopefully this will make it easy to add and remove conferences from the list.