### PR TITLE
Update macro usage error message when missing require

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -75,12 +75,12 @@ Elixir provides macros as a mechanism for meta-programming (writing code that ge
 Public functions in modules are globally available, but in order to use macros, you need to opt-in by requiring the module they are defined in.
 
 ```elixir
-iex> Integer.is_odd(3)
-** (CompileError) iex:1: you must require Integer before invoking the macro Integer.is_odd/1
-    (elixir) src/elixir_dispatch.erl:97: :elixir_dispatch.dispatch_require/6
-iex> require Integer
+iex(1)> Integer.is_odd(3)
+** (UndefinedFunctionError) function Integer.is_odd/1 is undefined or private. However there is a macro with the same name and arity. Be sure to require Integer if you intend to invoke this macro
+    (elixir 1.13.2) Integer.is_odd(3)
+iex(1)> require Integer
 Integer
-iex> Integer.is_odd(3)
+iex(2)> Integer.is_odd(3)
 true
 ```
 

--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -75,12 +75,12 @@ Elixir provides macros as a mechanism for meta-programming (writing code that ge
 Public functions in modules are globally available, but in order to use macros, you need to opt-in by requiring the module they are defined in.
 
 ```elixir
-iex(1)> Integer.is_odd(3)
+iex> Integer.is_odd(3)
 ** (UndefinedFunctionError) function Integer.is_odd/1 is undefined or private. However there is a macro with the same name and arity. Be sure to require Integer if you intend to invoke this macro
-    (elixir 1.13.2) Integer.is_odd(3)
-iex(1)> require Integer
+    (elixir) Integer.is_odd(3)
+iex> require Integer
 Integer
-iex(2)> Integer.is_odd(3)
+iex> Integer.is_odd(3)
 true
 ```
 


### PR DESCRIPTION
Hi Elixir team,

While reading the [alias, require, and import docs](https://elixir-lang.org/getting-started/alias-require-and-import.html) and running Elixir 1.13.2, I got a slightly different output in an `iex` session when using the [Integer.is_odd/1](https://hexdocs.pm/elixir/1.12/Integer.html#is_odd/1) macro without calling `require` first.

This tinny PR aims to fix that by showing the most recent message from the error raised.