### PR TITLE
Add support links for elixir-slack.community

### DIFF
--- a/_includes/important-links.html
+++ b/_includes/important-links.html
@@ -23,6 +23,7 @@
     <li><a class="spec" href="https://twitter.com/elixirlang">@elixirlang on Twitter</a></li>
     <li><a class="spec" href="irc://irc.libera.chat/elixir">#elixir on irc.libera.chat</a></li>
     <li><a class="spec" href="http://elixirforum.com">Elixir Forum</a></li>
+    <li><a class="spec" href="https://elixir-slack.community">Elixir on Slack</a></li>
     <li><a class="spec" href="https://discord.gg/elixir">Elixir on Discord</a></li>
     <li><a class="spec" href="https://github.com/elixir-lang/elixir/wiki/Code-Editor-Support">IDE/Editor support</a></li>
     <li><a class="spec" href="https://www.meetup.com/topics/elixir/">Meetups around the world</a></li>

--- a/install.markdown
+++ b/install.markdown
@@ -216,6 +216,7 @@ After Elixir is up and running, it is common to have questions as you learn and 
 
   * [#elixir on irc.libera.chat](irc://irc.libera.chat/elixir)
   * [Elixir Forum](http://elixirforum.com)
+  * [Elixir on Slack](https://elixir-slack.community)
   * [Elixir on Discord](https://discord.gg/elixir)
   * [elixir tag on StackOverflow](https://stackoverflow.com/questions/tagged/elixir)
 


### PR DESCRIPTION
This restores links to the Elixir Slack using a new [elixir-slack.community](https://elixir-slack.community) domain and [invite-driven plug app](https://github.com/sorentwo/elixir-slack).
