### PR TITLE
Add DOCS menu in top section

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -36,6 +36,7 @@
         <ul id="menu-primary-items">
           <li class="menu-item home"><a class="spec" href="/">Home</a></li>
           <li class="menu-item install"><a class="spec" href="/install.html">Install</a></li>
+          <li class="menu-item docs"><a class="spec" href="/docs.html">Docs</a></li>
           <li class="menu-item learning"><a class="spec" href="/learning.html">Learning</a></li>
           <li class="menu-item getting-started"><a class="spec" href="/getting-started/introduction.html">Guides</a></li>
           <li class="menu-item cases"><a class="spec" href="/cases.html">Cases</a></li>


### PR DESCRIPTION
This will be more exposure to the DOCS section

Origated from:
https://elixirforum.com/t/onboarding-website-for-mix-build-tool/44740/5?u=eksperimental

Additionally we could remove "API Documentation" from the sidebard, (under important links)
Peronally I don't find it clear that about API. I think just "Documentation" will do a better job.

Screenshot:
![image](https://user-images.githubusercontent.com/9133420/146981566-a28e01f9-0778-48e8-b65c-46d6934dc9db.png)
