### PR TITLE
Minor edit: use matching module to query dynamic supervisor

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -160,7 +160,7 @@ end
 
 Since we have now changed our registry to use `KV.BucketSupervisor`, which is registered globally, our tests are now relying on this shared supervisor even though each test has its own registry. The question is: should we?
 
-It depends. It is ok to rely on shared state as long as we depend only on a non-shared partition of this state. Although multiple registries may start buckets on the shared bucket supervisor, those buckets and registries are isolated from each other. We would only run into concurrency issues if we used a function like `Supervisor.count_children(KV.BucketSupervisor)` which would count all buckets from all registries, potentially giving different results when tests run concurrently.
+It depends. It is ok to rely on shared state as long as we depend only on a non-shared partition of this state. Although multiple registries may start buckets on the shared bucket supervisor, those buckets and registries are isolated from each other. We would only run into concurrency issues if we used a function like `DynamicSupervisor.count_children(KV.BucketSupervisor)` which would count all buckets from all registries, potentially giving different results when tests run concurrently.
 
 Since we have relied only on a non-shared partition of the bucket supervisor so far, we don't need to worry about concurrency issues in our test suite. In case it ever becomes a problem, we can start a supervisor per test and pass it as an argument to the registry `start_link` function.
 


### PR DESCRIPTION
`Supervisor` and `DynamicSupervisor` both have `count_children` and both appear to work identically in this situation. However, `KV.BucketSupervisor` is a `DynamicSupervisor` so we should probably use functions from the matching module.

While reading the docs I stumbled across this and had to go back up a bit to double-check it was still referring to the dynamic supervisor.