### PR TITLE
Improve install.bat to support PowerShell 7

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -139,7 +139,16 @@ if not exist "%otp_dir%\bin" (
   curl.exe -fsSLo %tmp_dir%\%otp_zip% "!otp_url!" || exit /b 1
 
   echo unpacking %tmp_dir%\%otp_zip%
-  powershell -Command "Expand-Archive -LiteralPath %tmp_dir%\%otp_zip% -DestinationPath %otp_dir%"
+  powershell -NoProfile -Command ^
+    "$ErrorActionPreference='Stop';" ^
+    "try {" ^
+    "  if (-not (Get-Command Expand-Archive -ErrorAction SilentlyContinue)) {" ^
+    "    Add-Type -AssemblyName System.IO.Compression.FileSystem;" ^
+    "    [System.IO.Compression.ZipFile]::ExtractToDirectory('%tmp_dir%\%otp_zip%', '%otp_dir%')" ^
+    "  } else {" ^
+    "    Expand-Archive -LiteralPath '%tmp_dir%\%otp_zip%' -DestinationPath '%otp_dir%' -Force" ^
+    "  }" ^
+    "} catch { Write-Error $_; exit 1 }"
   del /f /q "%tmp_dir%\%otp_zip%"
   cd /d "%otp_dir%"
 
@@ -166,7 +175,16 @@ if not exist "%elixir_dir%\bin" (
   curl.exe -fsSLo "%tmp_dir%\%elixir_zip%" "!elixir_url!" || exit /b 1
 
   echo unpacking %tmp_dir%\%elixir_zip%
-  powershell -Command "Expand-Archive -LiteralPath %tmp_dir%\%elixir_zip% -DestinationPath %elixir_dir%"
+  powershell -NoProfile -Command ^
+    "$ErrorActionPreference='Stop';" ^
+    "try {" ^
+    "  if (-not (Get-Command Expand-Archive -ErrorAction SilentlyContinue)) {" ^
+    "    Add-Type -AssemblyName System.IO.Compression.FileSystem;" ^
+    "    [System.IO.Compression.ZipFile]::ExtractToDirectory('%tmp_dir%\%elixir_zip%', '%elixir_dir%')" ^
+    "  } else {" ^
+    "    Expand-Archive -LiteralPath '%tmp_dir%\%elixir_zip%' -DestinationPath '%elixir_dir%' -Force" ^
+    "  }" ^
+    "} catch { Write-Error $_; exit 1 }"
   del /f /q %tmp_dir%\%elixir_zip%
 )
 goto :eof


### PR DESCRIPTION
- Added a PowerShell conditional check to see if `Expand-Archive` is available.
- If not, it falls back to using `.NET` APIs for zip extraction.
- Compatible with both PowerShell 5.1 and PowerShell 7+.

[Related issue](https://github.com/elixir-lang/elixir/issues/14321)