### PR TITLE
Add example of @callback with @doc tag

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -126,7 +126,14 @@ We can create a `Parser` behaviour:
 
 ```elixir
 defmodule Parser do
+  @doc """
+  Parses a JSON string.
+  """
   @callback parse(String.t) :: {:ok, term} | {:error, String.t}
+  
+  @doc """
+  Lists all supported file extensions.
+  """
   @callback extensions() :: [String.t]
 end
 ```


### PR DESCRIPTION
This PR adds a `@doc` tag along with the `@callback` tag. I think this might help to show where the doc usually is when using behaviours.