### PR TITLE
Fixed some grammar on the Elixir landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ receive do
 end
 {% endhighlight %}
 
-      <p>Due to their lightweight nature, you can spawn hundreds of thousands of processes <i>concurrently</i> in the same machine, using all machine resources efficiently (vertical scaling). Processes may also communicate with other processes running on different machines to coordinate work across multiple nodes (horizontal scaling).</p>
+      <p>Due to their lightweight nature, you can run hundreds of thousands of processes <i>concurrently</i> in the same machine, using all machine resources efficiently (vertical scaling). Processes may also communicate with other processes running on different machines to coordinate work across multiple nodes (horizontal scaling).</p>
 
       <p>Together with projects such as <a href="https://github.com/elixir-nx/">Numerical Elixir</a>, Elixir scales across cores, clusters, and GPUs.</p>
     </div>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ receive do
 end
 {% endhighlight %}
 
-      <p>Due to their lightweight nature, you can hundreds of thousands of processes <i>concurrently</i> in the same machine, using all machine resources efficiently (vertical scaling). Processes may also communicate with other processes running on different machines to coordinate work across multiple nodes (horizontal scaling).</p>
+      <p>Due to their lightweight nature, you can spawn hundreds of thousands of processes <i>concurrently</i> in the same machine, using all machine resources efficiently (vertical scaling). Processes may also communicate with other processes running on different machines to coordinate work across multiple nodes (horizontal scaling).</p>
 
       <p>Together with projects such as <a href="https://github.com/elixir-nx/">Numerical Elixir</a>, Elixir scales across cores, clusters, and GPUs.</p>
     </div>


### PR DESCRIPTION
I found this line that didn't flow well.

> Due to their lightweight nature, you can hundreds of thousands of processes concurrently in the same machine, using all machine resources efficiently (vertical scaling)

I added a _spawn_ after "you can"

> Due to their lightweight nature, you can _spawn_ hundreds of thousands