### PR TITLE
Add `use` to sentence in multi-alias example

### DIFF
--- a/getting-started/alias-require-and-import.markdown
+++ b/getting-started/alias-require-and-import.markdown
@@ -219,7 +219,7 @@ As we will see in later chapters, aliases also play a crucial role in macros, to
 
 ## Multi alias/import/require/use
 
-It is possible to alias, import or require multiple modules at once. This is particularly useful once we start nesting modules, which is very common when building Elixir applications. For example, imagine you have an application where all modules are nested under `MyApp`, you can alias the modules `MyApp.Foo`, `MyApp.Bar` and `MyApp.Baz` at once as follows:
+It is possible to `alias`, `import`, `require`, or `use` multiple modules at once. This is particularly useful once we start nesting modules, which is very common when building Elixir applications. For example, imagine you have an application where all modules are nested under `MyApp`, you can alias the modules `MyApp.Foo`, `MyApp.Bar` and `MyApp.Baz` at once as follows:
 
 ```elixir
 alias MyApp.{Foo, Bar, Baz}


### PR DESCRIPTION
This sentence was missing "use" despite its inclusion in the heading. The change includes the addition of code formatting to these words for clarification so it doesn't read as "... or use multiple modules".

If you'd prefer a roll-up of any changes I find in the getting started guide I can do so. It seems easier to accept/deny them separately though.