### PR TITLE
Removing font weight property for better readability.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,7 +33,7 @@ html {
 }
 body {
   margin: 0;
-  font: 0.95em/1.692307em 'Bitter', Georgia, 'Times New Roman', Times, serif;
+  font: 'Bitter', Georgia, 'Times New Roman', Times, serif;
   color: #24292e;
   padding: 0;
   height: 100%;


### PR DESCRIPTION
Current font weight setting "0.95em/1.692307em" produce thinner fonts than the default. Default font weight setting is more comfortable to the eyes for longer reading sessions. I found the default font weight work best with dark reader addon as well. Here's how the website renders with current "0.95em/1.692307em" setting,

![no-change](https://user-images.githubusercontent.com/80860863/116154682-d34c4780-a69d-11eb-8719-f1a5bbc07326.png)

Removing the font weight and leaving it to the browser,

![font-weight-removed](https://user-images.githubusercontent.com/80860863/116154743-e8c17180-a69d-11eb-8b2e-e45f97f3eef1.png)

I do understand this boils down to personal preference and anyone can change this through a browser extension like Stylus. In that case, feel free to ignore this.