### PR TITLE
Fixed incorrect file name

### DIFF
--- a/getting-started/mix-otp/distributed-tasks.markdown
+++ b/getting-started/mix-otp/distributed-tasks.markdown
@@ -307,7 +307,7 @@ def run({:create, bucket}) do
 end
 ```
 
-Now if you run the tests, you will see the test that checks the server interaction will fail, as it will attempt to use the routing table. To address this failure, change the `test_helper.exs` for `:kv_server` application as we did for `:kv` and add `@tag :distributed` to this test too:
+Now if you run the tests, you will see the test that checks the server interaction will fail, as it will attempt to use the routing table. To address this failure, change the `kv_server_test.exs` for `:kv_server` application as we did for `:kv` and add `@tag :distributed` to this test too:
 
 ```elixir
 @tag :distributed


### PR DESCRIPTION
Incredibly minor but tutorial says to add '@tag :distributed' in a test located in `test_helper.exs`, when it actually is in `kv_server_test.exs`.