### PR TITLE
Small phrasing change for Heredocs

### DIFF
--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -122,7 +122,7 @@ The following escape codes can be used in strings and char lists:
 * `\xDD` - character with hexadecimal representation DD (e.g., `\x13`)
 * `\x{D...}` - character with hexadecimal representation with one or more hexadecimal digits (e.g., `\x{abc13}`)
 
-Sigils also support heredocs, that is, triple double- or single-quotes as separators:
+Sigils also support heredocs, that is, three double-quotes or single-quotes as separators:
 
 ```iex
 iex> ~s"""


### PR DESCRIPTION
Issue
=====

When skimming the original phrasing of this sentence, I failed to understand the sentence properly. I read the sentence

> Sigils also support heredocs, that is, triple double- or single-quotes as separators

as

> Sigils also support heredocs, that is triple, double, or single quotes as separators

The difference between these two sentences is only punctuation. The good people of the Elixir Slack helped me to understand the true intent of the sentence.

Proposal
========

I believe this phrasing is somewhat clearer. While I am a native English speaker, I hope this rephrase is clearer to people who are not native English speakers. I'd be interested to get feedback from the community about this.