### PR TITLE
Clarify Any Protocol implementation derivation

### DIFF
--- a/getting-started/protocols.markdown
+++ b/getting-started/protocols.markdown
@@ -166,7 +166,7 @@ end
 
 The implementation above is arguably not a reasonable one. For example, it makes no sense to say that the size of a `PID` or an `Integer` is `0`.
 
-However, we should be fine with the implementation for `Any`, in order to use such implementation we would need to tell our struct to explicitly derive the `Size` protocol:
+However, should we be fine with the implementation for `Any`, in order to use such implementation we would need to tell our struct to explicitly derive the `Size` protocol:
 
 ```elixir
 defmodule OtherUser do


### PR DESCRIPTION
A small edit on the "Deriving" section of the "Protocols" chapter in "Getting Started".

Changing "we should be fine with the implementation of Any" to
"should we be fine with the implementation of any" hopefully
better communicates that we can use the Any implementation of
the protocol if we wish to but not that we have to.