### PR TITLE
Fix link for meetups in sidebar

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -25,7 +25,7 @@
     <li><a class="spec" href="http://elixirforum.com">Elixir Forum</a></li>
     <li><a class="spec" href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a></li>
     <li><a class="spec" href="https://discord.gg/elixir">Elixir on Discord</a></li>
-    <li><a class="spec" href="http://elixir.meetup.com">Meetups around the world</a></li>
+    <li><a class="spec" href="https://www.meetup.com/topics/elixir/">Meetups around the world</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/wiki">Wiki with events and resources maintained by the community</a></li>
   </ul>
 </div>


### PR DESCRIPTION
It seems that the current link for "[Meetups around the world](http://elixir.meetup.com)" in `_includes/important-links.html` returns 404 with a blank page. 

A [cursory look at web.archive.org](https://web.archive.org/web/20181114232109/https://elixir.meetup.com/) suggests that it has acted as a 301 redirect to https://www.meetup.com/topics/elixir/. That 301 redirect doesn't seem to be in place any longer, hence the 404 we get today.

This PR changes the link to the one we were being directed to anyway.