### PR TITLE
Improve sidebar in the getting-started section (a little bit)

### DIFF
--- a/_layouts/getting-started.html
+++ b/_layouts/getting-started.html
@@ -9,7 +9,12 @@
      <h3 class="widget-title">{{guide.title}}</h3>
       <ol>
         {% for node in guide.pages %}
-          <li><a class="spec" href="{{guide.dir}}{{node.slug}}.html" title="{{node.title | escape}}">{{node.title}}</a></li>
+          {% assign page_url = guide.dir | append: node.slug | append: '.html' %}
+          {% if page.url == page_url %}
+            <li><span title="{{node.title | escape}}">{{node.title}}</span></li>
+          {% else %}
+            <li><a class="spec" href="{{page_url}}" title="{{node.title | escape}}">{{node.title}}</a></li>
+          {% endif %}
         {% endfor %}
       </ol>
     </div>


### PR DESCRIPTION
I'm learning elixir now, but I feel lost when looking at the guides because the links looks all the same. So here I added a little control flow to disable the link of current page.