### PR TITLE
Link to correct precompiled binaries for supported OTP versions

### DIFF
--- a/_data/elixir-versions.yml
+++ b/_data/elixir-versions.yml
@@ -3,6 +3,7 @@ stable: v1_14
 v1_14:
   name: v1.14
   minimum_otp: 23.0
+  otp_versions: [23, 24, 25]
   version: 1.14.0
   docs_zip: true
 

--- a/install.markdown
+++ b/install.markdown
@@ -125,7 +125,12 @@ The above will automatically point to the latest Erlang and Elixir available. Fo
 
 ## Precompiled package
 
-Elixir provides a precompiled package for every release. First [install Erlang](/install.html#installing-erlang) and then download and unzip the [Precompiled.zip file for the latest release](https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/Precompiled.zip).
+Elixir provides a precompiled package for every release. First [install Erlang](/install.html#installing-erlang) and then download and unzip the appropriate `Precompiled.zip` file for the latest release, depending on which version of Erlang you are using:
+
+
+{% for otp_version in stable.otp_versions %}
+* [Elixir {{ stable.version }} on Erlang {{ otp_version }}](https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/elixir-otp-{{ otp_version }}.zip)
+{% endfor %}
 
 Once the release is unpacked, you are ready to run the `elixir` and `iex` commands from the `bin` directory, but we recommend you to [add Elixir's bin path to your PATH environment variable](#setting-path-environment-variable) to ease development.
 

--- a/install.markdown
+++ b/install.markdown
@@ -129,8 +129,7 @@ Elixir provides a precompiled package for every release. First [install Erlang](
 
 
 {% for otp_version in stable.otp_versions %}
-* [Elixir {{ stable.version }} on Erlang {{ otp_version }}](https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/elixir-otp-{{ otp_version }}.zip)
-{% endfor %}
+  * [Elixir {{ stable.version }} on Erlang {{ otp_version }}](https://github.com/elixir-lang/elixir/releases/download/v{{ stable.version }}/elixir-otp-{{ otp_version }}.zip){% endfor %}
 
 Once the release is unpacked, you are ready to run the `elixir` and `iex` commands from the `bin` directory, but we recommend you to [add Elixir's bin path to your PATH environment variable](#setting-path-environment-variable) to ease development.
 


### PR DESCRIPTION
The [existing installation instructions](http://elixir-lang.org/install.html#precompiled-package) point to an incorrect location for the precompiled binary download. This PR adds a separate link for each supported OTP version:

<img width="691" alt="Screenshot 2022-09-03 at 17 30 37" src="https://user-images.githubusercontent.com/1194/188279891-1446e4cd-cdd9-462f-a508-afcd70f58552.png">

I’ve added an `otp_versions` key to `_data/elixir-versions.yml`:

```yaml
v1_14:
  name: v1.14
  minimum_otp: 23.0
  otp_versions: [23, 24, 25]
  version: 1.14.0
  docs_zip: true
```

Not sure whether this is the best approach, but hopefully it’s a good start.