### PR TITLE
Fix meta programming anti-patterns link

### DIFF
--- a/_posts/2023-12-22-elixir-v1-16-0-released.markdown
+++ b/_posts/2023-12-22-elixir-v1-16-0-released.markdown
@@ -143,7 +143,7 @@ to keep only anti-patterns which are unambiguous and actionable, and divided
 them into four categories: [code-related](https://hexdocs.pm/elixir/code-anti-patterns.html),
 [design-related](https://hexdocs.pm/elixir/design-anti-patterns.html),
 [process-related](https://hexdocs.pm/elixir/process-anti-patterns.html),
-and [meta-programming](https://hexdocs.pm/elixir/meta-anti-patterns.html).
+and [meta-programming](https://hexdocs.pm/elixir/macro-anti-patterns.html).
 Then we collected more community feedback during the release candidate
 period, further refining and removing unclear guidance.
 


### PR DESCRIPTION
The link in the release blog post was broken, fixed with the current right one - whose name is macro not meta :)

Thanks for the 1.16 release and happy holidays!