### PR TITLE
Debian/Ubuntu alternate

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -33,6 +33,14 @@ Note version managers (described below), are also available for macOS.
 
 On Unix systems, there are two options to install Elixir. You can use the Erlang/Elixir packages that are part of your distribution, although those may lag behind in version numbers (especially for LTS releases). In such cases, you can also opt to use a version manager.
 
+For **Debian** and **Ubuntu**, there is also a third option to use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)
+
+```bash
+$ sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang
+$ sudo apt update
+$ sudo apt install elixir
+```
+
 #### Version managers
 
 There are many tools that allow developers to install and manage multiple Erlang and Elixir versions. They are useful if you have multiple projects running on different Elixir or Erlang versions, can't install Erlang or Elixir as mentioned above or if the version provided by your package manager is outdated. Here are some of those tools:

--- a/install.markdown
+++ b/install.markdown
@@ -33,14 +33,6 @@ Note version managers (described below), are also available for macOS.
 
 On Unix systems, there are two options to install Elixir. You can use the Erlang/Elixir packages that are part of your distribution, although those may lag behind in version numbers (especially for LTS releases). In such cases, you can also opt to use a version manager.
 
-For **Debian** and **Ubuntu**, there is also a third option to use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)
-
-```bash
-$ sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang
-$ sudo apt update
-$ sudo apt install elixir
-```
-
 #### Version managers
 
 There are many tools that allow developers to install and manage multiple Erlang and Elixir versions. They are useful if you have multiple projects running on different Elixir or Erlang versions, can't install Erlang or Elixir as mentioned above or if the version provided by your package manager is outdated. Here are some of those tools:
@@ -61,6 +53,15 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
 
   - **Debian**
     * Run: `sudo apt install elixir`
+
+  - **Debian** (and **Ubuntu**) alternative
+    * Use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)
+
+      ```bash
+      $ sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang
+      $ sudo apt update
+      $ sudo apt install elixir
+      ```
 
   - **Fedora 21 (and older)**
     * Run: `yum install elixir`

--- a/install.markdown
+++ b/install.markdown
@@ -52,7 +52,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
     * Run: `pacman -S elixir`
 
   - **Debian**
-    * Run: `sudo apt-get install elixir`
+    * Run: `sudo apt install elixir`
 
   - **Fedora 21 (and older)**
     * Run: `yum install elixir`
@@ -81,7 +81,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
     * Run: `eopkg install elixir`
 
   - **Ubuntu**
-    * Run: `sudo apt-get install elixir`
+    * Run: `sudo apt install elixir`
 
   - **Void Linux**
     * Run: `xbps-install -S elixir`


### PR DESCRIPTION
This resolves https://github.com/elixir-lang/elixir-lang.github.com/issues/1704

Feel free to reject/ignore the `apt is preferred over apt-get` commit
and make changes to the Debian/Ubuntu command positioning in the install.markdown file