### PR TITLE
Explicitly use 127.0.0.1 as IP address

### DIFF
--- a/getting-started/mix-otp/task-and-gen-tcp.markdown
+++ b/getting-started/mix-otp/task-and-gen-tcp.markdown
@@ -34,7 +34,7 @@ defmodule KVServer do
     # 4. `reuseaddr: true` - allows us to reuse the address if the listener crashes
     #
     {:ok, socket} =
-      :gen_tcp.listen(port, [:binary, packet: :line, active: false, reuseaddr: true])
+      :gen_tcp.listen(port, [:binary, packet: :line, active: false, reuseaddr: true, ip: {127,0,0,1}])
     Logger.info("Accepting connections on port #{port}")
     loop_acceptor(socket)
   end


### PR DESCRIPTION
On macOS `gen_tcp.listen()` wouldn't work without passing the explicit address for localhost. KVServer would start correctly, but the Telnet client wouldn't connect.