### PR TITLE
Update dynamic-supervisor.markdown

### DIFF
--- a/getting-started/mix-otp/dynamic-supervisor.markdown
+++ b/getting-started/mix-otp/dynamic-supervisor.markdown
@@ -158,7 +158,7 @@ setup do
 end
 ```
 
-Since we have now changed our registry to use `KV.BucketSupervisor`, which is registered globally, our tests are now relying on this shared supervisor even though each test has its own registry. The question is: should we?
+Since we have changed our registry to use `KV.BucketSupervisor`, our tests are now relying on this shared supervisor even though each test has its own registry. The question is: should we?
 
 It depends. It is ok to rely on shared state as long as we depend only on a non-shared partition of this state. Although multiple registries may start buckets on the shared bucket supervisor, those buckets and registries are isolated from each other. We would only run into concurrency issues if we used a function like `DynamicSupervisor.count_children(KV.BucketSupervisor)` which would count all buckets from all registries, potentially giving different results when tests run concurrently.
 


### PR DESCRIPTION
## Reason for change
See [issue 1559](https://github.com/elixir-lang/elixir-lang.github.com/issues/1559)

## Summary of changes
This PR changes the text from:
> Since we have **now** changed our registry to use KV.BucketSupervisor, **which is registered globally,** our tests are now relying on this shared supervisor even though each test has its own registry.

To:
> Since we have changed our registry to use KV.BucketSupervisor, our tests are now relying on this shared supervisor even though each test has its own registry.

#### Before
![Screen Shot 2021-09-02 at 11 43 34 PM](https://user-images.githubusercontent.com/3199675/131920285-2ce0e6de-7b2a-4f10-af2a-eb83873284e8.png)

#### After
![Screen Shot 2021-09-02 at 11 45 19 PM](https://user-images.githubusercontent.com/3199675/131920439-deed89a0-9ced-49a9-9059-9d2616cb7ba9.png)
