### PR TITLE
Update the example for variables visibility in the do-block of `try`

### DIFF
--- a/getting-started/try-catch-and-rescue.markdown
+++ b/getting-started/try-catch-and-rescue.markdown
@@ -266,7 +266,6 @@ iex> try do
 ...> rescue
 ...>   _ -> what_happened
 ...> end
-iex> what_happened
 ** (RuntimeError) undefined function: what_happened/0
 ```
 


### PR DESCRIPTION
The `iex> what_happened` line is unnecessary. The `** (RuntimeError) undefined function: what_happened/0` will be caused by an attempt to access the variable within the `rescue` block. This line will attempt to do the same again, which will only demonstrate that the variables defined inside the `try` block do not leak, as was already shown by the preceding example.