### PR TITLE
fixup example explanation

### DIFF
--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -125,7 +125,7 @@ defmodule Foo do
 
   @param :foo
   @param :bar     
-  # here @param == [:foo, :bar]
+  # here @param == [:bar, :foo]
 end
 ```
 


### PR DESCRIPTION
from the Docs: 
```
When registering an attribute, two options can be given:

    :accumulate - several calls to the same attribute will accumulate instead of overriding the previous one. New attributes are always added to the top of the accumulated list.
```