### PR TITLE
Clarify how agent passes state to anonymous func

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -134,7 +134,7 @@ The first step in our implementation is to call `use Agent`.
 
 Then we define a `start_link/1` function, which will effectively start the agent. It is a convention to define a `start_link/1` function that always accepts a list of options. We don't plan on using any options right now, but we might later on. We then proceed to call `Agent.start_link/1`, which receives an anonymous function that returns the Agent's initial state.
 
-We are keeping a map inside the agent to store our keys and values. Getting and putting values on the map is done with the Agent API  and the capture operator `&`, introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing). The agent passes its state to the anonymous function via the `&1` argument when Agent.get and Agent.update are called, as described in the [documentation](https://hexdocs.pm/elixir/Agent.html#get/3).
+We are keeping a map inside the agent to store our keys and values. Getting and putting values on the map is done with the Agent API  and the capture operator `&`, introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing). The agent passes its state to the anonymous function via the `&1` argument when `Agent.get/2` and `Agent.update/3` are called.
 
 Now that the `KV.Bucket` module has been defined, our test should pass! You can try it yourself by running: `mix test`.
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -134,7 +134,7 @@ The first step in our implementation is to call `use Agent`.
 
 Then we define a `start_link/1` function, which will effectively start the agent. It is a convention to define a `start_link/1` function that always accepts a list of options. We don't plan on using any options right now, but we might later on. We then proceed to call `Agent.start_link/1`, which receives an anonymous function that returns the Agent's initial state.
 
-We are keeping a map inside the agent to store our keys and values. Getting and putting values on the map is done with the Agent API  and the capture operator `&`, introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing).
+We are keeping a map inside the agent to store our keys and values. Getting and putting values on the map is done with the Agent API  and the capture operator `&`, introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing). The agent passes its state to the anonymous function via the `&1` argument when Agent.get and Agent.update are called, as described in the [documentation](https://hexdocs.pm/elixir/Agent.html#get/3).
 
 Now that the `KV.Bucket` module has been defined, our test should pass! You can try it yourself by running: `mix test`.
 


### PR DESCRIPTION
When encountering Agents for the first time, it is not clear to the newcomer that they pass their state to anonymous functions in this way. This problem stumped me for a whole day yesterday, when I couldn't figure out what was going on with that `&1`. 

It finally made sense when someone on the ElixirForum gave me this crucial piece of information, that the Agent calls the anonymous function and passes its state to it via the placeholder argument `&1`. https://elixirforum.com/t/partially-applied-functions-and-placeholder-arguments/30535/10

Hopefully this small edit can save someone else the confusion.