### PR TITLE
Ensure install.sh exits if either of OTP or Elixir fails to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,8 +107,13 @@ main() {
 
   if unzip_available; then
     install_otp &
+    pid_otp=$!
+
     install_elixir &
-    wait
+    pid_elixir=$!
+
+    wait $pid_otp
+    wait $pid_elixir
   else
     # if unzip is missing (e.g. official docker ubuntu image), install otp and elixir
     # serially because we unzip elixir using OTP zip:extract/2.


### PR DESCRIPTION
This script uses `set -e` to immediately exit the program if any commands return non-zero, but `wait` without arguments does not reliably return with the exit code of a failed subprocess. (Exactly which exit code is returned depends, I believe, on the order in which the subprocesses exit.)

By waiting on both pids explicitly, we ensure that the script exits if either OTP or Elixir fails to install. In the case of #1781, this change makes it so that the script halts after the `curl` fails to download OTP master instead of carrying on as if nothing failed.