### PR TITLE
Update pattern-matching.markdown

### DIFF
--- a/getting-started/pattern-matching.markdown
+++ b/getting-started/pattern-matching.markdown
@@ -59,7 +59,7 @@ iex> {a, b, c} = {:hello, "world"}
 ** (MatchError) no match of right hand side value: {:hello, "world"}
 ```
 
-And also when comparing different types:
+And also when comparing different types, for example if matching a tuple on the left side with a list on the right side:
 
 ```elixir
 iex> {a, b, c} = [:hello, "world", 42]


### PR DESCRIPTION
It's easy to confuse `{` and `[`. It happened to me and the code example at first didn't make sense. Clarify by mentioning types of example.