### PR TITLE
Remove @before_compile from popular module attrs

### DIFF
--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -26,8 +26,8 @@ In the example above, we are defining the module documentation by using the modu
 
 * `@moduledoc` - provides documentation for the current module.
 * `@doc` - provides documentation for the function or macro that follows the attribute.
+* `@spec` - provides a typespec for the function that follows the attribute.
 * `@behaviour` - (notice the British spelling) used for specifying an <abbr title="Open Telecom Platform">OTP</abbr> or user-defined behaviour.
-* `@before_compile` - provides a hook that will be invoked before the module is compiled. This makes it possible to inject functions inside the module exactly before compilation.
 
 `@moduledoc` and `@doc` are by far the most used attributes, and we expect you to use them a lot. Elixir treats documentation as first-class and provides many functions to access documentation. You can read more about [writing documentation in Elixir in our official documentation](https://hexdocs.pm/elixir/writing-documentation.html).
 


### PR DESCRIPTION
It isn't popular, as implied by the text, and it doesn't seem to me that beginners would benefit from this knowledge.

Add `@spec` instead. While there is already a section that cover type specifications (the same one that covers behaviours),
I think it is better to first mention them here instead of waiting as long as the guide does currently.

If you want to inform the reader that module attributes can be used to add compilation hooks, I can add a small section about
it in the end of the page.