### PR TITLE
Fix version check command

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -177,7 +177,7 @@ The only prerequisite for Elixir is Erlang, version {{ stable.minimum_otp }} or 
   * [Precompiled packages for some Unix-like installations](https://www.erlang-solutions.com/resources/download.html)
   * [A general list of installation methods from the Riak documentation](https://docs.riak.com/riak/kv/latest/setup/installing/source/erlang/).
 
-After Erlang is installed, you should be able to open up the command line (or command prompt) and check the Erlang version by typing `erl -s halt`. You will see some information similar to:
+After Erlang is installed, you should be able to open up the command line (or command prompt) and check the Erlang version by typing `erl -s erlang halt`. You will see some information similar to:
 
     Erlang/OTP {{ stable.minimum_otp }} [64-bit] [smp:2:2] [...]
 


### PR DESCRIPTION
The current command proposed for checking the Erlang version is `erl -s halt`, but that makes `init` call the module `halt`, which does not exist, and it results in a crash. This may mislead users into thinking their Erlang version is not working properly.

In this change the module name is added so that it calls `erlang:halt` correctly. This results in no crash.

Tested on Erlang 25 and Elixir 1.14. Checked in the Erlang docs that `-s` has worked this way (`-s Mod Fun`) since Erlang 18 at least.