### PR TITLE
Fix inconsistency in task-and-gen-tcp.markdown

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -216,7 +216,7 @@ Let's change `start/2` once again, to add a supervisor to our tree:
 
 ```elixir
   def start(_type, _args) do
-    port = String.to_integer(System.get_env("PORT") || raise "missing $PORT environment variable")
+    port = String.to_integer(System.get_env("PORT") || "4040")
 
     children = [
       {Task.Supervisor, name: KVServer.TaskSupervisor},


### PR DESCRIPTION
616d78c changed the example to use a default port if none was provided.
be1471b updated another code block to match that change.

This change fixes the remaining copy of that code.

Thus the trilogy of #1172 and #1367 is complete. :-)