### PR TITLE
Change Google to DuckDuckGo

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -5,9 +5,9 @@
 </div>
 
 <div class="widget search">
-  <form method="get" id="search-form" class="search-form" action="https://www.google.com/search" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
+  <form method="post" id="search-form" class="search-form" action="https://searx.be/" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
 		<input type="hidden" id="searchq" name="q" value="">
-    <input class="search-text" type="text" placeholder="Search..." id="searchfield" aria-label="Search box">
+    		<input class="search-text" type="text" placeholder="Search..." id="searchfield" aria-label="Search box">
 		<input class="search-submit button" name="submit" type="submit" value="Search" aria-label="Search button">
 	</form>
 </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -5,12 +5,8 @@
 </div>
 
 <div class="widget search">
-  <form method="post" role="search" id="search-form" class="search-form" action="https://searx.be/search" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
+  <form method="post" role="search" id="search-form" class="search-form" action="https://duckduckgo.com/?kg=p" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
 		<input type="hidden" id="searchq" name="q" value="" aria-hidden="true">
-	  
-	  	<!-- searX configuration parameters; let's stay away from Google. -->
-	 	<input type="hidden" name="autocomplete" value="duckduckgo" aria-hidden="true">
-	  	<input type="hidden" name="engines" value="duckduckgo" aria-hidden="true">
 	 
     		<input class="search-text" type="search" placeholder="Search..." id="searchfield" aria-label="Search box">
 		<input class="search-submit button" name="submit" type="submit" value="Search" aria-label="Search button">

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -5,9 +5,14 @@
 </div>
 
 <div class="widget search">
-  <form method="post" id="search-form" class="search-form" action="https://searx.be/search" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
-		<input type="hidden" id="searchq" name="q" value="">
-    		<input class="search-text" type="text" placeholder="Search..." id="searchfield" aria-label="Search box">
+  <form method="post" role="search" id="search-form" class="search-form" action="https://searx.be/search" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
+		<input type="hidden" id="searchq" name="q" value="" aria-hidden="true">
+	  
+	  	<!-- searX configuration parameters; let's stay away from Google. -->
+	 	<input type="hidden" name="autocomplete" value="duckduckgo" aria-hidden="true">
+	  	<input type="hidden" name="engines" value="duckduckgo" aria-hidden="true">
+	 
+    		<input class="search-text" type="search" placeholder="Search..." id="searchfield" aria-label="Search box">
 		<input class="search-submit button" name="submit" type="submit" value="Search" aria-label="Search button">
 	</form>
 </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -5,7 +5,7 @@
 </div>
 
 <div class="widget search">
-  <form method="post" id="search-form" class="search-form" action="https://searx.be/" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
+  <form method="post" id="search-form" class="search-form" action="https://searx.be/search" onsubmit="document.getElementById('searchq').value = document.getElementById('searchfield').value + ' site:elixir-lang.org | site:hexdocs.pm/elixir | site:hexdocs.pm/mix | site:hexdocs.pm/eex | site:hexdocs.pm/logger | site:hexdocs.pm/iex | site:hexdocs.pm/ex_unit'; return true;">
 		<input type="hidden" id="searchq" name="q" value="">
     		<input class="search-text" type="text" placeholder="Search..." id="searchfield" aria-label="Search box">
 		<input class="search-submit button" name="submit" type="submit" value="Search" aria-label="Search button">


### PR DESCRIPTION
With increasing privacy concerns regarding Google, we should seek to avoid them. This merge requests changes the documentation search field to use [searX](https://searx.me), a privacy-respecting metasearch engine.

The results are very close to that of Google, as I have configured this to use DuckDuckGo. This avoids sending data to Google.

If there are any issues, please contact me.

Many thanks.