### PR TITLE
Fix typo in 1.10 release post

### DIFF
--- a/_posts/2020-01-27-elixir-v1-10-0-released.markdown
+++ b/_posts/2020-01-27-elixir-v1-10-0-released.markdown
@@ -116,7 +116,7 @@ end
 
 While this is the preferred approach, there are still two scenarios we need to address:
 
-  1. Not everyone may be aware of this pitfall, so they will mistakenly read the application environemnt at compile-time, until they are bitten by this behaviour
+  1. Not everyone may be aware of this pitfall, so they will mistakenly read the application environment at compile-time, until they are bitten by this behaviour
 
   2. In rare occasions, you trully need to read the application environment at compile-time, and you want to be warned when you try to configure at runtime something that is valid only at compilation time
 


### PR DESCRIPTION
Fixes a tiny typo: environemnt -> environment