### PR TITLE
Fix mini documentary link

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -10,7 +10,7 @@
 </div>
 
 <div id="mini-docu" class="widget">
-  <a href="http://doc.honeypot.io/elixir-documentary-2018/?utm_source=elixir_home&utm_medium=referral">
+  <a href="https://cult.honeypot.io/originals/elixir-the-documentary">
     <div class="mini-docu-cta">
       <div class="mini-docu-copy">Watch the Elixir<br />mini-documentary!</div>
     </div>


### PR DESCRIPTION
The link on the page seems to be a dead one. I believe this is the the updated link https://cult.honeypot.io/originals/elixir-the-documentary