### PR TITLE
Minor update on console output

### DIFF
--- a/getting-started/mix-otp/distributed-tasks.markdown
+++ b/getting-started/mix-otp/distributed-tasks.markdown
@@ -269,8 +269,8 @@ Excluding tags: [distributed: true]
 
 .......
 
-Finished in 0.1 seconds (0.1s on load, 0.01s on tests)
-7 tests, 0 failures, 1 skipped
+Finished in 0.05 seconds
+8 tests, 0 failures, 1 excluded
 ```
 
 This time all tests passed and ExUnit warned us that distributed tests were being excluded. If you run tests with `$ elixir --sname foo -S mix test`, one extra test should run and successfully pass as long as the `bar@computer-name` node is available.


### PR DESCRIPTION
I've noticed that output in my console was different than the one in the example when running `mix test`. The number of tests (8 instead of 7) might be my fault, although I tried to strictly follow the tutorial. However, I don't get the info about `on load` and `on tests` and my output says `excluded`, not `skipped`

Output of my `elixir -v`, ran on MacOSX (BigSur):

```
Erlang/OTP 23 [erts-11.0.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

Elixir 1.11.2 (compiled with Erlang/OTP 23)
```