### PR TITLE
corrected inconsistent iex prompts

### DIFF
--- a/getting-started/debugging.markdown
+++ b/getting-started/debugging.markdown
@@ -113,13 +113,13 @@ $ iex
 Then start the debugger:
 
 ```elixir
-iex(1)> :debugger.start()
+iex> :debugger.start()
 {:ok, #PID<0.87.0>}
-iex(2)> :int.ni(Example)
+iex> :int.ni(Example)
 {:module, Example}
-iex(3)> :int.break(Example, 3)
+iex> :int.break(Example, 3)
 :ok
-iex(4)> Example.double_sum(1, 2)
+iex> Example.double_sum(1, 2)
 ```
 
 > If the `debugger` does not start, here is what may have happened: some package managers default to installing a minimized Erlang without WX bindings for GUI support. In some package managers, you may be able to replace the headless Erlang with a more complete package (look for packages named `erlang` vs `erlang-nox` on Debian/Ubuntu/Arch). In others managers, you may need to install a separate `erlang-wx` (or similarly named) package.
@@ -134,7 +134,7 @@ For debugging complex systems, jumping at the code is not enough. It is necessar
 
 ```elixir
 $ iex
-iex(1)> :observer.start()
+iex> :observer.start()
 ```
 
 > Similar to the `debugger` note above, your package manager may require a separate installation in order to run Observer.

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -40,9 +40,9 @@ Open up `iex` and type the following expressions:
 Erlang/OTP {{ stable.minimum_otp }} [64-bit] [smp:2:2] [...]
 
 Interactive Elixir ({{ stable.version }}) - press Ctrl+C to exit
-iex(1)> 40 + 2
+iex> 40 + 2
 42
-iex(2)> "hello" <> " world"
+iex> "hello" <> " world"
 "hello world"
 ```
 

--- a/getting-started/mix-otp/agent.markdown
+++ b/getting-started/mix-otp/agent.markdown
@@ -66,7 +66,6 @@ iex> Agent.update(agent, fn list -> [:nop | list] end)
 :ok
 iex> Agent.get(agent, fn content -> content end)
 [:nop, 12, %{a: 123}]
-iex>
 ```
 
 As you can see, we can modify the agent state in any way we want. Therefore, we most likely don't want to access the Agent API throughout many different places in our code. Instead, we want to encapsulate all Agent-related functionality in a single module, which we will call `KV.Bucket`. Before we implement it, let's write some tests which will outline the API exposed by our module.

--- a/getting-started/mix-otp/supervisor-and-application.markdown
+++ b/getting-started/mix-otp/supervisor-and-application.markdown
@@ -59,7 +59,7 @@ Once the supervisor starts, it will traverse the list of children and it will in
 The `child_spec/1` function returns the child specification which describes how to start the process, if the process is a worker or a supervisor, if the process is temporary, transient or permanent and so on. The `child_spec/1` function is automatically defined when we `use Agent`, `use GenServer`, `use Supervisor`, etc. Let's give it a try in the terminal with `iex -S mix`:
 
 ```elixir
-iex(1)> KV.Registry.child_spec([])
+iex> KV.Registry.child_spec([])
 %{id: KV.Registry, start: {KV.Registry, :start_link, [[]]}}
 ```
 
@@ -70,9 +70,9 @@ After the supervisor retrieves all child specifications, it proceeds to start it
 Let's take the supervisor for a spin:
 
 ```elixir
-iex(1)> {:ok, sup} = KV.Supervisor.start_link([])
+iex> {:ok, sup} = KV.Supervisor.start_link([])
 {:ok, #PID<0.148.0>}
-iex(2)> Supervisor.which_children(sup)
+iex> Supervisor.which_children(sup)
 [{KV.Registry, #PID<0.150.0>, :worker, [KV.Registry]}]
 ```
 
@@ -81,12 +81,12 @@ So far we have started the supervisor and listed its children. Once the supervis
 What happens if we intentionally crash the registry started by the supervisor? Let's do so by sending it a bad input on `call`:
 
 ```elixir
-iex(3)> [{_, registry, _, _}] = Supervisor.which_children(sup)
+iex> [{_, registry, _, _}] = Supervisor.which_children(sup)
 [{KV.Registry, #PID<0.150.0>, :worker, [KV.Registry]}]
-iex(4) GenServer.call(registry, :bad_input)
+iex GenServer.call(registry, :bad_input)
 08:52:57.311 [error] GenServer KV.Registry terminating
 ** (FunctionClauseError) no function clause matching in KV.Registry.handle_call/3
-iex(5) Supervisor.which_children(sup)
+iex Supervisor.which_children(sup)
 [{KV.Registry, #PID<0.157.0>, :worker, [KV.Registry]}]
 ```
 
@@ -250,9 +250,9 @@ When we `use Application`, we may define a couple of functions, similar to when 
 Now that you have defined an application callback which starts our supervisor, we expect the `KV.Registry` process to be up and running as soon as we start `iex -S mix`. Let's give it another try:
 
 ```elixir
-iex(1)> KV.Registry.create(KV.Registry, "shopping")
+iex> KV.Registry.create(KV.Registry, "shopping")
 :ok
-iex(2)> KV.Registry.lookup(KV.Registry, "shopping")
+iex> KV.Registry.lookup(KV.Registry, "shopping")
 {:ok, #PID<0.88.0>}
 ```
 

--- a/getting-started/modules-and-functions.markdown
+++ b/getting-started/modules-and-functions.markdown
@@ -186,7 +186,7 @@ iex> fun.(1)
 
 iex> fun2 = &"Good #{&1}"
 #Function<6.127694169/1 in :erl_eval.expr/5>
-iex)> fun2.("morning")
+iex> fun2.("morning")
 "Good morning"
 ```
 

--- a/getting-started/processes.markdown
+++ b/getting-started/processes.markdown
@@ -143,7 +143,7 @@ While other languages would require us to catch/handle exceptions, in Elixir we 
 Tasks build on top of the spawn functions to provide better error reports and introspection:
 
 ```elixir
-iex(1)> Task.start(fn -> raise "oops" end)
+iex> Task.start(fn -> raise "oops" end)
 {:ok, #PID<0.55.0>}
 
 15:22:33.046 [error] Task #PID<0.55.0> started from #PID<0.53.0> terminating


### PR DESCRIPTION
Most of the corrections are just removing the line numbers from the `iex>` prompts to be consistent with the rest of the guide.
One is a trailing ) - `iex)>`
One is an empty trailing `iex>` prompt
