### PR TITLE
Update ets.markdown for readability

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -29,7 +29,9 @@ iex> :ets.lookup(table, "foo")
 When creating an ETS table, two arguments are required: the table name and a set of options. From the available options, we passed the table type and its access rules. We have chosen the `:set` type, which means that keys cannot be duplicated. We've also set the table's access to `:protected`, meaning only the process that created the table can write to it, but all processes can read from it. The possible access controls:
 
   `:public` — Read/Write available to all processes.
+  
   `:protected` — Read available to all processes. Only writable by owner process. This is the default.
+  
   `:private` — Read/Write limited to owner process.
 
 Be aware that if your Read/Write call violates the access control, the operation will raise `ArgumentError`. Finally, since `:set` and `:protected` are the default values, we will skip them from now on.


### PR DESCRIPTION
Separate the access controls so they each show up on their own line for easier readability