### PR TITLE
Update code example in Elixir 1.5 post

### DIFF
--- a/_posts/2017-07-25-elixir-v1-5-0-released.markdown
+++ b/_posts/2017-07-25-elixir-v1-5-0-released.markdown
@@ -84,8 +84,8 @@ Elixir v1.5 streamlines how supervisors are defined and used in Elixir. Elixir n
 import Supervisor.Spec
 
 children = [
-  supervisor(MyApp.Repo, []),
-  supervisor(MyApp.Endpoint, [])
+  supervisor(MyApp.Repo, [[]]),
+  supervisor(MyApp.Endpoint, [[]])
 ]
 
 Supervisor.start_link(children, strategy: :one_for_one)


### PR DESCRIPTION
I was just updating one of my older apps' versions of Elixir to a recent version and had a lot of warnings to clean up, of the variety:

`warning: Supervisor.Spec.supervisor/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead`

I found myself on the official Elixir v1.5 release blog post, to refresh myself on the difference. I *believe* the blog post has a bug, in the before and after section, which tripped me up for a bit. The blog post said that in previous versions you'd write:

```ex
children = [
  supervisor(Module, [])
]
```

while in Elixir 1.5 you'd write:

```ex
children = [
  Module
]
```

Correct me if I'm wrong, but I don't think those are exactly equivalent, and they're not equivalent in a way that was quite confusing to me at first.

I believe in previous versions, the second argument to `worker/2` or `supervisor/2` were the arguments for an `:erlang.apply/3` style MFA, meaning `worker(Module, [])` would invoke `Module.start_link()`, and `worker(Module, [:a, :b, :c])` would call `Module.start_link(:a, :b, :c)`.

Meanwhile, in Elixir 1.5, just a plain `Module`, when the module is doing `use GenServer` is equivalent to the tuple `{Module, []}`. And _that_ calls `Module.start_link([])`. In other words, it always calls exactly `Module.start_link/1`, and the second element of the tuple is passed directly as its only argument. As far as I can tell, there's no drop in replacement for the blog post's `worker(Module, [])`, i.e. a way to call a `start_link/0`, without writing a custom `child_spec` in the module.