### PR TITLE
fix(otp): remove extra assert

### DIFF
--- a/getting-started/mix-otp/genserver.markdown
+++ b/getting-started/mix-otp/genserver.markdown
@@ -213,7 +213,7 @@ defmodule KV.RegistryTest do
     assert KV.Registry.lookup(registry, "shopping") == :error
 
     KV.Registry.create(registry, "shopping")
-    assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
+    {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
 
     KV.Bucket.put(bucket, "milk", 1)
     assert KV.Bucket.get(bucket, "milk") == 1


### PR DESCRIPTION
It looks like we don't need `assert` when lookup created registry.