### PR TITLE
Fix minor typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ drive(User.get("John Doe"))
     <h4>Extensibility and DSLs</h4>
 
     <div class="entry-summary">
-      <p>Elixir has been designed to be extensible, allowing developers naturally extend the language to particular domains, in order to increase their productivity.</p>
+      <p>Elixir has been designed to be extensible, allowing developers to naturally extend the language to particular domains, in order to increase their productivity.</p>
 
       <p>As an example, let's write a simple test case using <a href="https://hexdocs.pm/ex_unit/">Elixir's test framework called ExUnit</a>:</p>
 


### PR DESCRIPTION
This was a minor typo fix and therefore I didn't test the change by re-building the docs. If I've missed something, please let me know and I can take a closer look. 