### PR TITLE
Update config-and-releases.markdown

### DIFF
--- a/getting-started/mix-otp/config-and-releases.markdown
+++ b/getting-started/mix-otp/config-and-releases.markdown
@@ -174,7 +174,7 @@ With the configuration in place, let's give assembling the release another try:
     * assembling foo-0.0.1 on MIX_ENV=prod
     * skipping runtime configuration (config/runtime.exs not found)
 
-    Release created at _build/prod/rel/foo!
+    Release created at _build/prod/rel/foo
 
         # To start your system
         _build/prod/rel/foo/bin/foo start


### PR DESCRIPTION
When `MIX_ENV=prod mix release foo` is run, the output doesn't include an exclamantion mark at the end.