### PR TITLE
Prevent people from copying the versions as is and running into bugs

### DIFF
--- a/_data/elixir-versions.yml
+++ b/_data/elixir-versions.yml
@@ -3,7 +3,7 @@ stable: v1_18
 v1_18:
   name: v1.18
   minimum_otp: 26.0
-  recommended_otp: 27.1.2
+  recommended_otp: 27.2.3
   otp_versions: [27, 26, 25]
   version: 1.18.3
 


### PR DESCRIPTION
The bug: https://github.com/erlang/otp/pull/8729
Wojtek stating the fixed version: https://elixirforum.com/t/not-being-able-to-compile-telemetry-dependency/66730/42?u=lostkobrakai