### PR TITLE
Update getting started charlists to use ~c

### DIFF
--- a/getting-started/basic-types.markdown
+++ b/getting-started/basic-types.markdown
@@ -320,11 +320,18 @@ iex> hd([])
 ** (ArgumentError) argument error
 ```
 
-Sometimes you will create a list and it will return a value in single quotes. For example:
+Sometimes you will create a list and it will return a quoted value preceded by `~c`. For example:
 
 ```elixir
 iex> [11, 12, 13]
-'\v\f\r'
+~c"\v\f\r"
+iex> [104, 101, 108, 108, 111]
+~c"hello"
+```
+
+In Elixir < 1.15, this might be displayed as single quotes instead:
+
+```elixir
 iex> [104, 101, 108, 108, 111]
 'hello'
 ```
@@ -332,9 +339,9 @@ iex> [104, 101, 108, 108, 111]
 When Elixir sees a list of printable ASCII numbers, Elixir will print that as a charlist (literally a list of characters). Charlists are quite common when interfacing with existing Erlang code. Whenever you see a value in IEx and you are not quite sure what it is, you can use the `i/1` to retrieve information about it:
 
 ```elixir
-iex> i 'hello'
+iex> i ~c"hello"
 Term
-  'hello'
+  i ~c"hello"
 Data type
   List
 Description
@@ -352,6 +359,8 @@ Keep in mind single-quoted and double-quoted representations are not equivalent 
 ```elixir
 iex> 'hello' == "hello"
 false
+iex> 'hello' == ~c"hello"
+true
 ```
 
 Single quotes are charlists, double quotes are strings. We will talk more about them in the ["Binaries, strings and charlists"](/getting-started/binaries-strings-and-char-lists.html) chapter.

--- a/getting-started/binaries-strings-and-char-lists.markdown
+++ b/getting-started/binaries-strings-and-char-lists.markdown
@@ -238,13 +238,22 @@ Our tour of our bitstrings, binaries, and strings is nearly complete, but we hav
 
 **A charlist is a list of integers where all the integers are valid code points.** In practice, you will not come across them often, only in specific scenarios such as interfacing with older Erlang libraries that do not accept binaries as arguments.
 
-Whereas double-quotes creates strings, single-quotes create charlist literals:
+```elixir
+iex> ~c"hello"
+~c"hello"
+iex> [?h, ?e, ?l, ?l, ?o]
+~c"hello"
+```
+
+The `~c` sigil (we'll cover sigils later in the ["Sigils"](/getting-started/sigils.html) section)
+indicates the fact that we are dealing with a charlist and not a regular string.
+
+Whereas double-quotes creates strings, single-quotes create charlist literals.
+Charlists used to be represented with single quotes in Elixir <1.15:
 
 ```elixir
 iex> 'hello'
-'hello'
-iex> [?h, ?e, ?l, ?l, ?o]
-'hello'
+~c"hello"
 ```
 
 The key takeaway is that `"hello"` is not the same as `'hello'`. Generally speaking, **double-quotes must always be used to represent strings in Elixir**. In any case, let's learn how charlists work.
@@ -252,9 +261,9 @@ The key takeaway is that `"hello"` is not the same as `'hello'`. Generally speak
 Instead of containing bytes, a charlist contains integer code points. However, the list is only printed in single-quotes if all code points are within the ASCII range:
 
 ```elixir
-iex> 'hełło'
+iex> ~c"hełło"
 [104, 101, 322, 322, 111]
-iex> is_list('hełło')
+iex> is_list(~c"hełło")
 true
 ```
 
@@ -262,7 +271,7 @@ Interpreting integers as code points may lead to some surprising behavior. For e
 
 ```elixir
 iex> heartbeats_per_minute = [99, 97, 116]
-'cat'
+~c"cat"
 ```
 
 You can convert a charlist to a string and back by using the `to_string/1` and `to_charlist/1` functions:
@@ -270,7 +279,7 @@ You can convert a charlist to a string and back by using the `to_string/1` and `
 ```elixir
 iex> to_charlist("hełło")
 [104, 101, 322, 322, 111]
-iex> to_string('hełło')
+iex> to_string(~c"hełło")
 "hełło"
 iex> to_string(:hello)
 "hello"
@@ -283,14 +292,14 @@ Note that those functions are polymorphic - not only do they convert charlists t
 String (binary) concatenation uses the `<>` operator but charlists, being lists, use the list concatenation operator `++`:
 
 ```elixir
-iex> 'this ' <> 'fails'
-** (ArgumentError) expected binary argument in <> operator but got: 'this '
+iex> ~c"this " <> ~c"fails"
+** (ArgumentError) expected binary argument in <> operator but got: ~c"this "
     (elixir) lib/kernel.ex:1821: Kernel.wrap_concatenation/3
     (elixir) lib/kernel.ex:1808: Kernel.extract_concatenations/2
     (elixir) expanding macro: Kernel.<>/2
     iex:1: (file)
-iex> 'this ' ++ 'works'
-'this works'
+iex> ~c"this " ++ ~c"works"
+~c"this works"
 iex> "he" ++ "llo"
 ** (ArgumentError) argument error
     :erlang.++("he", "llo")

--- a/getting-started/comprehensions.markdown
+++ b/getting-started/comprehensions.markdown
@@ -44,7 +44,7 @@ Comprehensions discard all elements for which the filter expression returns `fal
 Comprehensions generally provide a much more concise representation than using the equivalent functions from the `Enum` and `Stream` modules. Furthermore, comprehensions also allow multiple generators and filters to be given. Here is an example that receives a list of directories and gets the size of each file in those directories:
 
 ```elixir
-dirs = ['/home/mikey', '/home/james']
+dirs = ["/home/mikey", "/home/james"]
 
 for dir <- dirs,
     file <- File.ls!(dir),

--- a/getting-started/sigils.markdown
+++ b/getting-started/sigils.markdown
@@ -65,11 +65,13 @@ iex> ~s(this is a string with "double" quotes, not 'single' ones)
 
 ### Char lists
 
-The `~c` sigil is useful for generating char lists that contain single quotes:
+The `~c` sigil is the regular way to represent charlists.
 
 ```elixir
-iex> ~c(this is a char list containing 'single quotes')
-'this is a char list containing \'single quotes\''
+iex> [?c, ?a, ?t]
+~c"cat"
+iex> ~c(this is a char list containing "double quotes")
+~c"this is a char list containing \"double quotes\""
 ```
 
 ### Word lists
@@ -214,7 +216,7 @@ iex> time_zone
 As hinted at the beginning of this chapter, sigils in Elixir are extensible. In fact, using the sigil `~r/foo/i` is equivalent to calling `sigil_r` with a binary and a char list as the argument:
 
 ```elixir
-iex> sigil_r(<<"foo">>, 'i')
+iex> sigil_r(<<"foo">>, ~c"i")
 ~r"foo"i
 ```
 


### PR DESCRIPTION
The getting started guide is still using single quote representations for charlists.

This PR updates it, while still mentioning about single quotes and the importance of using double quotes for strings. I tried my best to keep explanations simple, but I hope it's not too confusing for beginners 😅 (esp. since this shows sigils early on).