### PR TITLE
Improve link to short Erlang tutorial

### DIFF
--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -41,6 +41,6 @@ Elixir runs on the Erlang Virtual Machine and, sooner or later, an Elixir develo
 
 * This [Erlang Syntax: A Crash Course](/crash-course.html) provides a concise intro to Erlang's syntax. Each code snippet is accompanied by equivalent code in Elixir. This is an opportunity for you to not only get some exposure to Erlang's syntax but also review some of the things you have learned in this guide.
 
-* Erlang's official website has a short [tutorial](http://www.erlang.org/course/concurrent_programming.html) with pictures that briefly describe Erlang's primitives for concurrent programming.
+* Erlang's official website has a short [tutorial](https://www.erlang.org/course). There is chapter with pictures briefly describing Erlang's primitives for [Concurrent Programming](https://www.erlang.org/course/concurrent_programming.html).
 
 * [Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/) is an excellent introduction to Erlang, its design principles, standard library, best practices, and much more. Once you have read through the crash course mentioned above, you'll be able to safely skip the first couple of chapters in the book that mostly deal with the syntax. When you reach [The Hitchhiker's Guide to Concurrency](http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency) chapter, that's where the real fun starts.

--- a/getting-started/where-to-go-next.markdown
+++ b/getting-started/where-to-go-next.markdown
@@ -41,6 +41,6 @@ Elixir runs on the Erlang Virtual Machine and, sooner or later, an Elixir develo
 
 * This [Erlang Syntax: A Crash Course](/crash-course.html) provides a concise intro to Erlang's syntax. Each code snippet is accompanied by equivalent code in Elixir. This is an opportunity for you to not only get some exposure to Erlang's syntax but also review some of the things you have learned in this guide.
 
-* Erlang's official website has a short [tutorial](https://www.erlang.org/course). There is chapter with pictures briefly describing Erlang's primitives for [Concurrent Programming](https://www.erlang.org/course/concurrent_programming.html).
+* Erlang's official website has a short [tutorial](https://www.erlang.org/course). There is chapter with pictures briefly describing Erlang's primitives for [concurrent programming](https://www.erlang.org/course/concurrent_programming.html).
 
 * [Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/) is an excellent introduction to Erlang, its design principles, standard library, best practices, and much more. Once you have read through the crash course mentioned above, you'll be able to safely skip the first couple of chapters in the book that mostly deal with the syntax. When you reach [The Hitchhiker's Guide to Concurrency](http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency) chapter, that's where the real fun starts.


### PR DESCRIPTION
Proposition to mention/link to main page of short Erlang tutorial.
Cause there is no direct link from Concurrent Programming chapter page.