### PR TITLE
Nobody uses feedburner anymore. We should use the original feed

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="description" content="Welcome to Elixir, a dynamic, functional language designed for building scalable and maintainable applications">
   <title>{% if page.title %}{{ page.title }} - {% endif %}The Elixir programming language</title>
-  <link href="http://feeds.feedburner.com/ElixirLang" rel="alternate" title="Elixir's Blog" type="application/atom+xml" />
+  <link href="https://elixir-lang.org/atom.xml" rel="alternate" title="Elixir's Blog" type="application/atom+xml" />
   <link rel="stylesheet" type="text/css" href="/css/style.css" />
   <link rel="stylesheet" type="text/css" href="/css/syntax.css" />
   <link rel="stylesheet" href="/js/icons/style.css">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,7 +7,7 @@
 <div id="sidebar-primary" class="sidebar">
   {% include search.html %}
   <div class="rss-button">
-    <a href="http://feeds.feedburner.com/ElixirLang" target="_blank"><img src="/images/social/RSSButton.png" alt="RSS button" /></a>
+    <a href="https://elixir-lang.org/atom.xml" target="_blank"><img src="/images/social/RSSButton.png" alt="RSS button" /></a>
   </div>
   {% include categories-list.html %}
   {% include important-links.html %}


### PR DESCRIPTION
The feed url on the website is confusing, and do not work in many places. The original atom feed is good enough; there is no point to use the obsolete feedburner service.