### PR TITLE
Remove data-rows attr from asciinema script tags

### DIFF
--- a/_posts/2021-05-19-elixir-v1-12-0-released.markdown
+++ b/_posts/2021-05-19-elixir-v1-12-0-released.markdown
@@ -29,7 +29,7 @@ Furthermore, `Mix.install/2` pairs nicely with Livebook, a newly announced proje
 
 Another improvement to scripting is the ability to trap exit signals via `System.trap_signal/3`. All you need is the signal name and a callback that will be invoked when the signal triggers. For example, ExUnit leverages this functionality to print all currently running tests when you abort the test suite via SIGQUIT (`Ctrl+\\ `). You can see this in action when running tests in the Plug project below:
 
-<script type="text/javascript" src="https://asciinema.org/a/qPOJ9Vd8DiEXttEv7olNJPUR0.js" data-rows="20" id="asciicast-qPOJ9Vd8DiEXttEv7olNJPUR0" async></script><noscript><p><a href="https://asciinema.org/a/qPOJ9Vd8DiEXttEv7olNJPUR0">See the example in asciinema</a></p></noscript>
+<script type="text/javascript" src="https://asciinema.org/a/qPOJ9Vd8DiEXttEv7olNJPUR0.js" id="asciicast-qPOJ9Vd8DiEXttEv7olNJPUR0" async></script><noscript><p><a href="https://asciinema.org/a/qPOJ9Vd8DiEXttEv7olNJPUR0">See the example in asciinema</a></p></noscript>
 
 This is particularly useful when your tests get stuck and you want to know which one is the culprit.
 
@@ -41,11 +41,11 @@ This is particularly useful when your tests get stuck and you want to know which
 
 Another excellent feature in Erlang/OTP 24 is the implementation of [EEP 54](http://www.erlang.org/eeps/eep-0054.html), which provides extended error information for many functions in Erlang's stdlib. Elixir v1.12 fully leverages this feature to improve reporting for errors coming from Erlang. For example, in earlier OTP versions, inserting an invalid argument into an ETS table that no longer exists would simply error with `ArgumentError`:
 
-<script type="text/javascript" src="https://asciinema.org/a/1s79Cwf2JvSLYihAahIobVyBm.js" data-rows="20" id="asciicast-1s79Cwf2JvSLYihAahIobVyBm" async></script><noscript><p><a href="https://asciinema.org/a/1s79Cwf2JvSLYihAahIobVyBm">See the example in asciinema</a></p></noscript>
+<script type="text/javascript" src="https://asciinema.org/a/1s79Cwf2JvSLYihAahIobVyBm.js" id="asciicast-1s79Cwf2JvSLYihAahIobVyBm" async></script><noscript><p><a href="https://asciinema.org/a/1s79Cwf2JvSLYihAahIobVyBm">See the example in asciinema</a></p></noscript>
 
 However, in Elixir v1.12 with Erlang/OTP 24:
 
-<script type="text/javascript" src="https://asciinema.org/a/4l1ORaVDVdHB7Gi5DccIYFgSL.js" data-rows="20" id="asciicast-4l1ORaVDVdHB7Gi5DccIYFgSL" async></script><noscript><p><a href="https://asciinema.org/a/4l1ORaVDVdHB7Gi5DccIYFgSL">See the example in asciinema</a></p></noscript>
+<script type="text/javascript" src="https://asciinema.org/a/4l1ORaVDVdHB7Gi5DccIYFgSL.js" id="asciicast-4l1ORaVDVdHB7Gi5DccIYFgSL" async></script><noscript><p><a href="https://asciinema.org/a/4l1ORaVDVdHB7Gi5DccIYFgSL">See the example in asciinema</a></p></noscript>
 
 Finally, note Rebar v2 no longer works on Erlang/OTP 24+. Mix defaults to Rebar v3 since Elixir v1.4, so no changes should be necessary by the vast majority of developers. However, if you are explicitly setting `manager: :rebar` in your dependency, you want to move to Rebar v3 by removing the `:manager` option. Compatibility with unsupported Rebar versions will be removed from Mix in the future.
 
@@ -86,7 +86,7 @@ Both `tap/2` and `then/2` are implemented as macros, and compiler improvements a
 
 IEx got two important quality of life improvements in this release. Hitting tab after a function invocation will show all of the arguments for said function and it is now possible to paste code with pipelines in the shell. See both features in action below:
 
-<script type="text/javascript" src="https://asciinema.org/a/IMSAZUqLFlmGRsPk4gKuJ3tN0.js" data-rows="20" id="asciicast-IMSAZUqLFlmGRsPk4gKuJ3tN0" async></script><noscript><p><a href="https://asciinema.org/a/IMSAZUqLFlmGRsPk4gKuJ3tN0">See the example in asciinema</a></p></noscript>
+<script type="text/javascript" src="https://asciinema.org/a/IMSAZUqLFlmGRsPk4gKuJ3tN0.js" id="asciicast-IMSAZUqLFlmGRsPk4gKuJ3tN0" async></script><noscript><p><a href="https://asciinema.org/a/IMSAZUqLFlmGRsPk4gKuJ3tN0">See the example in asciinema</a></p></noscript>
 
 ## Additional functions
 


### PR DESCRIPTION
Hey!

First, it always feels good to see asciinema demo in new release posts ❤️ 

I've recently released a new major version of the asciinema web player which, among other things, comes with vastly better way of scaling the text with regards to the number of colums/rows and available space in the container element on the page (is also responsive, and looks much better on small screens, .e.g mobile). asciinema.org has been already updated to use it, including the embed script/iframe.

One result of this that's relevant for embedding is that font size is now automatically scaled to make all terminal content visible, while previously the font size was fixed and if there was more columns than can fit in the embed area the terminal content on the right side was cut off. 

For cases where you record in a wide terminal and then embed in a relatively narrow space on the website (grid column / div) this makes text very small, harder to read.

One way to solve this when embedding is to pass the `data-cols` and `data-rows` attributes to the embed script. This is what you did for the 1.12 release post.

I've just added a persistent settings for terminal colums and rows to the asciicast settings page:

<img width="1030" alt="terminal-size-settings" src="https://user-images.githubusercontent.com/17589/145723473-06daf873-0e51-4149-9cb0-29d97325e7fa.png">

These default to the original values found in uploaded asciicast files, and can be used to override the dimensions so it's applied automatically to the embeds as well as to the player viewed directly on asciinema.org. The `data-cols` / `data-rows` attrs still work, and can be used to override the persisted setting from asciinema.org

I went through the recent posts on this blog and found that the embedded demos have rather small text (due to the new fitting algorithm) so I went ahead and updated the columns and rows overrides to make the text in demos good looking. I set 100 columns on all your demos so the text size is consistent between demos. For the ones where I found you used `data-rows=20` I set this value in the database, which makes it look the same on the blog and when viewed directly on asciinema.org.

With that in place the override on the script tags in 1.12 post is now redundant so this PR removes it. Keeping it as it is brings no issues and doesn't change the display so feel free to ignore this PR. I just took this PR as an opportunity to let you know about the above changes :)

