### PR TITLE
Update Ubuntu/Debian install instructions

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -65,10 +65,14 @@ If your distribution contains an old Elixir/Erlang version, see the sections bel
     * Run: `eopkg install elixir`
 
   - **Ubuntu** or **Debian**
-    * Add Erlang Solutions repository: `wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && sudo dpkg -i erlang-solutions_2.0_all.deb`
-    * Run: `sudo apt-get update`
-    * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`
-    * Install Elixir: `sudo apt-get install elixir`
+    * From primary package repositories:
+      * Run: `sudo apt-get install elixir`
+ 
+    * From Erlang Solutions, for more recent Elixir/Erlang versions on Ubuntu LTS (< 22.04) or Debian Stable releases:
+      * Add Erlang Solutions repository: `wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && sudo dpkg -i erlang-solutions_2.0_all.deb`
+      * Run: `sudo apt-get update`
+      * Install the Erlang/OTP platform and all of its applications: `sudo apt-get install esl-erlang`
+      * Install Elixir: `sudo apt-get install elixir`
 
   - **Void Linux**
     * Run: `xbps-install -S elixir`


### PR DESCRIPTION
Unfortunately the Erlang Solutions package repository for Ubuntu and Debian packages has not been updated for recent Ubuntu releases or the latest LTS release. Simplify the instructions to use `apt-get` by default, while still providing an option for those on older releases to use the Erlang Solutions packages.

Fixes #1575.