### PR TITLE
Add missing piece of config info to instructions

### DIFF
--- a/getting-started/mix-otp/distributed-tasks.markdown
+++ b/getting-started/mix-otp/distributed-tasks.markdown
@@ -307,7 +307,7 @@ def run({:create, bucket}) do
 end
 ```
 
-Now if you run the tests, you will see the test that checks the server interaction will fail, as it will attempt to use the routing table. To address this failure, add `@tag :distributed` to this test too:
+Now if you run the tests, you will see the test that checks the server interaction will fail, as it will attempt to use the routing table. To address this failure, change the `test_helper.exs` for `:kv_server` application as we did for `:kv` and add `@tag :distributed` to this test too:
 
 ```elixir
 @tag :distributed


### PR DESCRIPTION
To be able to use the `distributed` tag for the exclusion afaik we need the same config in `test_helper.exs` for `:kv_server` as we do for `:kv`. This instruction is implicit and I think it would be better to have it stated explicitly.