### PR TITLE
add Scoop install instructions for Windows

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -94,6 +94,10 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Click next, next, ..., finish
     * If you run into issues, check out the [Windows Installer issues tracker](https://github.com/elixir-lang/elixir-windows-setup)
 
+  - Using Scoop:
+    * Install Erlang: `scoop install erlang`
+    * Install Elixir: `scoop install elixir`
+
   - Using Chocolatey:
     * Run: `cinst elixir`
 

--- a/install.markdown
+++ b/install.markdown
@@ -98,9 +98,6 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Install Erlang: `scoop install erlang`
     * Install Elixir: `scoop install elixir`
 
-  - Using Chocolatey:
-    * Run: `cinst elixir`
-
 ### Raspberry Pi
 
 If necessary, replace "buster" with the name of your Raspbian release.


### PR DESCRIPTION
chocolatey is rarely up to date and probably not even worth mentioning.  It probably does more harm than good having it here.