### PR TITLE
Use port 4321 in telnet command (Task and gen_tcp guide)

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -154,7 +154,7 @@ Insert these changes in your code and now you may start your application using t
 Now that the server is part of the supervision tree, it should start automatically when we run the application. Start your server, now passing the port, and once again use the `telnet` client to make sure that everything still works:
 
 ```console
-$ telnet 127.0.0.1 4040
+$ telnet 127.0.0.1 4321
 Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
@@ -169,7 +169,7 @@ Yes, it works! However, does it *scale*?
 Try to connect two telnet clients at the same time. When you do so, you will notice that the second client doesn't echo:
 
 ```console
-$ telnet 127.0.0.1 4040
+$ telnet 127.0.0.1 4321
 Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.


### PR DESCRIPTION
I think it would make sense to use port 4321 here since we are instructed to pass in `PORT=4321` to start the TCP acceptor. This would probably be most natural since the user wants to ensure that environment variables are working as indicated in the guide.