### PR TITLE
Add example with multiple nesting to `alias` guide

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -215,6 +215,21 @@ defmodule Foo do
 end
 ```
 
+Aliasing a nested module does not bring parent modules into scope. Consider the following example:
+
+```elixir
+defmodule Foo do
+  defmodule Bar do
+    defmodule Baz do
+    end
+  end
+end
+
+alias Foo.Bar.Baz
+# The module `Foo.Bar.Baz` is now available as `Baz`
+# However, the module `Foo.Bar` is *not* available as `Bar`
+```
+
 As we will see in later chapters, aliases also play a crucial role in macros, to guarantee they are hygienic.
 
 ## Multi alias/import/require/use


### PR DESCRIPTION
Updates the getting started guide for nested aliases to clarify `alias` behavior when applied to a module with multiple nesting e.g. `alias Foo.Bar.Baz`.

I think find this behavior very logical, but I was not certain what behavior Elixir provided without checking in `iex`.