### PR TITLE
Update wording to make clear @moduletag is for the whole module

### DIFF
--- a/getting-started/mix-otp/docs-tests-and-with.markdown
+++ b/getting-started/mix-otp/docs-tests-and-with.markdown
@@ -420,7 +420,7 @@ This time, since our test relies on global data, we have not given `async: true`
 18:12:10.698 [info] Application kv exited: :stopped
 ```
 
-To avoid printing log messages during tests, ExUnit provides a neat feature called `:capture_log`. By setting `@tag :capture_log` before each test or `@moduletag :capture_log` for the whole test case, ExUnit will automatically capture anything that is logged while the test runs. In case our test fails, the captured logs will be printed alongside the ExUnit report.
+To avoid printing log messages during tests, ExUnit provides a neat feature called `:capture_log`. By setting `@tag :capture_log` before each test or `@moduletag :capture_log` for the whole test module, ExUnit will automatically capture anything that is logged while the test runs. In case our test fails, the captured logs will be printed alongside the ExUnit report.
 
 Between `use ExUnit.Case` and setup, add the following call:
 


### PR DESCRIPTION
Updated "case" to "module" since `@moduletag :capture_log` refers to the whole module and not just a single test case.