### PR TITLE
Remove confusing `use` statement

### DIFF
--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -103,8 +103,6 @@ In order to fix the failing test, let's create a file at `lib/kv/bucket.ex` with
 
 ```elixir
 defmodule KV.Bucket do
-  use Agent
-
   @doc """
   Starts a new bucket.
   """
@@ -128,9 +126,7 @@ defmodule KV.Bucket do
 end
 ```
 
-The first step in our implementation is to call `use Agent`.
-
-Then we define a `start_link/1` function, which will effectively start the agent. It is a convention to define a `start_link/1` function that always accepts a list of options. We don't plan on using any options right now, but we might later on. We then proceed to call `Agent.start_link/1`, which receives an anonymous function that returns the Agent's initial state.
+We define a `start_link/1` function, which will effectively start the agent. It is a convention to define a `start_link/1` function that always accepts a list of options. We don't plan on using any options right now, but we might later on. We then proceed to call `Agent.start_link/1`, which receives an anonymous function that returns the Agent's initial state.
 
 We are keeping a map inside the agent to store our keys and values. Getting and putting values on the map is done with the Agent API  and the capture operator `&`, introduced in [the Getting Started guide](/getting-started/modules-and-functions.html#function-capturing). The agent passes its state to the anonymous function via the `&1` argument when `Agent.get/2` and `Agent.update/2` are called.
 


### PR DESCRIPTION
I think we should not `use Agent` here, since we use `Agent`'s functions  directly with module name everywhere. It may be confusing to `use` it inside `KV.Bucket` module.