### PR TITLE
Add cursor-pointer to stepped nav on install page

### DIFF
--- a/src/components/ui/SteppedNav.astro
+++ b/src/components/ui/SteppedNav.astro
@@ -79,7 +79,7 @@ const defaultActive =
         disabled={!s.hasContent}
         class:list={[
           "group flex items-center gap-4 text-left transition-colors duration-fast ease-out-quart",
-          !s.hasContent && "cursor-not-allowed",
+          s.hasContent ? "cursor-pointer" : "cursor-not-allowed",
         ]}
         aria-pressed={s.id === defaultActive ? "true" : "false"}
       >


### PR DESCRIPTION
Everywhere else seemed to use cursor-pointer, so this felt inconsistent.