### PR TITLE
Update module-attributes.markdown

### DIFF
--- a/getting-started/module-attributes.markdown
+++ b/getting-started/module-attributes.markdown
@@ -169,7 +169,7 @@ end
 
 ## As temporary storage
 
-To see an example of using module attributes as for storage, look no further than Elixir's unit test framework called [ExUnit](https://hexdocs.pm/ex_unit/). ExUnit uses module attributes for multiple different purposes:
+To see an example of using module attributes as storage, look no further than Elixir's unit test framework called [ExUnit](https://hexdocs.pm/ex_unit/). ExUnit uses module attributes for multiple different purposes:
 
 ```elixir
 defmodule MyTest do


### PR DESCRIPTION
Fixed typo: it should be either _as_ or _for_ but not both. Use _as_ because it matches the rest of the section.