### PR TITLE
Fix install.sh downloading otp-28 build for Elixir 1.20 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,8 +103,11 @@ main() {
     1.19.*)
       [ "${elixir_otp_release}" -ge 28 ] && elixir_otp_release=28
       ;;
+    1.20.*)
+      [ "${elixir_otp_release}" -ge 29 ] && elixir_otp_release=29
+      ;;
     *)
-      [ "${elixir_otp_release}" -ge 28 ] && elixir_otp_release=28
+      [ "${elixir_otp_release}" -ge 29 ] && elixir_otp_release=29
       ;;
   esac
 


### PR DESCRIPTION
Fix for issue #1832 

the install script defaults to otp 28 for elixir 1.20