### PR TITLE
Use elixir-slack.community for all Slack links

### DIFF
--- a/src/components/home/ShapedByMany.astro
+++ b/src/components/home/ShapedByMany.astro
@@ -13,7 +13,7 @@ const links = [
   { label: "Team", href: "/development/", icon: "none" as const },
   {
     label: "Slack",
-    href: "https://elixir-lang.slack.com",
+    href: "https://elixir-slack.community",
     icon: "slack" as const,
     external: true,
   },

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -79,7 +79,7 @@ export const footerSocials: NavItem[] = [
     href: "https://twitter.com/elixirlang",
     external: true,
   },
-  { label: "Slack", href: "https://elixir-lang.slack.com", external: true },
+  { label: "Slack", href: "https://elixir-slack.community", external: true },
   { label: "Discord", href: "https://discord.gg/elixir", external: true },
 ];
 


### PR DESCRIPTION
The elixir-lang.slack.com address only works for existing users, whereas the elixir-slack.community site handles automatic invites for new users.