### PR TITLE
Recommend a full installation of erlang on Fedora

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -41,7 +41,7 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Run: `yum install elixir`
 
   - **Fedora 22 (and newer)**
-    * Run `dnf install elixir`
+    * Run `dnf install elixir erlang`
 
   - **Gentoo**
     * Run: `emerge --ask dev-lang/elixir`


### PR DESCRIPTION
There was a person in the Elixir slack today that had trouble trying to
use a dependency that depended on xmerl. The solution for him was `sudo
dnf install erlang-xmerl` (although `sudo dnf install erlang` would have
been better).

I've also seen Fedora users having trouble running ElixirLS if they
don't have a full installation of erlang because they don't have the
`erlang-dialyzer` package:
https://github.com/elixir-lsp/elixir-ls/issues/231

Looking at the latest version of the elixir package for erlang we can
see that the "Requires" list is much smaller than the "BuildRequires"
list:
https://src.fedoraproject.org/rpms/elixir/blob/1118b2d2b1e973ba8188f7e479db174850697b2f/f/elixir.spec

Therefore, for typical Elixir development I believe it is important for
Fedora users to have a full installation of Erlang.