### PR TITLE
Update keywords-and-maps.markdown

### DIFF
--- a/getting-started/keywords-and-maps.markdown
+++ b/getting-started/keywords-and-maps.markdown
@@ -39,7 +39,7 @@ iex> String.split("1  2  3", " ", trim: true)
 ["1", "2", "3"]
 ```
 
-As the name implies, keyword lists are simply lists. In particular, keyword lists are 2-item tuples where the first element (the key) is an atom and the second element can be any value. Both representations are the same:
+As the name implies, keyword lists are simply lists. In particular, they are lists consisting of 2-item tuples where the first element (the key) is an atom and the second element can be any value. Both representations are the same:
 
 ```elixir
 iex> [{:trim, true}] == [trim: true]


### PR DESCRIPTION
The phrase "In particular, keyword lists are 2-item tuples where the first element ..." states that a keyword list *is* a 2-item tuple. As someone who is just reading about such concepts for the first time, I have found it to be a source of confusion, because in reality a keyword list is a list where each element is a 2-item tuple (this is accurate).