### PR TITLE
add {max-width: 100%} css rule to all img tags to improve mobile UX

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -192,6 +192,7 @@ img {
   border: 0;
   -ms-interpolation-mode: bicubic;
   vertical-align: middle;
+  max-width: 100%;
 }
 svg:not(:root) { overflow: hidden; }
 form { margin: 0; }


### PR DESCRIPTION
I was following the guides and noticed the Debugging page has horizontal overflow on screens < 640px due to the images having a hardcoded width, so adding this CSS rule makes the images contained to the screen width, improving mobile UX.

You can see the problem is especially relevant on small mobile devices like the iPhone SE.

Before:
![before](https://user-images.githubusercontent.com/22163194/80163351-e9638b80-85a3-11ea-97f5-ec7f9174e35a.gif)

After:
![after](https://user-images.githubusercontent.com/22163194/80163410-131cb280-85a4-11ea-8269-4f781e35dfa6.gif)

