### PR TITLE
Remove links to Slack

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -23,7 +23,6 @@
     <li><a class="spec" href="https://twitter.com/elixirlang">@elixirlang on Twitter</a></li>
     <li><a class="spec" href="irc://irc.libera.chat/elixir">#elixir on irc.libera.chat</a></li>
     <li><a class="spec" href="http://elixirforum.com">Elixir Forum</a></li>
-    <li><a class="spec" href="https://elixir-lang.slack.com/">Elixir on Slack</a></li>
     <li><a class="spec" href="https://discord.gg/elixir">Elixir on Discord</a></li>
     <li><a class="spec" href="https://www.meetup.com/topics/elixir/">Meetups around the world</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/wiki">Wiki with events and resources maintained by

--- a/install.markdown
+++ b/install.markdown
@@ -216,7 +216,6 @@ After Elixir is up and running, it is common to have questions as you learn and 
 
   * [#elixir on irc.libera.chat](irc://irc.libera.chat/elixir)
   * [Elixir Forum](http://elixirforum.com)
-  * [Elixir on Slack](https://elixir-lang.slack.com)
   * [Elixir on Discord](https://discord.gg/elixir)
   * [elixir tag on StackOverflow](https://stackoverflow.com/questions/tagged/elixir)
 


### PR DESCRIPTION
It's not possible to join the Slack without being invited. Getting an invite currently means that you actually have to go to one of the other communities and then ask for an invite.

Examples of this:
- https://www.reddit.com/r/elixir/comments/129w7sf/how_to_join_elixir_slack/
- https://elixirforum.com/t/unable-to-join-the-slack-channel/56331
- https://www.reddit.com/r/elixir/comments/eawv49/cant_get_an_invitation_for_the_elixir_slack/

Pointing newcomers to ask questions in Slack is not great, since it sends them down a rabbit hole of trying to find out how to even get access to it.