### PR TITLE
add missing syntax highlighting to getting-started/structs.markdown

### DIFF
--- a/getting-started/structs.markdown
+++ b/getting-started/structs.markdown
@@ -139,7 +139,7 @@ iex> %User{}
 
 Doing it in reverse order will raise a syntax error:
 
-```
+```elixir
 iex> defmodule User do                          
 ...>   defstruct [name: "John", age: 27, :email]
 ...> end


### PR DESCRIPTION
See the current: https://elixir-lang.org/getting-started/structs.html#default-values-and-required-keys