### PR TITLE
Redirect http traffic to https

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -151,3 +151,13 @@ $(document).ready(function() {
 
   $("#shuffled-cases").children().shuffle()
 });
+
+// Automatically redirect to https
+(function (){
+  const location = window.location.href;
+  const localhost = /:\/\/(?:localhost|127.0.0.1|::1)/
+
+  if (location.startsWith("http://") && !localhost.test(location)) {
+    window.location.href = location.replace("http://", "https://");
+  }
+})();


### PR DESCRIPTION
When visiting elixir-lang.org I noticed that the there is no automatic redirect to https so I added a small script to perform such redirect when the http:// version of the page is loaded 