### PR TITLE
Correct the Arity of 'call' in the ETS Guide

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -166,7 +166,7 @@ How can this line fail if we just created the bucket in the previous line?
 The reason those failures are happening is because, for didactic purposes, we have made two mistakes:
 
   1. We are prematurely optimizing (by adding this cache layer)
-  2. We are using `cast/2` (while we should be using `call/3`)
+  2. We are using `cast/2` (while we should be using `call/2`)
 
 ## Race conditions?
 


### PR DESCRIPTION
In the ETS guide, the function is written as `call/3`, but when we fix the issue in code, we use `call/2`. This is also supported by other written references to `call/2`.