### PR TITLE
Simplify example in enumerables-and-streams.markdown

### DIFF
--- a/getting-started/enumerables-and-streams.markdown
+++ b/getting-started/enumerables-and-streams.markdown
@@ -47,7 +47,7 @@ iex> Enum.filter(1..3, odd?)
 This means that when performing multiple operations with `Enum`, each operation is going to generate an intermediate list until we reach the result:
 
 ```iex
-iex> total_sum = 1..100_000 |> Enum.map(&(&1 * 3)) |> Enum.filter(odd?) |> Enum.sum
+iex> 1..100_000 |> Enum.map(&(&1 * 3)) |> Enum.filter(odd?) |> Enum.sum
 7500000000
 ```
 


### PR DESCRIPTION
The `total_sum` variable is unnecessary for this example, and is not discussed in the text. Also, the example is later compared to an equivalent code snippet without the pipe operator. In the comparison code there's no `total_sum` so they are not exact equivalents, hence confusing. Lastly, the example already introduces a few new concepts, so it might be better to keep it simple. For these reasons, I think it's better to drop the `total_sum` variable.