### PR TITLE
fix: remove extra _ on docs links

### DIFF
--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -129,9 +129,8 @@ const seo = {
                 target="_blank"
                 rel="noopener noreferrer"
                 class="font-sans font-normal leading-[23px] text-purple-40 underline decoration-solid underline-offset-2 transition-colors duration-fast ease-out-quart hover:text-purple-30"
-              >
-                {m.name}
-              </a>
+                set:text={m.name}
+              />
               <span class="font-sans font-normal leading-[23px] text-white-10">
                 {" "}- {m.description}
               </span>


### PR DESCRIPTION
Before:
<img width="827" height="405" alt="Xnapper-2026-07-23-13 15 19" src="https://github.com/user-attachments/assets/e264cb62-cc65-4c42-acad-f4ce05cc1c72" />



After:

<img width="765" height="399" alt="Xnapper-2026-07-23-13 15 45" src="https://github.com/user-attachments/assets/61822760-7c6d-46ef-9dfc-f98017740b99" />
