### PR TITLE
Remove obsolete border attribute from <img>

### DIFF
--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -2,12 +2,12 @@
   <h3 class="widget-title">Upcoming conferences</h3>
 
   <a href="http://bit.ly/2OH94JA">
-    <img src="https://i.imgur.com/97boNMf.png" alt="CodeBeam SF" border="0" style="max-width:240px; height:auto;" /><br />
+    <img src="https://i.imgur.com/97boNMf.png" alt="CodeBeam SF" style="max-width:240px; height:auto;" /><br />
     <span><strong>San Francisco, California</strong> | Conference 5–6 March | Training 2–4 March</span>
   </a>
 
   <a href="https://www2.elixirconf.eu/l/23452/2019-11-25/6t44sx">
-    <img src="https://s3.amazonaws.com/esl-conf-stg/media/files/000/000/935/original/elixirconfeu2020-elixirlang.jpg?1574953960" alt="ElixirConf EU 2020" border="0" style="max-width:240px; height:auto;" /><br />
+    <img src="https://s3.amazonaws.com/esl-conf-stg/media/files/000/000/935/original/elixirconfeu2020-elixirlang.jpg?1574953960" alt="ElixirConf EU 2020" style="max-width:240px; height:auto;" /><br />
     <span><strong>Warsaw, Poland</strong> | Conference 29–30 April | Training 28 April</span>
   </a>
 </div>


### PR DESCRIPTION
It's obsolete and unnecessary as all images are set to `border: 0`
in style.css.