### PR TITLE
Updates pseudocode example usage from Mix.env to Mix.env() to avoid confusion

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -286,7 +286,7 @@ Customization per environment can be done by accessing [the `Mix.env` function](
 def project do
   [
     ...,
-    start_permanent: Mix.env == :prod,
+    start_permanent: Mix.env() == :prod,
     ...
   ]
 end


### PR DESCRIPTION
I'm just getting into Elixir, so please bear with me if this is nonsense.

I was reading through the "introduction to Mix" guide, and https://github.com/elixir-lang/elixir-lang.github.com/blame/master/getting-started/mix-otp/introduction-to-mix.markdown#L283-L289 confused me slightly, since it is referencing that Mix.env is a function, but then not executing on the example usage.

By scrolling back, I could verify that the example mix.exs snippet https://github.com/elixir-lang/elixir-lang.github.com/blame/master/getting-started/mix-otp/introduction-to-mix.markdown#L85-L114, effectively points to executing Mix.env as function. 

Sorry if this comes across like a little bit nitpicky, just trying to contribute back my two cents, love the docs!