### PR TITLE
Fix inconsistency regarding default port env var

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -297,7 +297,7 @@ We could fix this by defining our own module that calls `use Task, restart: :per
 
 ```elixir
   def start(_type, _args) do
-    port = String.to_integer(System.get_env("PORT") || raise "missing $PORT environment variable")
+    port = String.to_integer(System.get_env("PORT") || "4040")
 
     children = [
       {Task.Supervisor, name: KVServer.TaskSupervisor},


### PR DESCRIPTION
Very similar to #1172 which missed last rewrite part
that still raised error if env variable was not present.

So if someone were to just copy last part then in next section tests would fail when doing simple `mix test`.