### PR TITLE
paths for kv application and quotes around atoms

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -73,7 +73,7 @@ iex>
 
 As you can see, we can modify the agent state in any way we want. Therefore, we most likely don't want to access the Agent API throughout many different places in our code. Instead, we want to encapsulate all Agent-related functionality in a single module, which we will call `KV.Bucket`. Before we implement it, let's write some tests which will outline the API exposed by our module.
 
-Create a file at `test/kv/bucket_test.exs` (remember the `.exs` extension) with the following:
+Create a file at `kv/test/bucket_test.exs` (remember the `.exs` extension) with the following:
 
 ```elixir
 defmodule KV.BucketTest do
@@ -101,7 +101,7 @@ Async or not, our new test should obviously fail, as none of the functionality i
 ** (UndefinedFunctionError) function KV.Bucket.start_link/1 is undefined (module KV.Bucket is not available)
 ```
 
-In order to fix the failing test, let's create a file at `lib/kv/bucket.ex` with the contents below. Feel free to give a try at implementing the `KV.Bucket` module yourself using agents before peeking at the implementation below.
+In order to fix the failing test, let's create a file at `kv/lib/bucket.ex` with the contents below. Feel free to give a try at implementing the `KV.Bucket` module yourself using agents before peeking at the implementation below.
 
 ```elixir
 defmodule KV.Bucket do

--- a/getting-started/mix-otp/config-and-releases.markdown
+++ b/getting-started/mix-otp/config-and-releases.markdown
@@ -90,8 +90,8 @@ defmodule KV.RouterTest do
     current = Application.get_env(:kv, :routing_table)
 
     Application.put_env(:kv, :routing_table, [
-      {?a..?m, :"foo@computer-name"},
-      {?n..?z, :"bar@computer-name"}
+      {?a..?m, :foo@computer-name},
+      {?n..?z, :bar@computer-name}
     ])
 
     on_exit fn -> Application.put_env(:kv, :routing_table, current) end
@@ -148,8 +148,8 @@ Before we assemble the release, let's also define our routing table for producti
 
     if Mix.env() == :prod do
       config :kv, :routing_table, [
-        {?a..?m, :"foo@computer-name"},
-        {?n..?z, :"bar@computer-name"}
+        {?a..?m, :foo@computer-name},
+        {?n..?z, :bar@computer-name}
       ]
     end
 
@@ -227,7 +227,7 @@ And let's connect to it and issue a request in another terminal:
 Since the "shopping" bucket would be stored on `bar`, the request fails as `bar` is not available. If you go back to the terminal running `foo`, you will see:
 
     17:16:19.555 [error] Task #PID<0.622.0> started from #PID<0.620.0> terminating
-    ** (stop) exited in: GenServer.call({KV.RouterTasks, :"bar@computer-name"}, {:start_task, [{:"foo@josemac-2", #PID<0.622.0>, #PID<0.622.0>}, [#PID<0.622.0>, #PID<0.620.0>, #PID<0.618.0>], :monitor, {KV.Router, :route, ["shopping", KV.Registry, :lookup, [KV.Registry, "shopping"]]}], :temporary, nil}, :infinity)
+    ** (stop) exited in: GenServer.call({KV.RouterTasks, :bar@computer-name}, {:start_task, [{:foo@computer-name, #PID<0.622.0>, #PID<0.622.0>}, [#PID<0.622.0>, #PID<0.620.0>, #PID<0.618.0>], :monitor, {KV.Router, :route, ["shopping", KV.Registry, :lookup, [KV.Registry, "shopping"]]}], :temporary, nil}, :infinity)
         ** (EXIT) no connection to bar@computer-name
         (elixir) lib/gen_server.ex:1010: GenServer.call/3
         (elixir) lib/task/supervisor.ex:454: Task.Supervisor.async/6

--- a/getting-started/mix-otp/distributed-tasks.markdown
+++ b/getting-started/mix-otp/distributed-tasks.markdown
@@ -119,7 +119,7 @@ res + Task.await(task)
 
 ## Distributed tasks
 
-Distributed tasks are exactly the same as supervised tasks. The only difference is that we pass the node name when spawning the task on the supervisor. Open up `lib/kv/supervisor.ex` from the `:kv` application. Let's add a task supervisor as the last child of the tree:
+Distributed tasks are exactly the same as supervised tasks. The only difference is that we pass the node name when spawning the task on the supervisor. Open up `kv/lib/supervisor.ex` from the `:kv` application. Let's add a task supervisor as the last child of the tree:
 
 ```elixir
 {Task.Supervisor, name: KV.RouterTasks},
@@ -158,7 +158,7 @@ With this knowledge in hand, let's finally write the routing code.
 
 ## Routing layer
 
-Create a file at `lib/kv/router.ex` with the following contents:
+Create a file at `kv/lib/router.ex` with the following contents:
 
 ```elixir
 defmodule KV.Router do
@@ -200,7 +200,7 @@ defmodule KV.Router do
 end
 ```
 
-Let's write a test to verify our router works. Create a file named `test/kv/router_test.exs` containing:
+Let's write a test to verify our router works. Create a file named `kv/test/router_test.exs` containing:
 
 ```elixir
 defmodule KV.RouterTest do
@@ -245,7 +245,7 @@ Although our tests pass, our testing structure is getting more complex. In parti
 
 Luckily, ExUnit ships with a facility to tag tests, allowing us to run specific callbacks or even filter tests altogether based on those tags. We have already used the `:capture_log` tag in the previous chapter, which has its semantics specified by ExUnit itself.
 
-This time let's add a `:distributed` tag to `test/kv/router_test.exs`:
+This time let's add a `:distributed` tag to `kv/test/router_test.exs`:
 
 ```elixir
 @tag :distributed

--- a/getting-started/mix-otp/distributed-tasks.markdown
+++ b/getting-started/mix-otp/distributed-tasks.markdown
@@ -68,7 +68,7 @@ iex> Hello.world
 However, we can spawn a new process on `foo@computer-name` from `bar@computer-name`! Let's give it a try (where `@computer-name` is the one you see locally):
 
 ```elixir
-iex> Node.spawn_link :"foo@computer-name", fn -> Hello.world end
+iex> Node.spawn_link :foo@computer-name, fn -> Hello.world end
 #PID<9014.59.0>
 hello world
 ```
@@ -78,7 +78,7 @@ Elixir spawned a process on another node and returned its pid. The code then exe
 We can send and receive messages from the pid returned by `Node.spawn_link/2` as usual. Let's try a quick ping-pong example:
 
 ```elixir
-iex> pid = Node.spawn_link :"foo@computer-name", fn ->
+iex> pid = Node.spawn_link :foo@computer-name, fn ->
 ...>   receive do
 ...>     {:ping, client} -> send client, :pong
 ...>   end
@@ -135,21 +135,21 @@ $ iex --sname bar -S mix
 From inside `bar@computer-name`, we can now spawn a task directly on the other node via the supervisor:
 
 ```elixir
-iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, fn ->
+iex> task = Task.Supervisor.async {KV.RouterTasks, :foo@computer-name}, fn ->
 ...>   {:ok, node()}
 ...> end
 %Task{owner: #PID<0.122.0>, pid: #PID<12467.88.0>, ref: #Reference<0.0.0.400>}
 iex> Task.await(task)
-{:ok, :"foo@computer-name"}
+{:ok, :foo@computer-name}
 ```
 
 Our first distributed task retrieves the name of the node the task is running on. Notice we have given an anonymous function to `Task.Supervisor.async/2` but, in distributed cases, it is preferable to give the module, function, and arguments explicitly:
 
 ```elixir
-iex> task = Task.Supervisor.async {KV.RouterTasks, :"foo@computer-name"}, Kernel, :node, []
+iex> task = Task.Supervisor.async {KV.RouterTasks, :foo@computer-name}, Kernel, :node, []
 %Task{owner: #PID<0.122.0>, pid: #PID<12467.89.0>, ref: #Reference<0.0.0.404>}
 iex> Task.await(task)
-:"foo@computer-name"
+:foo@computer-name
 ```
 
 The difference is that anonymous functions require the target node to have exactly the same code version as the caller. Using module, function, and arguments is more robust because you only need to find a function with matching arity in the given module.

--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -61,7 +61,7 @@ Doctests are specified by an indentation of four spaces followed by the `iex>` p
 
 Also, note that we started the documentation string using `@doc ~S"""`. The `~S` prevents the `\r\n` characters from being converted to a carriage return and line feed until they are evaluated in the test.
 
-To run our doctests, we'll create a file at `test/kv_server/command_test.exs` and call `doctest KVServer.Command` in the test case:
+To run our doctests, we'll create a file at `kv_server/test/command_test.exs` and call `doctest KVServer.Command` in the test case:
 
 ```elixir
 defmodule KVServer.CommandTest do
@@ -73,11 +73,15 @@ end
 Run the test suite and the doctest should fail:
 
 ```
-  1) test doc at KVServer.Command.parse/1 (1) (KVServer.CommandTest)
-     test/kv_server/command_test.exs:3
+  1) doctest KVServer.Command.parse/1 (1) (KVServer.CommandTest)
+     test/command_test.exs:3
      Doctest failed
-     code: KVServer.Command.parse "CREATE shopping\r\n" === {:ok, {:create, "shopping"}}
-     lhs:  :not_implemented
+     doctest:
+       iex> KVServer.Command.parse("CREATE shopping\r\n")
+       {:ok, {:create, "shopping"}}
+     code:  KVServer.Command.parse("CREATE shopping\r\n") === {:ok, {:create, "shopping"}}
+     left:  :not_implemented
+     right: {:ok, {:create, "shopping"}}
      stacktrace:
        lib/kv_server/command.ex:7: KVServer.Command (module)
 ```

--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -39,13 +39,13 @@ Since the bucket terminated, the registry also stopped, and our test fails when 
 
 ```
   1) test removes bucket on crash (KV.RegistryTest)
-     test/kv/registry_test.exs:26
-     ** (exit) exited in: GenServer.call(#PID<0.148.0>, {:lookup, "shopping"}, 5000)
+     test/registry_test.exs:26
+     ** (exit) exited in: GenServer.call(#PID<0.179.0>, {:lookup, "shopping"}, 5000)
          ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
      code: assert KV.Registry.lookup(registry, "shopping") == :error
      stacktrace:
-       (elixir) lib/gen_server.ex:770: GenServer.call/3
-       test/kv/registry_test.exs:33: (test)
+       (elixir 1.10.2) lib/gen_server.ex:1023: GenServer.call/3
+       test/registry_test.exs:32: (test)
 ```
 
 We are going to solve this issue by defining a new supervisor that will spawn and supervise all buckets. Opposite to the previous Supervisor we defined, the children are not known upfront, but they are rather started dynamically. For those situations, we use a `DynamicSupervisor`. The `DynamicSupervisor` does not expect a list of children during initialization; instead each child is started manually via `DynamicSupervisor.start_child/2`.
@@ -54,7 +54,7 @@ We are going to solve this issue by defining a new supervisor that will spawn an
 
 Since a `DynamicSupervisor` does not define any children during initialization, the `DynamicSupervisor` also allows us to skip the work of defining a whole separate module with the usual `start_link` function and the `init` callback. Instead, we can define a `DynamicSupervisor` directly in the supervision tree, by giving it a name and a strategy.
 
-Open up `lib/kv/supervisor.ex` and add the dynamic supervisor as a child as follows:
+Open up `kv/lib/supervisor.ex` and add the dynamic supervisor as a child as follows:
 
 
 ```elixir
@@ -112,7 +112,7 @@ defmodule KV.Bucket do
   use Agent, restart: :temporary
 ```
 
-Let's also add a test to `test/kv/bucket_test.exs` that guarantees the bucket is temporary:
+Let's also add a test to `kv/test/bucket_test.exs` that guarantees the bucket is temporary:
 
 ```elixir
   test "are temporary workers" do

--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -92,7 +92,7 @@ There is quite a bit more ceremony in the GenServer code but, as we will see, it
 
 For now, we will write only the server callbacks for our bucket registering logic, without providing a proper API, which we will do later.
 
-Create a new file at `lib/kv/registry.ex` with the following contents:
+Create a new file at `kv/lib/registry.ex` with the following contents:
 
 ```elixir
 defmodule KV.Registry do
@@ -147,7 +147,7 @@ This is all good and well, but we still want to offer our users an API that allo
 
 A GenServer is implemented in two parts: the client API and the server callbacks. You can either combine both parts into a single module or you can separate them into a client module and a server module. The client is any process that invokes the client function. The server is always the process identifier or process name that we will explicitly pass as argument to the client API. Here we'll use a single module for both the server callbacks and the client API.
 
-Edit the file at `lib/kv/registry.ex`, filling in the blanks for the client API:
+Edit the file at `kv/lib/registry.ex`, filling in the blanks for the client API:
 
 ```elixir
   ## Client API
@@ -200,7 +200,7 @@ For now, let's write some tests to guarantee our GenServer works as expected.
 
 ## Testing a GenServer
 
-Testing a GenServer is not much different from testing an agent. We will spawn the server on a setup callback and use it throughout our tests. Create a file at `test/kv/registry_test.exs` with the following:
+Testing a GenServer is not much different from testing an agent. We will spawn the server on a setup callback and use it throughout our tests. Create a file at `kv/test/registry_test.exs` with the following:
 
 ```elixir
 defmodule KV.RegistryTest do

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -31,7 +31,7 @@ At the end of the chapter, we will also talk about Applications. As we will see,
 
 A supervisor is a process which supervises other processes, which we refer to as child processes. The act of supervising a process includes three distinct responsibilities. The first one is to start child processes. Once a child process is running, the supervisor may restart a child process, either because it terminated abnormally or because a certain condition was reached. For example, a supervisor may restart all children if any child dies. Finally, a supervisor is also responsible for shutting down the child processes when the system is shutting down. Please see the [Supervisor](https://hexdocs.pm/elixir/Supervisor.html) module for a more in-depth discussion.
 
-Creating a supervisor is not much different from creating a GenServer. We are going to define a module named `KV.Supervisor`, which will use the Supervisor behaviour, inside the `lib/kv/supervisor.ex` file:
+Creating a supervisor is not much different from creating a GenServer. We are going to define a module named `KV.Supervisor`, which will use the Supervisor behaviour, inside the `kv/lib/supervisor.ex` file:
 
 ```elixir
 defmodule KV.Supervisor do

--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -114,9 +114,9 @@ My particular telnet client can be exited by typing `ctrl + ]`, typing `quit`, a
 Once you exit the telnet client, you will likely see an error in the IEx session:
 
     ** (MatchError) no match of right hand side value: {:error, :closed}
-        (kv_server) lib/kv_server.ex:45: KVServer.read_line/1
-        (kv_server) lib/kv_server.ex:37: KVServer.serve/1
-        (kv_server) lib/kv_server.ex:30: KVServer.loop_acceptor/1
+        (kv_server) lib/kv_server.ex:33: KVServer.read_line/1
+        (kv_server) lib/kv_server.ex:26: KVServer.serve/1
+        (kv_server) lib/kv_server.ex:20: KVServer.loop_acceptor/1
 
 That's because we were expecting data from `:gen_tcp.recv/2` but the client closed the connection. We need to handle such cases better in future revisions of our server.
 


### PR DESCRIPTION
Hi,

I just ran through getting-started and noticed some inconsistencies with current elixir (1.10.2 on erlang22).
These are:
* paths for the source files are specified the other way around than what the current mix generates, e.g. lib/kv/file.ex instead of
  kv/lib/file.ex.
* and there are several examples of quotes around atoms, all of the form :"node@host". When I use this form, iex gives me warnings,
  that this is not necessary if the atoms only contain unicode, numbers, etc.

And, lastly, I want to say that this is a great introduction. It was fun to follow along, especially, if one has a bit of erlang background. 

Dieter