### PR TITLE
Update link to full guard documentation

### DIFF
--- a/getting-started/case-cond-and-if.markdown
+++ b/getting-started/case-cond-and-if.markdown
@@ -72,7 +72,7 @@ iex> case :ok do
 ** (CaseClauseError) no case clause matching: :ok
 ```
 
-Consult [the full documentation for guards](https://hexdocs.pm/elixir/guards.html) for more information about guards, how they are used, and what expressions are allowed in them.
+Consult [the full documentation for guards](https://hexdocs.pm/elixir/patterns-and-guards.html#guards) for more information about guards, how they are used, and what expressions are allowed in them.
 
 Note anonymous functions can also have multiple clauses and guards:
 


### PR DESCRIPTION
The previous link pointed at the guard documentation for Elixir v1.9.4. This was moved from a separate "Guards" page in v1.9.4 to the "Patterns and Guards" page in v1.10.4.