### PR TITLE
remove the "apt-key is deprecated" warning

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -102,7 +102,8 @@ If necessary, replace "buster" with the name of your Raspbian release.
   * Get Erlang key and add it to the keychain:
     * Run: `echo "deb https://packages.erlang-solutions.com/debian buster contrib" | sudo tee /etc/apt/sources.list.d/erlang-solutions.list`
     * Run: `wget https://packages.erlang-solutions.com/debian/erlang_solutions.asc`
-    * Run: `sudo apt-key add erlang_solutions.asc`
+    * Run: `cat erlang_solutions.asc | gpg --dearmor > erlang_solutions.gpg`
+    * Run: `sudo install -o root -g root -m 644 erlang_solutions.gpg /etc/apt/trusted.gpg.d/`
   * Install Elixir:
     * Update apt to latest: `sudo apt update`
     * Run: `sudo apt install elixir`


### PR DESCRIPTION
Trying to install elixir on a Raspberry pi using the [official instructions](https://elixir-lang.org/install.html#raspberry-pi) leads to an error.

The `sudo apt-key add erlang_solutions.asc` command issues this message: 

```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```

It's just a warning, but things go wrong starting from that point...

It seems that this is the new way to import the key

```
cat erlang_solutions.asc | gpg --dearmor > erlang_solutions.gpg
sudo install -o root -g root -m 644 erlang_solutions.gpg /etc/apt/trusted.gpg.d/
```

And from that point on, it installs successfully.
