### PR TITLE
Expand install instructions for Debian

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -53,7 +53,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
     * Run: `pacman -S elixir`
 
   - **Debian**
-    * Run: `sudo apt install elixir`. If you plan to develop Elixir applications you need `erlang-dev` as well. 
+    * Run: `sudo apt install erlang-dev elixir`
 
   - **Debian** (and **Ubuntu**) alternative
     * Use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)

--- a/install.markdown
+++ b/install.markdown
@@ -53,7 +53,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
     * Run: `pacman -S elixir`
 
   - **Debian**
-    * Run: `sudo apt install elixir`. If you plan to develop elixir applications you need `erlang-dev` as well. 
+    * Run: `sudo apt install elixir`. If you plan to develop Elixir applications you need `erlang-dev` as well. 
 
   - **Debian** (and **Ubuntu**) alternative
     * Use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)

--- a/install.markdown
+++ b/install.markdown
@@ -53,7 +53,7 @@ Keep in mind that each Elixir version supports specific Erlang/OTP versions. [Se
     * Run: `pacman -S elixir`
 
   - **Debian**
-    * Run: `sudo apt install elixir`
+    * Run: `sudo apt install elixir`. If you plan to develop elixir applications you need `erlang-dev` as well. 
 
   - **Debian** (and **Ubuntu**) alternative
     * Use the [RabbitMQ Packages](https://launchpad.net/~rabbitmq) (might not be up-to-date however likely newer than the distribution)


### PR DESCRIPTION
On Debian bookworm the package erlang-dev needs to be installed as well, otherwise you will have problems creating the first elixir application (see https://github.com/elixir-lang/elixir/issues/12681#issuecomment-1699374362 )