### PR TITLE
minor improvements to Debian/Ubuntu based install guide

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -60,7 +60,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
       ```bash
       $ sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang
       $ sudo apt update
-      $ sudo apt install elixir
+      $ sudo apt install elixir erlang-dev erlang-xmerl
       ```
 
   - **Fedora 21 (and older)**


### PR DESCRIPTION
Without erlang-dev and erlang-xmerl, it's not possible to build mint, nor phoenix.
It seems reasonable to add these as general dependencies for everybody.

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.3 LTS
Release:        22.04
Codename:       jammy

$ mix hex.info

Hex:    2.0.6
Elixir: 1.15.7
OTP:    26.1.2

Built with: Elixir 1.14.2 and OTP 23.3
```

```
> Compiling 1 file (.erl)
    src/mint_shims.erl:37:14: can't find include lib "public_key/include/public_key.hrl"
    %   37| -include_lib("public_key/include/public_key.hrl").
```