### PR TITLE
Fix the missing link to the guides page

### DIFF
--- a/docs.markdown
+++ b/docs.markdown
@@ -8,7 +8,7 @@ layout: default
 
 The Elixir programming language is broken into 6 applications. The links below
 reference the documentation for the modules and functions in each of those
-applications. For a general introduction to the language, see our [guides](/guides.html).
+applications. For a general introduction to the language, see our [guides](/getting-started/introduction.html).
 
 {% assign stable = site.data.elixir-versions[site.data.elixir-versions.stable] %}
 


### PR DESCRIPTION
A path I'd like to fix points to a seemingly obsolete guides page. I'll fix it along with the path that is linked from "GUIDES" in the header menu.

![image](https://user-images.githubusercontent.com/3458/145528898-576873ab-03a7-4baf-946a-188671a8cf8c.png)
