### PR TITLE
Improve 'Types and Specs' introduction

### DIFF
--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -11,7 +11,7 @@ Elixir is a dynamically typed language, so all types in Elixir are checked at ru
 1. declaring typed function signatures (also called specifications);
 2. declaring custom types.
 
-Although typespecs are primarily for documentation (i.e. they are not enforced, either at compile-time or run-time), they are useful for code clarity and static code analysis (e.g. Erlang's [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html) tool).
+Typespecs are useful for code clarity and static code analysis (for example, Erlang's [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html) tool).
 
 ### Function specifications
 

--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -6,10 +6,12 @@ title: Typespecs and behaviours
 
 ## Types and specs
 
-Elixir is a dynamically typed language, so all types in Elixir are checked at runtime. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
+Elixir is a dynamically typed language. Types are not checked, and type errors are not thrown, at compile-time. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
 
 1. declaring typed function signatures (also called specifications);
 2. declaring custom types.
+
+Although typespecs are primarily for documentation (i.e. they are not enforced, either at compile-time or run-time), they are useful for code clarity and static code analysis (e.g. Erlang's [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html) tool).
 
 ### Function specifications
 

--- a/getting-started/typespecs-and-behaviours.markdown
+++ b/getting-started/typespecs-and-behaviours.markdown
@@ -6,7 +6,7 @@ title: Typespecs and behaviours
 
 ## Types and specs
 
-Elixir is a dynamically typed language. Types are not checked, and type errors are not thrown, at compile-time. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
+Elixir is a dynamically typed language, so all types in Elixir are checked at runtime. Nonetheless, Elixir comes with **typespecs**, which are a notation used for:
 
 1. declaring typed function signatures (also called specifications);
 2. declaring custom types.


### PR DESCRIPTION
Clarifies the statement "all types in Elixir are checked at runtime". They are not checked per say, exceptions are thrown. Thus I think it's better to say "Types are not checked at compile time".

Expands on what Types and Specs are useful for (i.e. documentation, code clarity, static code analysis).