### PR TITLE
Update the URI to the ElixirConf EU logo

### DIFF
--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -7,7 +7,7 @@
   </a>
 
   <a href="https://www2.elixirconf.eu/l/23452/2019-11-25/6t44sx">
-    <img src="https://s3.amazonaws.com/esl-conf-stg/media/files/000/000/935/original/elixirconfeu2020-elixirlang.jpg?1574953960" alt="ElixirConf EU 2020" style="max-width:240px; height:auto;" /><br />
+    <img src="https://esl-conf-staging.s3.eu-central-1.amazonaws.com/esl-conf-stg/media/files/000/000/935/original/elixirconfeu2020-elixirlang.jpg" alt="ElixirConf EU 2020" style="max-width:240px; height:auto;" /><br />
     <span><strong>Warsaw, Poland</strong> | Conference 29–30 April | Training 28 April</span>
   </a>
 </div>


### PR DESCRIPTION
The image file for the ElixirConf EU logo in the upcoming conferences section had gone awol. I've updated the uri to one that will hopefully stay up *forever*!