### PR TITLE
Remove broken link to protocol consolidation

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -155,7 +155,7 @@ Will output:
     Compiling 1 file (.ex)
     Generated kv app
 
-The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was generated and [all protocols were consolidated](https://hexdocs.pm/elixir/Protocol.html#module-consolidation). All compilation artifacts are placed inside the `_build` directory using the options defined in the `mix.exs` file.
+The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was generated. All compilation artifacts are placed inside the `_build` directory using the options defined in the `mix.exs` file.
 
 Once the project is compiled, you can start an `iex` session inside the project by running:
 

--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -155,7 +155,7 @@ Will output:
     Compiling 1 file (.ex)
     Generated kv app
 
-The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was generated and [all protocols were consolidated as described in the Getting Started guide](/getting-started/protocols.html#protocol-consolidation). All compilation artifacts are placed inside the `_build` directory using the options defined in the `mix.exs` file.
+The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was generated and [all protocols were consolidated](https://hexdocs.pm/elixir/Protocol.html#module-consolidation). All compilation artifacts are placed inside the `_build` directory using the options defined in the `mix.exs` file.
 
 Once the project is compiled, you can start an `iex` session inside the project by running:
 


### PR DESCRIPTION
The section about protocol consolidation in the Getting Started guide seems to have been removed. Consider pointing to Protocol documentation that explains consolidation instead.