### PR TITLE
install.bat: fix parens-in-username breaking OTP path expansion

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -145,9 +145,9 @@ if not exist "%otp_dir%\bin" (
 
   set otp_url=https://github.com/erlang/otp/releases/download/OTP-!otp_version!/%otp_zip%
   echo downloading !otp_url!...
-  curl.exe -fsSLo %tmp_dir%\%otp_zip% "!otp_url!" || exit /b 1
+  curl.exe -fsSLo "%tmp_dir%\%otp_zip%" "!otp_url!" || exit /b 1
 
-  echo unpacking %tmp_dir%\%otp_zip%
+  echo unpacking !tmp_dir!\!otp_zip!
   powershell -NoProfile -Command ^
     "$ErrorActionPreference='Stop';" ^
     "try {" ^
@@ -191,7 +191,7 @@ if not exist "%elixir_dir%\bin" (
   echo downloading !elixir_url!...
   curl.exe -fsSLo "%tmp_dir%\%elixir_zip%" "!elixir_url!" || exit /b 1
 
-  echo unpacking %tmp_dir%\%elixir_zip%
+  echo unpacking !tmp_dir!\!elixir_zip!
   powershell -NoProfile -Command ^
     "$ErrorActionPreference='Stop';" ^
     "try {" ^
@@ -202,6 +202,6 @@ if not exist "%elixir_dir%\bin" (
     "    Expand-Archive -LiteralPath '%tmp_dir%\%elixir_zip%' -DestinationPath '%elixir_dir%' -Force" ^
     "  }" ^
     "} catch { Write-Error $_; exit 1 }"
-  del /f /q %tmp_dir%\%elixir_zip%
+  del /f /q "%tmp_dir%\%elixir_zip%"
 )
 goto :eof


### PR DESCRIPTION
## Summary

On Windows, when `%USERPROFILE%` contains parentheses (e.g. `C:\Users\PeterLinder(3Txpert)`), `install.bat` fails on the OTP download/unpack step with a German `"syntactisch nicht verarbeitbar"` / English `"... was unexpected at this time"` cmd-batch parse error — before any download begins.

Root cause: four lines in `install.bat` use unquoted `%tmp_dir%` inside `if (...)` blocks. Because cmd-batch performs `%var%` expansion at *parse time* (not execution time), the close-paren embedded in `%tmp_dir%` terminates the surrounding `if` block prematurely. The cmd parser then sees a `then`-clause without an opening paren.

This PR applies two patterns already present elsewhere in the file:

- **Quote the path argument** at the `curl.exe` (line 148) and `del /f /q` (line 205) calls. The Elixir-side curl at line 192 was already correctly quoted — this restores symmetry with the OTP-side calls.
- **Use delayed expansion** (`!tmp_dir!\!otp_zip!`) at the two `echo unpacking …` lines (150, 194). Delayed expansion happens at execution time, after the parser has already matched the if-block parens.

The change is minimal (4 lines) and entirely additive: every modified line was either missing quotes or using the wrong expansion form; no existing behavior changes for usernames without parentheses.

## Reproduction

On a Windows account with `(` in the username:

```cmd
.\install.bat elixir@latest otp@latest
```

Before patch: errors at the OTP curl/echo step before the download starts.

After patch: both downloads complete cleanly; OTP and Elixir install as expected.

## Test plan

- [x] Manual: `install.bat elixir@latest otp@latest` runs cleanly under `PeterLinder(3Txpert)` (parenthesized) — both OTP and Elixir downloaded, unpacked, and version-checked.
- [x] Manual: same command continues to work under a non-parenthesized username (no regression).
- [x] Diff against `main`: 4 lines changed, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)