### PR TITLE
fix(getting-started): change example.ex compilation order for debug

### DIFF
--- a/getting-started/debugging.markdown
+++ b/getting-started/debugging.markdown
@@ -103,19 +103,23 @@ defmodule Example do
 end
 ```
 
-Now let's start an IEx session to compile the file and start the debugger:
+Now let's compile the file and run an IEx session:
+
+```console
+$ elixirc example.ex
+$ iex
+```
+
+Then start the debugger:
 
 ```elixir
-$ iex
-iex(1)> c "example.ex"
-[Example]
-iex(2)> :debugger.start()
+iex(1)> :debugger.start()
 {:ok, #PID<0.87.0>}
-iex(3)> :int.ni(Example)
+iex(2)> :int.ni(Example)
 {:module, Example}
-iex(4)> :int.break(Example, 3)
+iex(3)> :int.break(Example, 3)
 :ok
-iex(5)> Example.double_sum(1,2)
+iex(4)> Example.double_sum(1, 2)
 ```
 
 > If the `debugger` does not start, here is what may have happened: some package managers default to installing a minimized Erlang without WX bindings for GUI support. In some package managers, you may be able to replace the headless Erlang with a more complete package (look for packages named `erlang` vs `erlang-nox` on Debian/Ubuntu/Arch). In others managers, you may need to install a separate `erlang-wx` (or similarly named) package.


### PR DESCRIPTION
Found that current execution order fails in [Debugger section](https://elixir-lang.org/getting-started/debugging.html#debugger).

If I compile `example.ex` in IEx session I get this error:

```elixir
$ iex
iex(1)> c "example.ex"
[Example]
iex(2)> :debugger.start()
{:ok, #PID<0.115.0>}
iex(3)> :int.ni(Example)
** Invalid beam file or no abstract code: 'Elixir.Example'
:error
iex(4)> 
01:33:33.465 [error] [label: {:erl_prim_loader, :file_error}, report: 'File operation error: eisdir. Target: /Users/psylone/dev. Function: get_file. ']
```

But it works if I compile `example.ex` beforehand with `elixirc`. Moreover, if I do it and then invoke `c "example.ex"` inside an IEx session, I get this error again.

Tested with Elixir 1.11.3 on Ubuntu 20.04 LTS and macOS 10.14.6.