### PR TITLE
Add an additional note explaining what the '-S mix' flag is for

### DIFF
--- a/getting-started/mix-otp/introduction-to-mix.markdown
+++ b/getting-started/mix-otp/introduction-to-mix.markdown
@@ -155,7 +155,7 @@ Will output:
 
 The `lib/kv.ex` file was compiled, an application manifest named `kv.app` was generated. All compilation artifacts are placed inside the `_build` directory using the options defined in the `mix.exs` file.
 
-Once the project is compiled, you can start an `iex` session inside the project by running:
+Once the project is compiled, you can start an `iex` session inside the project by running the command below. The `-S mix` is necessary to load the project in the interactive shell:
 
 ```console
 $ iex -S mix


### PR DESCRIPTION
### Context
I'm new to Elixir and while reading the documentation about Mix there was a code snippet that got me thinking about the purpose of the flag `-S mix` when invoking `iex`. I went straight to run `iex --help` but the output from the help, assuming that's the right way to get it as a user, lacked documentation that flag.

### What
I went ahead and added an additional phrase for people that might come across the same question. Please, let me know that's align how you'd expect this to be addressed or I should explore something else instead. For example improving the `iex --help` output. Thanks in advance for taking your time to review this tiny change.