### PR TITLE
Update to the output of ExUnit 1.12

### DIFF
--- a/getting-started/mix-otp/ets.markdown
+++ b/getting-started/mix-otp/ets.markdown
@@ -227,9 +227,9 @@ The `--trace` option is useful when your tests are deadlocking or there are race
   1) test removes buckets on exit (KV.RegistryTest)
      test/kv/registry_test.exs:19
      Assertion with == failed
-     code: KV.Registry.lookup(registry, "shopping") == :error
-     lhs:  {:ok, #PID<0.109.0>}
-     rhs:  :error
+     code:  assert KV.Registry.lookup(registry, "shopping") == :error
+     left:  {:ok, #PID<0.109.0>}
+     right: :error
      stacktrace:
        test/kv/registry_test.exs:23
 ```


### PR DESCRIPTION
The output of the current version of ExUnit is different from here.

We need `assert` because this output should come from https://github.com/elixir-lang/elixir-lang.github.com/blob/01af1d9f2a14956371361ef55c663ed415e565bc/getting-started/mix-otp/genserver.markdown?plain=1#L245 .