### PR TITLE
Update basic-types.markdown

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -198,7 +198,7 @@ world
 
 Notice that the `IO.puts/1` function returns the atom `:ok` after printing.
 
-Strings in Elixir are represented internally by binaries which are sequences of bytes:
+Strings in Elixir are represented internally by contiguous sequences of bytes known as binaries:
 
 ```iex
 iex> is_binary("hellö")


### PR DESCRIPTION
Slight adjustment to the explanation of "binaries" to make it easier to transition into the more detailed explanations in the "Binaries, Strings, and charlists" section.