### PR TITLE
git unauthenticated protocol is no longer supported

### DIFF
--- a/getting-started/mix-otp/dependencies-and-umbrella-projects.markdown
+++ b/getting-started/mix-otp/dependencies-and-umbrella-projects.markdown
@@ -52,7 +52,7 @@ Typically, stable releases are pushed to Hex. If you want to depend on an extern
 
 ```elixir
 def deps do
-  [{:plug, git: "git://github.com/elixir-lang/plug.git"}]
+  [{:plug, git: "https://github.com/elixir-lang/plug.git"}]
 end
 ```
 


### PR DESCRIPTION
When I ran mix deps.get with a git repo as my dependency, it threw me the following error. Looks like git unauthenticated protocol is no longer supported for security reasons and https protocol is the way to go. 

mix deps.get
* Getting broadway_kafka (git://github.com/dashbitco/broadway_kafka.git)
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/