### PR TITLE
Fix Slack community links

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -23,7 +23,7 @@
     <li><a class="spec" href="https://twitter.com/elixirlang">@elixirlang on Twitter</a></li>
     <li><a class="spec" href="irc://irc.libera.chat/elixir">#elixir on irc.libera.chat</a></li>
     <li><a class="spec" href="http://elixirforum.com">Elixir Forum</a></li>
-    <li><a class="spec" href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a></li>
+    <li><a class="spec" href="https://elixir-lang.slack.com/">Elixir on Slack</a></li>
     <li><a class="spec" href="https://discord.gg/elixir">Elixir on Discord</a></li>
     <li><a class="spec" href="https://www.meetup.com/topics/elixir/">Meetups around the world</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/wiki">Wiki with events and resources maintained by the community</a></li>

--- a/getting-started/introduction.markdown
+++ b/getting-started/introduction.markdown
@@ -75,7 +75,7 @@ When going through this getting started guide, it is common to have questions; a
 
   * [#elixir on irc.libera.chat](irc://irc.libera.chat/elixir)
   * [Elixir Forum](http://elixirforum.com)
-  * [Elixir on Slack](https://elixir-slackin.herokuapp.com/)
+  * [Elixir on Slack](https://elixir-lang.slack.com)
   * [Elixir on Discord](https://discord.gg/elixir)
   * [elixir tag on StackOverflow](https://stackoverflow.com/questions/tagged/elixir)
 


### PR DESCRIPTION
Current [link](https://elixir-slackin.herokuapp.com/) points to a broken Heroku app.

Fixed in
- "Important links" sidebar
- "Asking questions" section on [Introduction](http://localhost:4000/getting-started/introduction.html#asking-questions) page